### PR TITLE
docs: mention that Dev MCP tool list is dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ NEW PROJECT                           EXISTING PROJECT
 
 ### What the agent can do with a running app
 
-Once a Quarkus app is running in dev mode, the agent can discover and use all Dev MCP tools via `quarkus/searchTools` and `quarkus/callTool`. These typically include:
+Once a Quarkus app is running in dev mode, the agent can discover and use all Dev MCP tools via `quarkus/searchTools` and `quarkus/callTool`. The tool list is **dynamic** — it changes when extensions are added or removed, so the agent should re-discover tools after any extension change. Typical tools include:
 
 | Capability | How to discover | Example |
 |-----------|----------------|---------|

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -430,7 +430,7 @@ public class CreateTools {
                     1. **Use quarkus/update (via subagent) when returning to this project** — checks if the Quarkus version is up-to-date and suggests upgrades.
                     2. **Use quarkus/skills BEFORE writing any code or tests** — it contains extension-specific patterns, testing approaches, and common pitfalls that prevent mistakes. Call this EVERY time you are about to add or modify a feature, not just at project creation.
                     3. **Use quarkus/searchDocs for Quarkus documentation** — do NOT use generic documentation tools (Context7, web search). The Quarkus doc search is version-aware and more accurate.
-                    4. **Use quarkus/searchTools to discover Dev MCP tools** on the running app for testing, config changes, and extension management.
+                    4. **Use quarkus/searchTools to discover Dev MCP tools** on the running app for testing, config changes, and extension management. The tool list is **dynamic** — it changes when extensions are added or removed. Re-call `quarkus/searchTools` after any extension change to discover newly available tools.
                     5. **Use quarkus/callTool to invoke Dev MCP tools** — run tests, add extensions, update configuration. Do NOT run Maven/Gradle commands manually.
                     6. **After code changes, trigger a reload** via `quarkus/callTool` with toolName `devui-logstream_forceRestart`. Do NOT restart the app manually.
                     7. **After pom.xml / build.gradle changes** (adding dependencies or extensions), you MUST do a full `quarkus/stop` + `quarkus/start` cycle. A `forceRestart` only recompiles source files — it does NOT re-resolve dependencies.

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -58,7 +58,9 @@ public class DevMcpProxyTools {
 
     @Tool(name = "quarkus/searchTools", description = "Discover available tools on the running Quarkus app's Dev MCP server. "
             + "Use this before interacting with the running app — for testing, config, extensions, "
-            + "endpoints, dev services, etc. Then use quarkus/callTool to invoke the discovered tool.")
+            + "endpoints, dev services, etc. Then use quarkus/callTool to invoke the discovered tool. "
+            + "The tool list is DYNAMIC — it changes when extensions are added or removed. "
+            + "Re-call this after any extension change to discover newly available tools.")
     ToolResponse searchTools(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
             @ToolArg(description = "Search query to filter tools by name or description (case-insensitive). "


### PR DESCRIPTION
Agents should know that the available Dev MCP tools change when extensions are added or removed, so they re-discover tools after extension changes instead of relying on a stale list.

Updated the `searchTools` tool description, the generated AGENTS.md template, and the README to call this out.