### PR TITLE
feat: add post-completion summary and next steps instruction

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -442,6 +442,7 @@ public class CreateTools {
                     - NEVER write code for a feature without first loading its skill via `quarkus/skills`.
                     - ALWAYS write tests for every feature — no exceptions.
                     - ALWAYS keep README.md updated with app description, features, endpoints, and Quarkus guide links.
+                    - ALWAYS summarize after completing work — when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment).
                     - Use `@QuarkusTest` for integration tests — Dev Services auto-starts backing services (databases, messaging, etc.).
                     - Use `%dev.` and `%test.` profile prefixes for dev/test configuration — never hardcode connection URLs without a profile prefix.
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,7 +33,8 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   - NEVER use generic documentation tools (Context7, web search) for Quarkus unless the user asks you to or until you're sure quarkus/searchDocs doesn't yield what you need\n\
   - NEVER run build commands manually — use quarkus/start, quarkus/callTool for testing\n\
   - ALWAYS write tests for every feature\n\
-  - ALWAYS keep README.md updated
+  - ALWAYS keep README.md updated\n\
+  - ALWAYS summarize after completing work — when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment)
 
 # Default Quarkus version for created projects (omit to use latest release)
 # Uncomment for local testing against a SNAPSHOT build:


### PR DESCRIPTION
After building an app or completing a feature, the agent should always wrap up with a summary of what was done and suggest what the user might want to tackle next. This was missing — agents would finish the work but leave the user without a clear picture of the outcome or where to go from there.

Adds a new KEY RULE to both the MCP server instructions (`application.properties`) and the generated `AGENTS.md` template (`CreateTools.java`) instructing agents to always provide:
- A summary of what was done (files created/modified, endpoints added, extensions used)
- Suggested next steps (security, observability, persistence, testing, deployment, etc.)