### PR TITLE
docs: update workgroup name and tagline on title slide

### DIFF
--- a/presentation/index.html
+++ b/presentation/index.html
@@ -826,9 +826,9 @@
 <!-- ============================================ -->
 <section class="title-slide">
   <h1 style="font-size:3.2em;">Dev<span style="-webkit-text-fill-color: var(--q-red);">Star</span></h1>
-  <div class="subtitle">Quarkus Developer Tooling Workgroup</div>
+  <div class="subtitle">Quarkus Coding Agent Tooling Workgroup</div>
   <div class="tagline">
-    Rethinking how developers &mdash; and AI agents &mdash; interact with Quarkus at dev time
+    Rethinking how AI coding agents interact with Quarkus at dev time
   </div>
   <div class="agents" style="margin-top:24px;">
     <span class="tag">Dev UI</span>


### PR DESCRIPTION
Rename the DevStar title slide to "Quarkus Coding Agent Tooling Workgroup" and simplify the tagline to "Rethinking how AI coding agents interact with Quarkus at dev time".