### PR TITLE
fix: address review feedback on CreateTools and DevMcpProxyTools

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -130,7 +130,7 @@ public class CreateTools {
             createSourceDirectories(projectDir);
 
             // Generate AGENTS.md with Quarkus-specific instructions (and CLAUDE.md pointing to it)
-            generateClaudeMd(projectDir, extensions);
+            generateProjectInstructions(projectDir, extensions);
 
             // Auto-start the app in dev mode
             try {
@@ -325,15 +325,25 @@ public class CreateTools {
 
     private void addRestAssuredIfMissing(String projectDir) {
         Path pomPath = Path.of(projectDir, "pom.xml");
-        if (!Files.exists(pomPath)) {
-            return;
+        Path gradleKtsPath = Path.of(projectDir, "build.gradle.kts");
+        Path gradlePath = Path.of(projectDir, "build.gradle");
+
+        if (Files.exists(pomPath)) {
+            addRestAssuredToMaven(pomPath);
+        } else if (Files.exists(gradleKtsPath)) {
+            addRestAssuredToGradle(gradleKtsPath, "testImplementation(\"io.rest-assured:rest-assured\")");
+        } else if (Files.exists(gradlePath)) {
+            addRestAssuredToGradle(gradlePath, "testImplementation 'io.rest-assured:rest-assured'");
         }
+    }
+
+    // Safe for freshly-generated POMs from Quarkus CLI where the structure is predictable.
+    private void addRestAssuredToMaven(Path pomPath) {
         try {
             String pom = Files.readString(pomPath, StandardCharsets.UTF_8);
             if (pom.contains("rest-assured")) {
                 return;
             }
-            // Insert rest-assured dependency before </dependencies>
             String restAssuredDep = """
                         <dependency>
                             <groupId>io.rest-assured</groupId>
@@ -352,7 +362,48 @@ public class CreateTools {
         }
     }
 
-    private void generateClaudeMd(String projectDir, String extensions) {
+    private void addRestAssuredToGradle(Path buildFile, String dependency) {
+        try {
+            String content = Files.readString(buildFile, StandardCharsets.UTF_8);
+            if (content.contains("rest-assured")) {
+                return;
+            }
+            int depsStart = content.indexOf("dependencies");
+            if (depsStart < 0) {
+                return;
+            }
+            int braceStart = content.indexOf('{', depsStart);
+            if (braceStart < 0) {
+                return;
+            }
+            // Find the matching closing brace (safe for freshly-generated Quarkus projects)
+            int depth = 0;
+            int closingBrace = -1;
+            for (int i = braceStart; i < content.length(); i++) {
+                if (content.charAt(i) == '{') {
+                    depth++;
+                } else if (content.charAt(i) == '}') {
+                    depth--;
+                    if (depth == 0) {
+                        closingBrace = i;
+                        break;
+                    }
+                }
+            }
+            if (closingBrace < 0) {
+                return;
+            }
+            content = content.substring(0, closingBrace)
+                    + "    " + dependency + "\n"
+                    + content.substring(closingBrace);
+            Files.writeString(buildFile, content, StandardCharsets.UTF_8);
+            LOG.debugf("Added rest-assured test dependency to %s", buildFile);
+        } catch (IOException e) {
+            LOG.debugf("Failed to add rest-assured dependency: %s", e.getMessage());
+        }
+    }
+
+    private void generateProjectInstructions(String projectDir, String extensions) {
         try {
             String agentsMdContent = """
                     # AGENTS.md — Quarkus Project Instructions

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -41,6 +41,12 @@ public class DevMcpProxyTools {
 
     private static final AtomicLong REQUEST_ID = new AtomicLong(0);
 
+    // --- Startup / build polling ---
+    private static final int STARTUP_WAIT_SECONDS = 120;
+    private static final int POLL_INTERVAL_MS = 1000;
+    private static final long BUILD_POLL_INTERVAL_MS = 3000;
+    private static final long BUILD_WAIT_TIMEOUT_MS = 120000;
+
     @Inject
     QuarkusProcessManager processManager;
 
@@ -77,9 +83,6 @@ public class DevMcpProxyTools {
             return ToolResponse.error(e.getMessage());
         }
     }
-
-    private static final long BUILD_POLL_INTERVAL_MS = 3000;
-    private static final long BUILD_WAIT_TIMEOUT_MS = 120000;
 
     @Tool(name = "quarkus/skills", description = "Get coding skills, patterns, testing guidelines, and configuration reference "
             + "for the Quarkus extensions used in the project. "
@@ -162,24 +165,11 @@ public class DevMcpProxyTools {
             return List.of();
         }
 
-        long deadline = System.currentTimeMillis() + BUILD_WAIT_TIMEOUT_MS;
-        while (System.currentTimeMillis() < deadline) {
-            try {
-                Thread.sleep(BUILD_POLL_INTERVAL_MS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return List.of();
-            }
-
-            QuarkusInstance.Status status = instance.getStatus();
-            if (status == QuarkusInstance.Status.RUNNING) {
-                return SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null));
-            }
-            if (status == QuarkusInstance.Status.CRASHED || status == QuarkusInstance.Status.STOPPED) {
-                return List.of();
-            }
+        QuarkusInstance.Status status = awaitStartup(instance, BUILD_WAIT_TIMEOUT_MS, BUILD_POLL_INTERVAL_MS);
+        if (status == QuarkusInstance.Status.CRASHED || status == QuarkusInstance.Status.STOPPED) {
+            return List.of();
         }
-        // Timeout — try one last time in case JARs appeared
+        // RUNNING or timed out (still STARTING) — try reading skills either way
         return SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null));
     }
 
@@ -221,9 +211,6 @@ public class DevMcpProxyTools {
         }
     }
 
-    private static final int STARTUP_WAIT_SECONDS = 120;
-    private static final int POLL_INTERVAL_MS = 1000;
-
     private int resolvePort(String projectDir) {
         QuarkusInstance instance = processManager.getInstance(projectDir);
         if (instance == null) {
@@ -233,15 +220,9 @@ public class DevMcpProxyTools {
 
         // If the app is still starting, wait for it to become ready
         if (instance.getStatus() == QuarkusInstance.Status.STARTING) {
-            long deadline = System.currentTimeMillis() + STARTUP_WAIT_SECONDS * 1000L;
-            while (instance.getStatus() == QuarkusInstance.Status.STARTING
-                    && System.currentTimeMillis() < deadline) {
-                try {
-                    Thread.sleep(POLL_INTERVAL_MS);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new IllegalStateException("Interrupted while waiting for Quarkus to start.");
-                }
+            QuarkusInstance.Status status = awaitStartup(instance, STARTUP_WAIT_SECONDS * 1000L, POLL_INTERVAL_MS);
+            if (status == null) {
+                throw new IllegalStateException("Interrupted while waiting for Quarkus to start.");
             }
         }
 
@@ -256,6 +237,24 @@ public class DevMcpProxyTools {
             throw new IllegalStateException("Could not detect HTTP port for the running Quarkus application.");
         }
         return port;
+    }
+
+    /**
+     * Polls the instance status until it leaves STARTING or the deadline expires.
+     * Returns the final observed status, or null if interrupted.
+     */
+    private QuarkusInstance.Status awaitStartup(QuarkusInstance instance, long timeoutMs, long pollIntervalMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (instance.getStatus() == QuarkusInstance.Status.STARTING
+                && System.currentTimeMillis() < deadline) {
+            try {
+                Thread.sleep(pollIntervalMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+        }
+        return instance.getStatus();
     }
 
     private List<JsonNode> filterTools(JsonNode tools, String query) {


### PR DESCRIPTION
- Add Gradle support (`build.gradle` and `build.gradle.kts`) to `addRestAssuredIfMissing`, which previously only handled Maven projects. Uses brace-matching to find the `dependencies` block closing brace.
- Extract `addRestAssuredToMaven` and `addRestAssuredToGradle` helpers from the monolithic method.
- Rename `generateClaudeMd` → `generateProjectInstructions` to reflect that it generates both AGENTS.md and CLAUDE.md.
- Unify the two busy-wait polling patterns (`resolvePort` and `waitForBuildAndRetry`) into a shared `awaitStartup` helper that returns the final status or `null` on interrupt.
- Group all four polling constants together at the top of `DevMcpProxyTools` instead of having them scattered between methods.