### PR TITLE
Add three-layer skill override chain and exception handling guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ NEW PROJECT                           EXISTING PROJECT
 - **Hot reload** is automatic in Quarkus dev mode — triggered on the next access (HTTP request or test run), not on file save.
 - **Skills before code** — the agent reads extension-specific skills to learn correct patterns, testing approaches, and common pitfalls before writing any code.
 - **Tests via subagents** — test execution is dispatched to a subagent so the main conversation stays responsive.
-- **The MCP server survives crashes** — if the app crashes due to a code error, the agent can check `quarkus/logs` to see what went wrong and fix it.
+- **The MCP server survives crashes** — if the app crashes due to a code error, the agent can use `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location) and fix it. Use `quarkus/logs` for broader context.
 - **CLAUDE.md** — every new project gets a `CLAUDE.md` with Quarkus-specific workflow instructions that guide the agent.
 
 ### What the agent can do with a running app
@@ -150,12 +150,19 @@ Once a Quarkus app is running in dev mode, the agent can discover and use all De
 | Endpoints | `quarkus/searchTools` query: `endpoint` | List all REST endpoints and their URLs |
 | Dev Services | `quarkus/searchTools` query: `dev-services` | View database URLs, container info |
 | Log levels | `quarkus/searchTools` query: `log` | Change log levels at runtime |
+| Exceptions | `devui-exceptions_getLastException` | Get last compilation/deployment/runtime exception with stack trace and source location |
 
 ### Extension skills
 
-The agent can read extension-specific coding skills using `quarkus/skills`. These are read from the `quarkus-extension-skills` JAR, which is automatically downloaded from Maven Central (or a configured mirror) for the project's Quarkus version.
+The agent can read extension-specific coding skills using `quarkus/skills`. Skills contain patterns, testing guidelines, and common pitfalls for each extension — things like "always use `@Transactional` for write operations with Panache" or "don't create REST clients manually, let CDI inject them."
 
-Skills contain patterns, testing guidelines, and common pitfalls for each extension — things like "always use `@Transactional` for write operations with Panache" or "don't create REST clients manually, let CDI inject them."
+Skills are loaded using a three-layer override chain (most specific wins):
+
+1. **JAR skills** — from the `quarkus-extension-skills` JAR, automatically downloaded from Maven Central (or a configured mirror) for the project's Quarkus version. These are the official defaults.
+2. **User-level skills** — from `~/.quarkus/skills/<extension-name>/SKILL.md` (or a directory configured via `agent-mcp.local-skills-dir`). Useful for extension developers testing new or modified skills without rebuilding the aggregated JAR.
+3. **Project-level skills** — from `src/main/resources/META-INF/skills/<extension-name>/SKILL.md` in the project directory. Allows teams to customize extension patterns for their specific project conventions.
+
+Each layer overrides the previous by skill name. For example, a project-level `quarkus-rest` skill replaces both the user-level and JAR versions.
 
 ### Documentation search
 
@@ -255,6 +262,7 @@ Configuration via `application.properties`, system properties (`-D`), or environ
 | `agent-mcp.doc-search.pg-password` | `quarkus` | PostgreSQL password |
 | `agent-mcp.doc-search.pg-database` | `quarkus` | PostgreSQL database |
 | `agent-mcp.doc-search.min-score` | `0.82` | Minimum similarity score for search results |
+| `agent-mcp.local-skills-dir` | `~/.quarkus/skills` | Directory for user-level skill overrides |
 
 ## Building a Native Image
 

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -323,6 +323,24 @@ public class CreateTools {
                     - Use `devui-testing_runTest` with arguments `{"className":"com.example.MyTest"}` to run a specific test class.
                     - Do NOT run Maven/Gradle test commands manually — the Dev MCP test tools handle compilation, hot reload, and result reporting.
                     - After fixing test failures, re-run tests with a subagent to verify the fix.
+
+                    ## Error Handling
+
+                    When something goes wrong (compilation error, deployment failure, runtime exception):
+
+                    1. Use `quarkus/callTool` with toolName `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location).
+                    2. Fix the issue based on the exception details.
+                    3. Call `devui-exceptions_clearLastException` to clear the recorded exception.
+                    4. Use `quarkus/logs` only when you need broader log context beyond the exception itself.
+
+                    **Note:** If the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet — fall back to `quarkus/logs` in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy.
+
+                    ## Customizing Skills
+
+                    Extension skills can be overridden per-project by placing SKILL.md files under
+                    `src/main/resources/META-INF/skills/<extension-name>/SKILL.md`. Project-level
+                    skills take precedence over the built-in defaults. This is useful for enforcing
+                    team conventions or adjusting patterns for specific project requirements.
                     """;
             Files.writeString(Path.of(projectDir, "CLAUDE.md"), content, StandardCharsets.UTF_8);
             LOG.debugf("Generated CLAUDE.md in %s", projectDir);

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -5,14 +5,18 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -42,6 +46,9 @@ public class DevMcpProxyTools {
 
     @Inject
     ObjectMapper mapper;
+
+    @ConfigProperty(name = "agent-mcp.local-skills-dir")
+    Optional<String> localSkillsDir;
 
     @Tool(name = "quarkus/searchTools", description = "Discover available tools on the running Quarkus app's Dev MCP server. "
             + "Use this before interacting with the running app — for testing, config, extensions, "
@@ -78,14 +85,17 @@ public class DevMcpProxyTools {
             + "for the Quarkus extensions used in the project. "
             + "ALWAYS call this BEFORE writing code or tests to learn the correct Quarkus patterns for each extension. "
             + "Does NOT require the app to be running — reads from built extension JARs. "
-            + "If the app is still building (just created), this will wait for the build to complete.")
+            + "If the app is still building (just created), this will wait for the build to complete. "
+            + "Skills can be customized per-project by placing SKILL.md files under "
+            + "src/main/resources/META-INF/skills/<extension-name>/SKILL.md in the project directory. "
+            + "Project-level skills override the built-in defaults.")
     ToolResponse skills(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
             @ToolArg(description = "Optional query to filter skills by extension name (case-insensitive). "
                     + "Examples: 'panache', 'rest', 'security', 'kafka'. "
                     + "If omitted, lists all available skills with their descriptions.", required = false) String query) {
         try {
-            List<SkillReader.SkillInfo> skills = SkillReader.readSkills(projectDir);
+            List<SkillReader.SkillInfo> skills = SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null));
 
             // If no skills found, check if the app is still building and wait for it
             if (skills.isEmpty()) {
@@ -163,14 +173,14 @@ public class DevMcpProxyTools {
 
             QuarkusInstance.Status status = instance.getStatus();
             if (status == QuarkusInstance.Status.RUNNING) {
-                return SkillReader.readSkills(projectDir);
+                return SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null));
             }
             if (status == QuarkusInstance.Status.CRASHED || status == QuarkusInstance.Status.STOPPED) {
                 return List.of();
             }
         }
         // Timeout — try one last time in case JARs appeared
-        return SkillReader.readSkills(projectDir);
+        return SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null));
     }
 
     @Tool(name = "quarkus/callTool", description = "Invoke a Dev MCP tool by name on the running Quarkus app. "

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -81,7 +81,9 @@ public class LifecycleTools {
         }
     }
 
-    @Tool(name = "quarkus/logs", description = "Get recent log output from a managed Quarkus application.")
+    @Tool(name = "quarkus/logs", description = "Get recent log output from a managed Quarkus application. "
+            + "For structured exception details (class, message, stack trace, user code location), "
+            + "prefer quarkus/callTool with toolName 'devui-exceptions_getLastException' instead.")
     ToolResponse logs(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
             @ToolArg(description = "Number of recent lines to return (default: 50)", required = false) Integer lines) {

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -7,13 +7,18 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
@@ -27,9 +32,16 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 /**
- * Reads extension skill files (SKILL.md) from the aggregated
- * {@code quarkus-extension-skills} JAR. Skills are static documentation
- * that don't require a running application.
+ * Reads extension skill files (SKILL.md) using a three-layer override chain:
+ * <ol>
+ *   <li><b>JAR skills</b> — from the aggregated {@code quarkus-extension-skills} JAR
+ *       shipped with each Quarkus release (baseline defaults)</li>
+ *   <li><b>User-level skills</b> — from {@code ~/.quarkus/skills/} or a configured
+ *       directory (for extension developers testing globally)</li>
+ *   <li><b>Project-level skills</b> — from {@code src/main/resources/META-INF/skills/}
+ *       in the project directory (for per-project customization)</li>
+ * </ol>
+ * Each layer overrides the previous by skill name (most specific wins).
  */
 public final class SkillReader {
 
@@ -53,40 +65,76 @@ public final class SkillReader {
     private SkillReader() {
     }
 
+    private static final Path DEFAULT_LOCAL_SKILLS_DIR = Path.of(System.getProperty("user.home"), ".quarkus", "skills");
+
     /**
-     * Reads all available skills for a project by looking up the aggregated
-     * {@code quarkus-extension-skills} JAR in the local Maven repository.
-     * If the JAR is not found locally, it is downloaded from Maven Central.
+     * Reads all available skills using the default local skills directory
+     * ({@code ~/.quarkus/skills/}).
      *
-     * @param projectDir the absolute path to the Quarkus project
-     * @return list of available skills, never null
+     * @see #readSkills(String, Path)
      */
     public static List<SkillInfo> readSkills(String projectDir) {
+        return readSkills(projectDir, null);
+    }
+
+    /**
+     * Reads all available skills for a project using the three-layer override chain.
+     *
+     * @param projectDir     the absolute path to the Quarkus project
+     * @param localSkillsDir optional user-level directory to scan for SKILL.md files, or null for the default
+     * @return list of available skills, never null
+     */
+    public static List<SkillInfo> readSkills(String projectDir, Path localSkillsDir) {
+        // Use a map keyed by skill name so each layer can override the previous
+        Map<String, SkillInfo> skillsByName = new LinkedHashMap<>();
+
+        // Layer 1: Load skills from the aggregated JAR (baseline)
         String version = QuarkusVersionDetector.detect(projectDir);
-        if (version == null) {
-            LOG.debugf("Could not detect Quarkus version for %s", projectDir);
-            return List.of();
-        }
+        if (version != null) {
+            Path m2Repo = Path.of(System.getProperty("user.home"), ".m2", "repository");
+            Path jarPath = resolveSkillsJarPath(version, m2Repo);
 
-        Path m2Repo = Path.of(System.getProperty("user.home"), ".m2", "repository");
-        Path jarPath = resolveSkillsJarPath(version, m2Repo);
-
-        if (!Files.isRegularFile(jarPath)) {
-            LOG.infof("Skills JAR not found locally, downloading for version %s", version);
-            jarPath = downloadFromMavenRepo(version, jarPath, projectDir);
-            if (jarPath == null) {
-                LOG.debugf("Could not download skills JAR for version %s", version);
-                return List.of();
+            if (!Files.isRegularFile(jarPath)) {
+                LOG.infof("Skills JAR not found locally, downloading for version %s", version);
+                jarPath = downloadFromMavenRepo(version, jarPath, projectDir);
             }
+
+            if (jarPath != null) {
+                try {
+                    for (SkillInfo skill : readSkillsFromJar(jarPath)) {
+                        skillsByName.put(skill.name(), skill);
+                    }
+                } catch (IOException e) {
+                    LOG.debugf("Failed to read skills from %s: %s", jarPath, e.getMessage());
+                }
+            }
+        } else {
+            LOG.debugf("Could not detect Quarkus version for %s", projectDir);
         }
 
-        try {
-            List<SkillInfo> skills = readSkillsFromJar(jarPath);
-            LOG.infof("Found %d skills for project %s (version %s)", skills.size(), projectDir, version);
-            return skills;
-        } catch (IOException e) {
-            LOG.debugf("Failed to read skills from %s: %s", jarPath, e.getMessage());
-            return List.of();
+        // Layer 2: Overlay user-level skills (~/.quarkus/skills/ or configured dir)
+        Path effectiveLocalDir = localSkillsDir != null ? localSkillsDir : DEFAULT_LOCAL_SKILLS_DIR;
+        overlaySkills(skillsByName, readLocalSkills(effectiveLocalDir), effectiveLocalDir.toString());
+
+        // Layer 3: Overlay project-level skills (src/main/resources/META-INF/skills/)
+        if (projectDir != null) {
+            Path projectSkillsDir = Path.of(projectDir, "src", "main", "resources", SKILLS_PATH_PREFIX);
+            overlaySkills(skillsByName, readLocalSkills(projectSkillsDir), projectSkillsDir.toString());
+        }
+
+        LOG.infof("Found %d skills for project %s (version %s)",
+                skillsByName.size(), projectDir, version);
+        return new ArrayList<>(skillsByName.values());
+    }
+
+    private static void overlaySkills(Map<String, SkillInfo> target, List<SkillInfo> overlay, String source) {
+        for (SkillInfo skill : overlay) {
+            if (target.containsKey(skill.name())) {
+                LOG.infof("Skill '%s' overridden by %s", skill.name(), source);
+            } else {
+                LOG.infof("Skill '%s' added from %s", skill.name(), source);
+            }
+            target.put(skill.name(), skill);
         }
     }
 
@@ -138,6 +186,44 @@ public final class SkillReader {
                     }
                 }
             }
+        }
+        return skills;
+    }
+
+    /**
+     * Reads SKILL.md files from a local directory. Scans for any
+     * {@code SKILL.md} files under the given directory, following the
+     * same {@code <extension-name>/SKILL.md} structure used inside
+     * the aggregated JAR.
+     *
+     * @param skillsDir the directory to scan for SKILL.md files
+     * @return list of locally found skills, never null
+     */
+    static List<SkillInfo> readLocalSkills(Path skillsDir) {
+        if (!Files.isDirectory(skillsDir)) {
+            return List.of();
+        }
+
+        List<SkillInfo> skills = new ArrayList<>();
+        try {
+            Files.walkFileTree(skillsDir, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (file.getFileName().toString().equals(SKILL_FILE_NAME)) {
+                        try {
+                            String content = Files.readString(file, StandardCharsets.UTF_8);
+                            SkillInfo skill = parseFrontmatter(content);
+                            skills.add(skill);
+                            LOG.debugf("Found local skill '%s' at %s", skill.name(), file);
+                        } catch (IOException e) {
+                            LOG.debugf("Failed to read local skill %s: %s", file, e.getMessage());
+                        }
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            LOG.debugf("Failed to scan local skills directory %s: %s", skillsDir, e.getMessage());
         }
         return skills;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,11 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   - Use quarkus/callTool with toolName 'devui-testing_runTests' to run all tests\n\
   - Use quarkus/callTool with toolName 'devui-testing_runTest' and toolArguments '{"className":"com.example.MyTest"}' to run a specific test\n\
   - Do NOT run Maven/Gradle test commands manually\n\n\
+  ERROR HANDLING:\n\
+  - When something goes wrong (compilation error, deployment failure, runtime exception), use quarkus/callTool with toolName 'devui-exceptions_getLastException' to get structured exception details (class, message, stack trace, user code location)\n\
+  - After fixing the issue, call 'devui-exceptions_clearLastException' to clear the recorded exception\n\
+  - NOTE: if the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet — fall back to quarkus/logs in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy\n\
+  - Use quarkus/logs only when you need broader log context beyond the exception itself\n\n\
   KEY RULES:\n\
   - NEVER skip quarkus/skills — it contains critical patterns that prevent common mistakes\n\
   - NEVER use generic documentation tools (Context7, web search) for Quarkus unless the user asks you to or until you're sure quarkus/searchDocs doesn't yield what you need\n\

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -182,6 +182,100 @@ class SkillReaderTest {
     }
 
     @Test
+    void readLocalSkillsFindsSkillFiles() throws Exception {
+        Path skillsDir = tempDir.resolve("skills");
+        Path restDir = skillsDir.resolve("quarkus-rest");
+        Files.createDirectories(restDir);
+        Files.writeString(restDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                description: "Local REST skill"
+                ---
+
+                ### Local REST
+                Local override content.
+                """);
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readLocalSkills(skillsDir);
+
+        assertEquals(1, skills.size());
+        assertEquals("quarkus-rest", skills.get(0).name());
+        assertEquals("Local REST skill", skills.get(0).description());
+        assertTrue(skills.get(0).content().contains("Local override content."));
+    }
+
+    @Test
+    void readLocalSkillsFindsMultipleSkills() throws Exception {
+        Path skillsDir = tempDir.resolve("skills");
+        Path restDir = skillsDir.resolve("quarkus-rest");
+        Path arcDir = skillsDir.resolve("quarkus-arc");
+        Files.createDirectories(restDir);
+        Files.createDirectories(arcDir);
+        Files.writeString(restDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                ---
+
+                ### REST
+                """);
+        Files.writeString(arcDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-arc
+                ---
+
+                ### CDI
+                """);
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readLocalSkills(skillsDir);
+
+        assertEquals(2, skills.size());
+    }
+
+    @Test
+    void readLocalSkillsReturnsEmptyWhenDirDoesNotExist() {
+        Path nonExistent = tempDir.resolve("no-such-dir");
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readLocalSkills(nonExistent);
+
+        assertTrue(skills.isEmpty());
+    }
+
+    @Test
+    void readLocalSkillsIgnoresNonSkillFiles() throws Exception {
+        Path skillsDir = tempDir.resolve("skills");
+        Path restDir = skillsDir.resolve("quarkus-rest");
+        Files.createDirectories(restDir);
+        Files.writeString(restDir.resolve("README.md"), "Not a skill file");
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readLocalSkills(skillsDir);
+
+        assertTrue(skills.isEmpty());
+    }
+
+    @Test
+    void readLocalSkillsFromProjectDir() throws Exception {
+        // Simulate a project with skills under src/main/resources/META-INF/skills/
+        Path projectSkillsDir = tempDir.resolve("src/main/resources/META-INF/skills/quarkus-rest");
+        Files.createDirectories(projectSkillsDir);
+        Files.writeString(projectSkillsDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                description: "Project-level REST skill"
+                ---
+
+                ### Custom REST patterns for this project
+                """);
+
+        Path skillsDir = tempDir.resolve("src/main/resources/META-INF/skills");
+        List<SkillReader.SkillInfo> skills = SkillReader.readLocalSkills(skillsDir);
+
+        assertEquals(1, skills.size());
+        assertEquals("quarkus-rest", skills.get(0).name());
+        assertEquals("Project-level REST skill", skills.get(0).description());
+        assertTrue(skills.get(0).content().contains("Custom REST patterns"));
+    }
+
+    @Test
     void parseMirrorUrlFromSettingsXml() throws Exception {
         Path settingsFile = tempDir.resolve("settings.xml");
         Files.writeString(settingsFile, """


### PR DESCRIPTION
## Summary
- **Three-layer skill override chain**: Skills are now loaded from JAR (baseline) → user-level (`~/.quarkus/skills/` or configured dir) → project-level (`src/main/resources/META-INF/skills/`), with each layer overriding the previous by skill name. This lets extension developers test skills locally without rebuilding the aggregated JAR, and lets teams customize patterns per-project.
- **Configurable user-level skills dir**: New `agent-mcp.local-skills-dir` config property to override the default `~/.quarkus/skills/` location.
- **Exception handling guidance**: Surfaces `devui-exceptions_getLastException` (from quarkusio/quarkus#53298) in server instructions, generated CLAUDE.md, `quarkus/logs` tool description, and README. Includes edge case note about first-deploy failures where the endpoint isn't registered yet.