### PR TITLE
feat: add plugin marketplace for self-service discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "quarkus-tools",
+  "owner": {
+    "name": "Quarkus"
+  },
+  "metadata": {
+    "description": "MCP servers and tools for Quarkus development with AI coding agents"
+  },
+  "plugins": [
+    {
+      "name": "quarkus-agent",
+      "source": ".",
+      "description": "MCP server for AI coding agents to create, manage, and interact with Quarkus applications. Provides tools for project scaffolding, dev mode lifecycle, extension skills, Dev MCP proxy, and documentation search.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Quarkus"
+      },
+      "homepage": "https://github.com/quarkusio/quarkus-agent-mcp",
+      "repository": "https://github.com/quarkusio/quarkus-agent-mcp",
+      "license": "Apache-2.0",
+      "keywords": ["quarkus", "java", "mcp", "dev-mode", "documentation"]
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,11 @@ jobs:
           }
           CATALOG_EOF
           jq --arg v "$VERSION" '.version = $v' .claude-plugin/plugin.json > tmp.json && mv tmp.json .claude-plugin/plugin.json
+          jq --arg v "$VERSION" '.plugins[0].version = $v' .claude-plugin/marketplace.json > tmp.json && mv tmp.json .claude-plugin/marketplace.json
 
       - name: Commit updated JBang catalog and plugin manifest
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: update versions for v${{ env.VERSION }}"
-          file_pattern: jbang-catalog.json .claude-plugin/plugin.json
+          file_pattern: jbang-catalog.json .claude-plugin/plugin.json .claude-plugin/marketplace.json
           branch: main

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Part of the [DevStar](https://github.com/quarkusio/quarkus/discussions/53093) wo
 
 ## Installation
 
-### Claude Code plugin (one command)
+### Claude Code plugin
+
+Add the marketplace and install the plugin:
 
 ```bash
-claude plugin install --url https://github.com/quarkusio/quarkus-agent-mcp
+claude plugin marketplace add quarkusio/quarkus-agent-mcp
+claude plugin install quarkus-agent@quarkus-tools
 ```
 
 This installs the plugin and configures the MCP server automatically. Requires [JBang](https://www.jbang.dev/download/).


### PR DESCRIPTION
Add a `marketplace.json` so users can discover and install the plugin
directly from this repo without waiting for the official Anthropic
directory:

```bash
claude plugin marketplace add quarkusio/quarkus-agent-mcp
claude plugin install quarkus-agent@quarkus-tools
```

Also updates the README install instructions and the release workflow
to keep the marketplace version in sync on release.