### PR TITLE
feat: add Maven Central publishing and Claude Code plugin support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "quarkus-agent",
+  "description": "MCP server for AI coding agents to create, manage, and interact with Quarkus applications. Provides tools for project scaffolding, dev mode lifecycle, extension skills, Dev MCP proxy, and documentation search.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Quarkus"
+  },
+  "homepage": "https://github.com/quarkusio/quarkus-agent-mcp",
+  "repository": "https://github.com/quarkusio/quarkus-agent-mcp",
+  "license": "Apache-2.0"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           files: |
             target/quarkus-agent-mcp-${{ env.VERSION }}-runner.jar
 
-      - name: Update JBang catalog
+      - name: Update version in JBang catalog and plugin manifest
         run: |
           cat > jbang-catalog.json << CATALOG_EOF
           {
@@ -61,10 +61,11 @@ jobs:
             }
           }
           CATALOG_EOF
+          jq --arg v "$VERSION" '.version = $v' .claude-plugin/plugin.json > tmp.json && mv tmp.json .claude-plugin/plugin.json
 
-      - name: Commit updated JBang catalog
+      - name: Commit updated JBang catalog and plugin manifest
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "Update JBang catalog for v${{ env.VERSION }}"
-          file_pattern: jbang-catalog.json
+          commit_message: "chore: update versions for v${{ env.VERSION }}"
+          file_pattern: jbang-catalog.json .claude-plugin/plugin.json
           branch: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
+          server-id: ossrh
+          server-username: SONATYPE_USERNAME
+          server-password: SONATYPE_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
 
       - name: Set version from tag
         run: |
@@ -29,34 +34,33 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           ./mvnw versions:set -DnewVersion=$VERSION -DgenerateBackupPoms=false
 
-      - name: Build JVM uber-jar
-        run: ./mvnw package -DskipTests -Dquarkus.package.jar.type=uber-jar
-
-      - name: Rename artifacts
-        run: |
-          mv target/quarkus-agent-mcp-${VERSION}-runner.jar target/quarkus-agent-mcp-${VERSION}.jar
+      - name: Deploy to Maven Central
+        run: ./mvnw deploy -Prelease -DskipTests
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: |
-            target/quarkus-agent-mcp-${{ env.VERSION }}.jar
+            target/quarkus-agent-mcp-${{ env.VERSION }}-runner.jar
 
       - name: Update JBang catalog
         run: |
-          cat > jbang-catalog.json << 'CATALOG_EOF'
+          cat > jbang-catalog.json << CATALOG_EOF
           {
             "aliases": {
               "quarkus-agent-mcp": {
-                "script-ref": "https://github.com/quarkusio/quarkus-agent-mcp/releases/download/v${VERSION}/quarkus-agent-mcp-${VERSION}.jar",
+                "script-ref": "io.quarkus:quarkus-agent-mcp:${VERSION}:runner",
                 "description": "Standalone MCP server for AI coding agents to manage Quarkus applications",
                 "java-version": "21+"
               }
             }
           }
           CATALOG_EOF
-          sed -i "s/\${VERSION}/${VERSION}/g" jbang-catalog.json
 
       - name: Commit updated JBang catalog
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "quarkus-agent": {
+    "command": "jbang",
+    "args": ["quarkus-agent-mcp@quarkusio"]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -16,24 +16,22 @@ Part of the [DevStar](https://github.com/quarkusio/quarkus/discussions/53093) wo
 
 ## Installation
 
-### Build from source
+### Claude Code plugin (one command)
 
 ```bash
-git clone https://github.com/quarkusio/quarkus-agent-mcp.git
-cd quarkus-agent-mcp
-./mvnw package -DskipTests
+claude plugin install --url https://github.com/quarkusio/quarkus-agent-mcp
 ```
 
-This produces the runner jar at `target/quarkus-app/quarkus-run.jar`.
+This installs the plugin and configures the MCP server automatically. Requires [JBang](https://www.jbang.dev/download/).
 
-### Configure your coding agent
+### Via JBang (recommended)
 
-Once built, register the MCP server with your coding agent. Choose the section for your agent below.
+[JBang](https://www.jbang.dev/download/) resolves the uber-jar from Maven Central automatically — no build step needed.
 
 #### Claude Code
 
 ```bash
-claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp/target/quarkus-app/quarkus-run.jar
+claude mcp add quarkus-agent -- jbang quarkus-agent-mcp@quarkusio
 ```
 
 #### VS Code / GitHub Copilot
@@ -45,8 +43,8 @@ Add to `.vscode/mcp.json` in your workspace:
   "servers": {
     "quarkus-agent": {
       "type": "stdio",
-      "command": "java",
-      "args": ["-jar", "/path/to/quarkus-agent-mcp/target/quarkus-app/quarkus-run.jar"]
+      "command": "jbang",
+      "args": ["quarkus-agent-mcp@quarkusio"]
     }
   }
 }
@@ -60,8 +58,8 @@ Add to `.cursor/mcp.json`:
 {
   "mcpServers": {
     "quarkus-agent": {
-      "command": "java",
-      "args": ["-jar", "/path/to/quarkus-agent-mcp/target/quarkus-app/quarkus-run.jar"]
+      "command": "jbang",
+      "args": ["quarkus-agent-mcp@quarkusio"]
     }
   }
 }
@@ -75,11 +73,33 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 {
   "mcpServers": {
     "quarkus-agent": {
-      "command": "java",
-      "args": ["-jar", "/path/to/quarkus-agent-mcp/target/quarkus-app/quarkus-run.jar"]
+      "command": "jbang",
+      "args": ["quarkus-agent-mcp@quarkusio"]
     }
   }
 }
+```
+
+### Via direct download
+
+Download the uber-jar from the [latest GitHub Release](https://github.com/quarkusio/quarkus-agent-mcp/releases/latest), then:
+
+```bash
+claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp-1.0.0-runner.jar
+```
+
+### Build from source
+
+```bash
+git clone https://github.com/quarkusio/quarkus-agent-mcp.git
+cd quarkus-agent-mcp
+./mvnw package -DskipTests -Dquarkus.package.jar.type=uber-jar
+```
+
+This produces the uber-jar at `target/quarkus-agent-mcp-1.0.0-SNAPSHOT-runner.jar`.
+
+```bash
+claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp/target/quarkus-agent-mcp-1.0.0-SNAPSHOT-runner.jar
 ```
 
 #### Verify
@@ -273,13 +293,13 @@ Configuration via `application.properties`, system properties (`-D`), or environ
 For instant startup (no JVM warmup):
 
 ```bash
-./mvnw package -Dnative -DskipTests
+./mvnw package -Dnative -DskipTests -Dquarkus.package.jar.type=uber-jar
 ```
 
 Then reference the native binary in your MCP config:
 
 ```bash
-claude mcp add quarkus-agent -- ./target/quarkus-agent-mcp-1.0.0-SNAPSHOT-runner
+claude mcp add quarkus-agent -- ./target/quarkus-agent-mcp-*-runner
 ```
 
 ## Related Projects

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,7 +1,7 @@
 {
   "aliases": {
     "quarkus-agent-mcp": {
-      "script-ref": "io.quarkus:quarkus-agent-mcp:1.0.0-SNAPSHOT:runner",
+      "script-ref": "io.quarkus:quarkus-agent-mcp:RELEASE:runner",
       "description": "Standalone MCP server for AI coding agents to manage Quarkus applications",
       "java-version": "21+"
     }

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,40 @@
     <version>1.0.0-SNAPSHOT</version>
     <name>Quarkus Agent MCP</name>
     <description>Standalone MCP server for AI coding agents to manage Quarkus applications</description>
+    <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>phillip-kruger</id>
+            <name>Phillip Kruger</name>
+            <url>https://github.com/phillip-kruger</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/quarkusio/quarkus-agent-mcp.git</connection>
+        <developerConnection>scm:git:ssh://github.com:quarkusio/quarkus-agent-mcp.git</developerConnection>
+        <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
+    </scm>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
@@ -136,6 +170,73 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>release</id>
+            <properties>
+                <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.11.2</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.7</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>native</id>
             <activation>


### PR DESCRIPTION
Add the infrastructure to publish releases to Maven Central and make this repo installable as a Claude Code plugin.

### Maven Central
- POM: required metadata (license, SCM, developers, URL), `distributionManagement` for OSSRH, and a `release` profile with source, javadoc, GPG signing, and nexus-staging plugins producing an uber-jar
- Release workflow: `mvn deploy -Prelease` using the existing `quarkusio` org secrets (`SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`), GitHub Release with uber-jar attached, and JBang catalog updated to Maven Central coordinates

### Claude Code plugin
- `.claude-plugin/plugin.json` manifest and `.mcp.json` so the repo can be installed with:
  ```
  claude plugin install --url https://github.com/quarkusio/quarkus-agent-mcp
  ```
- Ready for submission to the [official Anthropic plugin directory](https://platform.claude.com/plugins/submit)

### README
- New installation options: Claude Code plugin (one command), JBang, direct download — alongside build-from-source