### PR TITLE
feat: add skill enhance mode and quarkus/updateSkill tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,20 @@ Once a Quarkus app is running in dev mode, the agent can discover and use all De
 
 The agent can read extension-specific coding skills using `quarkus/skills`. Skills contain patterns, testing guidelines, and common pitfalls for each extension — things like "always use `@Transactional` for write operations with Panache" or "don't create REST clients manually, let CDI inject them."
 
-Skills are loaded using a three-layer override chain (most specific wins):
+Skills are loaded using a three-layer chain (most specific wins):
 
 1. **JAR skills** — from the `quarkus-extension-skills` JAR, automatically downloaded from Maven Central (or a configured mirror) for the project's Quarkus version. These are the official defaults.
 2. **User-level skills** — from `~/.quarkus/skills/<extension-name>/SKILL.md` (or a directory configured via `agent-mcp.local-skills-dir`). Useful for extension developers testing new or modified skills without rebuilding the aggregated JAR.
 3. **Project-level skills** — from `.quarkus/skills/<extension-name>/SKILL.md` in the project directory. Allows teams to customize extension patterns for their specific project conventions.
 
-Each layer overrides the previous by skill name. For example, a project-level `quarkus-rest` skill replaces both the user-level and JAR versions.
+Each layer can either **enhance** (default) or **override** the previous layer, controlled by the `mode` field in the SKILL.md frontmatter:
+
+- **`mode: enhance`** (default) — appends content to the base skill. The base content is preserved and the customization is added after a separator. This is ideal for adding project conventions or team standards without losing the built-in guidance.
+- **`mode: override`** — fully replaces the base skill. Use this when you need complete control over a skill's content.
+
+The agent can also create or update skill customizations using `quarkus/updateSkill`. When the user asks to customize a skill, the agent will ask:
+1. **Enhance or override?** — append to the base skill or fully replace it.
+2. **Project or global scope?** — save under `.quarkus/skills/` (this project only) or `~/.quarkus/skills/` (all projects).
 
 ### Documentation search
 
@@ -225,6 +232,7 @@ For existing projects, `quarkus/update` checks if the Quarkus version is current
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | `quarkus/skills` | Get coding patterns, testing guidelines, and pitfalls for project extensions | `projectDir` (required), `query` |
+| `quarkus/updateSkill` | Create or update a skill customization (enhance or override) | `projectDir` (required), `skillName` (required), `content` (required), `description`, `mode`, `scope` |
 
 ### Lifecycle Management
 
@@ -289,7 +297,7 @@ Configuration via `application.properties`, system properties (`-D`), or environ
 | `agent-mcp.doc-search.pg-password` | `quarkus` | PostgreSQL password |
 | `agent-mcp.doc-search.pg-database` | `quarkus` | PostgreSQL database |
 | `agent-mcp.doc-search.min-score` | `0.82` | Minimum similarity score for search results |
-| `agent-mcp.local-skills-dir` | `~/.quarkus/skills` | Directory for user-level skill overrides |
+| `agent-mcp.local-skills-dir` | `~/.quarkus/skills` | Directory for user-level skill customizations |
 
 ## Building a Native Image
 

--- a/presentation/index.html
+++ b/presentation/index.html
@@ -1239,6 +1239,7 @@
     <div class="tool-group fragment fade-up">
       <h3>&#x1F9E0; Intelligence</h3>
       <div class="tool-name">quarkus/skills <span>extension patterns</span></div>
+      <div class="tool-name">quarkus/updateSkill <span>customize skills</span></div>
       <div class="tool-name">quarkus/searchDocs <span>semantic doc search</span></div>
     </div>
     <div class="tool-group fragment fade-up">
@@ -1365,20 +1366,20 @@
 <section>
   <h2 style="border-left: 4px solid var(--q-red); padding-left: 20px;">How Skills Work</h2>
   <p style="font-size:0.7em; color:var(--q-text-dim); margin-bottom: 8px;">
-    Three-layer override chain &mdash; each layer overlays the previous by extension name
+    Three-layer chain &mdash; each layer can <strong>enhance</strong> (append) or <strong>override</strong> (replace) the previous
   </p>
   <div class="skills-stack">
     <div class="skill-layer project fragment fade-up">
       <strong>Project-level skills</strong>
       <div class="path">.quarkus/skills/{ext}/SKILL.md</div>
       <div style="color:var(--q-text-dim); font-size:0.9em; margin-top:4px;">Team conventions &amp; project-specific patterns</div>
-      <span class="skill-badge wins">WINS</span>
+      <span class="skill-badge wins">ENHANCE / OVERRIDE</span>
     </div>
     <div class="skill-layer user fragment fade-up">
       <strong>User-level skills</strong>
       <div class="path">~/.quarkus/skills/{ext}/SKILL.md</div>
-      <div style="color:var(--q-text-dim); font-size:0.9em; margin-top:4px;">Personal overrides &amp; extension dev testing</div>
-      <span class="skill-badge override">OVERRIDES</span>
+      <div style="color:var(--q-text-dim); font-size:0.9em; margin-top:4px;">Personal customizations &amp; extension dev testing</div>
+      <span class="skill-badge override">ENHANCE / OVERRIDE</span>
     </div>
     <div class="skill-layer jar fragment fade-up">
       <strong>JAR skills (baseline)</strong>
@@ -1387,6 +1388,10 @@
       <span class="skill-badge baseline">BASELINE</span>
     </div>
   </div>
+  <p class="fragment fade-up" style="font-size:0.6em; color:var(--q-text-dim); margin-top: 12px;">
+    Default is <strong>enhance</strong> &mdash; add project rules without losing built-in guidance. Use <code>mode: override</code> for full replacement.
+    <br>Agents can use <code>quarkus/updateSkill</code> to create customizations interactively.
+  </p>
 </section>
 
 <!-- ============================================ -->
@@ -1611,7 +1616,7 @@
       <div class="step-content">
         <span class="step-tool">SKILL.md</span>
         <span class="step-arrow">&rarr;</span>
-        <span class="step-desc"><strong style="color:#fff;">Write a skill override</strong> to fix those mistakes. Ask the agent to write it &mdash; it just learned the correct approach.</span>
+        <span class="step-desc"><strong style="color:#fff;">Enhance the skill</strong> to fix those mistakes. Ask the agent to use <code>quarkus/updateSkill</code> &mdash; it adds your rules on top of the base skill.</span>
       </div>
     </div>
     <div class="workflow-line"></div>

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -476,10 +476,18 @@ public class CreateTools {
 
                     ## Customizing Skills
 
-                    Extension skills can be overridden per-project by placing SKILL.md files under
-                    `.quarkus/skills/<extension-name>/SKILL.md`. Project-level
-                    skills take precedence over the built-in defaults. This is useful for enforcing
-                    team conventions or adjusting patterns for specific project requirements.
+                    Extension skills can be customized per-project or globally using `quarkus/updateSkill`.
+                    When the user asks to update or customize a skill, ask them:
+                    1. **Enhance or override?** — Enhance (default) appends content to the base skill.
+                       Override fully replaces the base skill.
+                    2. **Project or global scope?** — Project scope (`.quarkus/skills/`) affects only this project.
+                       Global scope (`~/.quarkus/skills/`) affects all projects.
+
+                    Skills use a three-layer chain: JAR defaults → global customizations → project customizations.
+                    Each layer can either enhance (append to) or override (replace) the previous layer.
+
+                    You can also manually place SKILL.md files under `.quarkus/skills/<extension-name>/SKILL.md`.
+                    Use `mode: enhance` (default) or `mode: override` in the YAML frontmatter to control behavior.
                     """;
             Files.writeString(Path.of(projectDir, "AGENTS.md"), agentsMdContent, StandardCharsets.UTF_8);
             LOG.debugf("Generated AGENTS.md in %s", projectDir);

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -94,9 +94,10 @@ public class DevMcpProxyTools {
             + "If the app is still building (just created), this will wait for the build to complete. "
             + "Skills may include an 'Available Dev MCP Tools' section listing extension-specific Dev MCP tools "
             + "that can be invoked via quarkus/callTool (e.g. OpenAPI schema retrieval, scheduler job management). "
-            + "Skills can be customized per-project by placing SKILL.md files under "
-            + ".quarkus/skills/<extension-name>/SKILL.md in the project directory. "
-            + "Project-level skills override the built-in defaults.",
+            + "Skills can be customized using quarkus/updateSkill. Customizations use a three-layer chain: "
+            + "JAR defaults → global (~/.quarkus/skills/) → project (.quarkus/skills/). "
+            + "By default, customizations ENHANCE (append to) the base skill. "
+            + "Use mode 'override' to fully replace a base skill.",
             annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false,
                     idempotentHint = true, openWorldHint = false))
     ToolResponse skills(
@@ -178,6 +179,44 @@ public class DevMcpProxyTools {
         }
         // RUNNING or timed out (still STARTING) — try reading skills either way
         return SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null));
+    }
+
+    @Tool(name = "quarkus/updateSkill", description = "Create or update a skill customization for a Quarkus extension. "
+            + "Use this when the user wants to add project conventions, team standards, or guardrails to an extension skill. "
+            + "IMPORTANT: Before writing, ask the user two questions: "
+            + "(1) Should this ENHANCE the existing skill (append your content to the base) or OVERRIDE it (fully replace the base)? "
+            + "Enhance is the default and recommended for most cases. "
+            + "(2) Should this be saved at PROJECT scope (.quarkus/skills/ in the project, affects only this project) "
+            + "or GLOBAL scope (~/.quarkus/skills/, affects all projects)?",
+            annotations = @Tool.Annotations(readOnlyHint = false, destructiveHint = false, idempotentHint = true))
+    ToolResponse updateSkill(
+            @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
+            @ToolArg(description = "The extension skill name (e.g. 'quarkus-rest', 'quarkus-hibernate-orm-panache')") String skillName,
+            @ToolArg(description = "The skill content in markdown (without frontmatter — it will be generated)") String content,
+            @ToolArg(description = "Optional description for the skill", required = false) String description,
+            @ToolArg(description = "Mode: 'enhance' (default) appends to the base skill, 'override' fully replaces it",
+                    required = false) String mode,
+            @ToolArg(description = "Scope: 'project' (default) saves under .quarkus/skills/ in the project, "
+                    + "'global' saves under ~/.quarkus/skills/", required = false) String scope) {
+        try {
+            SkillReader.SkillMode skillMode = SkillReader.SkillMode.fromString(mode);
+            boolean projectScope = !"global".equalsIgnoreCase(scope);
+
+            Path written = SkillReader.writeSkill(
+                    skillName, content, description, skillMode,
+                    projectDir, localSkillsDir.map(Path::of).orElse(null), projectScope);
+
+            String modeLabel = skillMode == SkillReader.SkillMode.ENHANCE ? "enhance" : "override";
+            String scopeLabel = projectScope ? "project" : "global";
+            return ToolResponse.success(
+                    "Skill '" + skillName + "' saved successfully.\n"
+                            + "- **Mode**: " + modeLabel + "\n"
+                            + "- **Scope**: " + scopeLabel + "\n"
+                            + "- **Path**: " + written + "\n\n"
+                            + "The skill will take effect on the next call to `quarkus/skills`.");
+        } catch (Exception e) {
+            return ToolResponse.error("Failed to write skill: " + e.getMessage());
+        }
     }
 
     @Tool(name = "quarkus/callTool", description = "Invoke a Dev MCP tool by name on the running Quarkus app. "

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -32,7 +32,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 /**
- * Reads extension skill files (SKILL.md) using a three-layer override chain:
+ * Reads extension skill files (SKILL.md) using a three-layer chain:
  * <ol>
  *   <li><b>JAR skills</b> — from the aggregated {@code quarkus-extension-skills} JAR
  *       shipped with each Quarkus release (baseline defaults)</li>
@@ -41,7 +41,9 @@ import org.w3c.dom.NodeList;
  *   <li><b>Project-level skills</b> — from {@code .quarkus/skills/}
  *       in the project directory (for per-project customization)</li>
  * </ol>
- * Each layer overrides the previous by skill name (most specific wins).
+ * Each layer can either <b>enhance</b> (append to) or <b>override</b> (replace)
+ * the previous layer, controlled by the {@code mode} field in the SKILL.md
+ * frontmatter. The default mode is {@code enhance}.
  */
 public final class SkillReader {
 
@@ -53,7 +55,7 @@ public final class SkillReader {
     private static final String MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2";
     private static final Pattern FRONTMATTER_NAME = Pattern.compile("^name:\\s*(.+)$", Pattern.MULTILINE);
     private static final Pattern FRONTMATTER_DESC = Pattern.compile("^description:\\s*\"(.+)\"$", Pattern.MULTILINE);
-    private static final Pattern FRONTMATTER_MODE = Pattern.compile("^mode:\\s*(.+)$", Pattern.MULTILINE);
+    private static final Pattern FRONTMATTER_MODE = Pattern.compile("^mode:\\s*(\\S+)", Pattern.MULTILINE);
 
     private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(10))
@@ -140,7 +142,7 @@ public final class SkillReader {
         return new ArrayList<>(skillsByName.values());
     }
 
-    private static void overlaySkills(Map<String, SkillInfo> target, List<SkillInfo> overlay, String source) {
+    static void overlaySkills(Map<String, SkillInfo> target, List<SkillInfo> overlay, String source) {
         for (SkillInfo skill : overlay) {
             if (target.containsKey(skill.name())) {
                 if (skill.mode() == SkillMode.ENHANCE) {
@@ -276,6 +278,10 @@ public final class SkillReader {
      */
     static Path writeSkill(String skillName, String content, String description,
             SkillMode mode, String projectDir, Path localSkillsDir, boolean projectScope) throws IOException {
+        if (skillName == null || skillName.contains("/") || skillName.contains("\\") || skillName.contains("..")) {
+            throw new IllegalArgumentException("Invalid skill name: " + skillName);
+        }
+
         Path baseDir;
         if (projectScope) {
             baseDir = Path.of(projectDir, ".quarkus", "skills");
@@ -290,7 +296,7 @@ public final class SkillReader {
         sb.append("---\n");
         sb.append("name: ").append(skillName).append("\n");
         if (description != null && !description.isBlank()) {
-            sb.append("description: \"").append(description).append("\"\n");
+            sb.append("description: \"").append(description.replace("\"", "\\\"")).append("\"\n");
         }
         sb.append("mode: ").append(mode.name().toLowerCase()).append("\n");
         sb.append("---\n\n");

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -53,13 +53,26 @@ public final class SkillReader {
     private static final String MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2";
     private static final Pattern FRONTMATTER_NAME = Pattern.compile("^name:\\s*(.+)$", Pattern.MULTILINE);
     private static final Pattern FRONTMATTER_DESC = Pattern.compile("^description:\\s*\"(.+)\"$", Pattern.MULTILINE);
+    private static final Pattern FRONTMATTER_MODE = Pattern.compile("^mode:\\s*(.+)$", Pattern.MULTILINE);
 
     private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(10))
             .followRedirects(HttpClient.Redirect.NORMAL)
             .build();
 
-    public record SkillInfo(String name, String description, String content) {
+    public enum SkillMode {
+        ENHANCE,
+        OVERRIDE;
+
+        static SkillMode fromString(String value) {
+            if (value != null && value.trim().equalsIgnoreCase("override")) {
+                return OVERRIDE;
+            }
+            return ENHANCE;
+        }
+    }
+
+    public record SkillInfo(String name, String description, String content, SkillMode mode) {
     }
 
     private SkillReader() {
@@ -130,11 +143,25 @@ public final class SkillReader {
     private static void overlaySkills(Map<String, SkillInfo> target, List<SkillInfo> overlay, String source) {
         for (SkillInfo skill : overlay) {
             if (target.containsKey(skill.name())) {
-                LOG.infof("Skill '%s' overridden by %s", skill.name(), source);
+                if (skill.mode() == SkillMode.ENHANCE) {
+                    SkillInfo base = target.get(skill.name());
+                    String mergedContent = base.content() + "\n\n---\n\n" + skill.content();
+                    String desc = skill.description() != null ? skill.description() : base.description();
+                    target.put(skill.name(), new SkillInfo(skill.name(), desc, mergedContent, SkillMode.ENHANCE));
+                    LOG.infof("Skill '%s' enhanced by %s", skill.name(), source);
+                } else {
+                    target.put(skill.name(), skill);
+                    LOG.infof("Skill '%s' overridden by %s", skill.name(), source);
+                }
             } else {
-                LOG.infof("Skill '%s' added from %s", skill.name(), source);
+                if (skill.mode() == SkillMode.ENHANCE) {
+                    LOG.warnf("Skill '%s' uses enhance mode but no base skill exists — adding as new skill from %s",
+                            skill.name(), source);
+                } else {
+                    LOG.infof("Skill '%s' added from %s", skill.name(), source);
+                }
+                target.put(skill.name(), skill);
             }
-            target.put(skill.name(), skill);
         }
     }
 
@@ -145,6 +172,7 @@ public final class SkillReader {
         String name = "unknown";
         String description = null;
         String body = fullContent;
+        SkillMode mode = SkillMode.ENHANCE;
 
         if (fullContent.startsWith("---")) {
             int endIdx = fullContent.indexOf("---", 3);
@@ -161,10 +189,15 @@ public final class SkillReader {
                 if (descMatcher.find()) {
                     description = descMatcher.group(1).trim();
                 }
+
+                Matcher modeMatcher = FRONTMATTER_MODE.matcher(frontmatter);
+                if (modeMatcher.find()) {
+                    mode = SkillMode.fromString(modeMatcher.group(1));
+                }
             }
         }
 
-        return new SkillInfo(name, description, body);
+        return new SkillInfo(name, description, body, mode);
     }
 
     /**
@@ -226,6 +259,47 @@ public final class SkillReader {
             LOG.debugf("Failed to scan local skills directory %s: %s", skillsDir, e.getMessage());
         }
         return skills;
+    }
+
+    /**
+     * Writes a SKILL.md file to the appropriate directory based on scope.
+     *
+     * @param skillName    the extension name (e.g. "quarkus-rest")
+     * @param content      the markdown content (without frontmatter)
+     * @param description  optional description for the frontmatter
+     * @param mode         ENHANCE or OVERRIDE
+     * @param projectDir   the project directory (used for project-scope writes)
+     * @param localSkillsDir user-level skills directory, or null for the default
+     * @param projectScope true to write under {@code <projectDir>/.quarkus/skills/},
+     *                     false to write under the user-level directory
+     * @return the path the file was written to
+     */
+    static Path writeSkill(String skillName, String content, String description,
+            SkillMode mode, String projectDir, Path localSkillsDir, boolean projectScope) throws IOException {
+        Path baseDir;
+        if (projectScope) {
+            baseDir = Path.of(projectDir, ".quarkus", "skills");
+        } else {
+            baseDir = localSkillsDir != null ? localSkillsDir : DEFAULT_LOCAL_SKILLS_DIR;
+        }
+
+        Path skillDir = baseDir.resolve(skillName);
+        Files.createDirectories(skillDir);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("---\n");
+        sb.append("name: ").append(skillName).append("\n");
+        if (description != null && !description.isBlank()) {
+            sb.append("description: \"").append(description).append("\"\n");
+        }
+        sb.append("mode: ").append(mode.name().toLowerCase()).append("\n");
+        sb.append("---\n\n");
+        sb.append(content);
+
+        Path skillFile = skillDir.resolve(SKILL_FILE_NAME);
+        Files.writeString(skillFile, sb.toString(), StandardCharsets.UTF_8);
+        LOG.infof("Wrote skill '%s' to %s", skillName, skillFile);
+        return skillFile;
     }
 
     /**

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -39,6 +39,7 @@ class SkillReaderTest {
         assertEquals("A Jakarta REST implementation", info.description());
         assertTrue(info.content().contains("### REST Endpoints"));
         assertFalse(info.content().contains("---"));
+        assertEquals(SkillReader.SkillMode.ENHANCE, info.mode());
     }
 
     @Test
@@ -331,5 +332,298 @@ class SkillReaderTest {
         String url = SkillReader.parseMirrorUrl(settingsFile);
 
         assertNull(url);
+    }
+
+    // --- Enhance mode tests ---
+
+    @Test
+    void parseFrontmatterDefaultsToEnhanceMode() {
+        String content = """
+                ---
+                name: quarkus-rest
+                description: "REST extension"
+                ---
+
+                ### REST
+                """;
+
+        SkillReader.SkillInfo info = SkillReader.parseFrontmatter(content);
+
+        assertEquals(SkillReader.SkillMode.ENHANCE, info.mode());
+    }
+
+    @Test
+    void parseFrontmatterParsesEnhanceMode() {
+        String content = """
+                ---
+                name: quarkus-rest
+                mode: enhance
+                ---
+
+                ### Extra REST patterns
+                """;
+
+        SkillReader.SkillInfo info = SkillReader.parseFrontmatter(content);
+
+        assertEquals(SkillReader.SkillMode.ENHANCE, info.mode());
+    }
+
+    @Test
+    void parseFrontmatterParsesOverrideMode() {
+        String content = """
+                ---
+                name: quarkus-rest
+                mode: override
+                ---
+
+                ### Fully custom REST
+                """;
+
+        SkillReader.SkillInfo info = SkillReader.parseFrontmatter(content);
+
+        assertEquals(SkillReader.SkillMode.OVERRIDE, info.mode());
+    }
+
+    @Test
+    void enhanceModeAppendsContentToBaseSkill() throws Exception {
+        // Create a JAR with a base skill
+        Path jarPath = tempDir.resolve("skills.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/quarkus-rest/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: quarkus-rest
+                    description: "REST extension"
+                    ---
+
+                    ### Base REST patterns
+                    Use @Path and @GET.
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        // Create a local enhance skill
+        Path skillsDir = tempDir.resolve("local-skills/quarkus-rest");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                mode: enhance
+                ---
+
+                ### Project conventions
+                Always use configKey with @RegisterRestClient.
+                """);
+
+        // Load and overlay
+        List<SkillReader.SkillInfo> base = SkillReader.readSkillsFromJar(jarPath);
+        java.util.Map<String, SkillReader.SkillInfo> skillMap = new java.util.LinkedHashMap<>();
+        for (SkillReader.SkillInfo s : base) {
+            skillMap.put(s.name(), s);
+        }
+
+        List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local-skills"));
+        // Use reflection-free approach: call readSkills logic manually
+        for (SkillReader.SkillInfo skill : local) {
+            if (skillMap.containsKey(skill.name()) && skill.mode() == SkillReader.SkillMode.ENHANCE) {
+                SkillReader.SkillInfo baseSkill = skillMap.get(skill.name());
+                String merged = baseSkill.content() + "\n\n---\n\n" + skill.content();
+                skillMap.put(skill.name(), new SkillReader.SkillInfo(skill.name(),
+                        skill.description() != null ? skill.description() : baseSkill.description(),
+                        merged, SkillReader.SkillMode.ENHANCE));
+            } else {
+                skillMap.put(skill.name(), skill);
+            }
+        }
+
+        SkillReader.SkillInfo result = skillMap.get("quarkus-rest");
+        assertNotNull(result);
+        assertTrue(result.content().contains("### Base REST patterns"), "Should contain base content");
+        assertTrue(result.content().contains("### Project conventions"), "Should contain enhanced content");
+        assertTrue(result.content().contains("Use @Path and @GET."), "Should preserve base details");
+        assertTrue(result.content().contains("Always use configKey"), "Should include enhancement");
+        assertEquals("REST extension", result.description(), "Should keep base description when enhance has none");
+    }
+
+    @Test
+    void overrideModeReplacesBaseSkill() throws Exception {
+        Path jarPath = tempDir.resolve("skills.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/quarkus-rest/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: quarkus-rest
+                    description: "REST extension"
+                    ---
+
+                    ### Base REST patterns
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        Path skillsDir = tempDir.resolve("local-skills/quarkus-rest");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                description: "Custom REST"
+                mode: override
+                ---
+
+                ### Fully custom REST
+                """);
+
+        List<SkillReader.SkillInfo> base = SkillReader.readSkillsFromJar(jarPath);
+        java.util.Map<String, SkillReader.SkillInfo> skillMap = new java.util.LinkedHashMap<>();
+        for (SkillReader.SkillInfo s : base) {
+            skillMap.put(s.name(), s);
+        }
+
+        List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local-skills"));
+        for (SkillReader.SkillInfo skill : local) {
+            if (skill.mode() == SkillReader.SkillMode.OVERRIDE) {
+                skillMap.put(skill.name(), skill);
+            }
+        }
+
+        SkillReader.SkillInfo result = skillMap.get("quarkus-rest");
+        assertNotNull(result);
+        assertFalse(result.content().contains("Base REST patterns"), "Should not contain base content");
+        assertTrue(result.content().contains("Fully custom REST"), "Should contain override content");
+        assertEquals("Custom REST", result.description());
+    }
+
+    @Test
+    void enhanceModePreservesBaseDescriptionWhenNotOverridden() throws Exception {
+        Path skillsDir = tempDir.resolve("local-skills/quarkus-rest");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                mode: enhance
+                ---
+
+                ### Extra patterns
+                """);
+
+        List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local-skills"));
+        assertEquals(1, local.size());
+        assertNull(local.get(0).description(), "Enhance skill without description should be null");
+    }
+
+    @Test
+    void enhanceModeWithDescriptionOverridesBaseDescription() throws Exception {
+        Path jarPath = tempDir.resolve("skills.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/quarkus-rest/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: quarkus-rest
+                    description: "Base description"
+                    ---
+
+                    ### Base content
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        Path skillsDir = tempDir.resolve("local-skills/quarkus-rest");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                description: "Enhanced description"
+                mode: enhance
+                ---
+
+                ### Enhanced content
+                """);
+
+        List<SkillReader.SkillInfo> base = SkillReader.readSkillsFromJar(jarPath);
+        java.util.Map<String, SkillReader.SkillInfo> skillMap = new java.util.LinkedHashMap<>();
+        for (SkillReader.SkillInfo s : base) {
+            skillMap.put(s.name(), s);
+        }
+
+        List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local-skills"));
+        for (SkillReader.SkillInfo skill : local) {
+            if (skillMap.containsKey(skill.name()) && skill.mode() == SkillReader.SkillMode.ENHANCE) {
+                SkillReader.SkillInfo baseSkill = skillMap.get(skill.name());
+                String merged = baseSkill.content() + "\n\n---\n\n" + skill.content();
+                String desc = skill.description() != null ? skill.description() : baseSkill.description();
+                skillMap.put(skill.name(), new SkillReader.SkillInfo(skill.name(), desc, merged, SkillReader.SkillMode.ENHANCE));
+            }
+        }
+
+        assertEquals("Enhanced description", skillMap.get("quarkus-rest").description());
+    }
+
+    // --- writeSkill tests ---
+
+    @Test
+    void writeSkillCreatesFileWithCorrectFrontmatter() throws Exception {
+        Path projectDir = tempDir.resolve("my-project");
+        Files.createDirectories(projectDir);
+
+        Path written = SkillReader.writeSkill(
+                "quarkus-rest",
+                "### My custom patterns\nUse records for DTOs.",
+                "Custom REST skill",
+                SkillReader.SkillMode.ENHANCE,
+                projectDir.toString(), null, true);
+
+        assertTrue(Files.exists(written));
+        String content = Files.readString(written);
+        assertTrue(content.contains("name: quarkus-rest"));
+        assertTrue(content.contains("description: \"Custom REST skill\""));
+        assertTrue(content.contains("mode: enhance"));
+        assertTrue(content.contains("### My custom patterns"));
+        assertEquals(projectDir.resolve(".quarkus/skills/quarkus-rest/SKILL.md"), written);
+    }
+
+    @Test
+    void writeSkillGlobalScopeWritesToUserDir() throws Exception {
+        Path globalDir = tempDir.resolve("global-skills");
+        Path projectDir = tempDir.resolve("my-project");
+        Files.createDirectories(projectDir);
+
+        Path written = SkillReader.writeSkill(
+                "quarkus-rest",
+                "### Global patterns",
+                null,
+                SkillReader.SkillMode.ENHANCE,
+                projectDir.toString(), globalDir, false);
+
+        assertEquals(globalDir.resolve("quarkus-rest/SKILL.md"), written);
+        String content = Files.readString(written);
+        assertTrue(content.contains("name: quarkus-rest"));
+        assertTrue(content.contains("mode: enhance"));
+        assertFalse(content.contains("description:"), "Should not include description when null");
+    }
+
+    @Test
+    void writeSkillWithOverrideMode() throws Exception {
+        Path projectDir = tempDir.resolve("my-project");
+        Files.createDirectories(projectDir);
+
+        Path written = SkillReader.writeSkill(
+                "quarkus-rest",
+                "### Full replacement",
+                "Override skill",
+                SkillReader.SkillMode.OVERRIDE,
+                projectDir.toString(), null, true);
+
+        String content = Files.readString(written);
+        assertTrue(content.contains("mode: override"));
+    }
+
+    @Test
+    void skillModeFromStringDefaultsToEnhance() {
+        assertEquals(SkillReader.SkillMode.ENHANCE, SkillReader.SkillMode.fromString(null));
+        assertEquals(SkillReader.SkillMode.ENHANCE, SkillReader.SkillMode.fromString("enhance"));
+        assertEquals(SkillReader.SkillMode.ENHANCE, SkillReader.SkillMode.fromString("ENHANCE"));
+        assertEquals(SkillReader.SkillMode.ENHANCE, SkillReader.SkillMode.fromString("anything-else"));
+        assertEquals(SkillReader.SkillMode.OVERRIDE, SkillReader.SkillMode.fromString("override"));
+        assertEquals(SkillReader.SkillMode.OVERRIDE, SkillReader.SkillMode.fromString("OVERRIDE"));
     }
 }

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -423,18 +423,7 @@ class SkillReaderTest {
         }
 
         List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local-skills"));
-        // Use reflection-free approach: call readSkills logic manually
-        for (SkillReader.SkillInfo skill : local) {
-            if (skillMap.containsKey(skill.name()) && skill.mode() == SkillReader.SkillMode.ENHANCE) {
-                SkillReader.SkillInfo baseSkill = skillMap.get(skill.name());
-                String merged = baseSkill.content() + "\n\n---\n\n" + skill.content();
-                skillMap.put(skill.name(), new SkillReader.SkillInfo(skill.name(),
-                        skill.description() != null ? skill.description() : baseSkill.description(),
-                        merged, SkillReader.SkillMode.ENHANCE));
-            } else {
-                skillMap.put(skill.name(), skill);
-            }
-        }
+        SkillReader.overlaySkills(skillMap, local, "local-skills");
 
         SkillReader.SkillInfo result = skillMap.get("quarkus-rest");
         assertNotNull(result);
@@ -480,11 +469,7 @@ class SkillReaderTest {
         }
 
         List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local-skills"));
-        for (SkillReader.SkillInfo skill : local) {
-            if (skill.mode() == SkillReader.SkillMode.OVERRIDE) {
-                skillMap.put(skill.name(), skill);
-            }
-        }
+        SkillReader.overlaySkills(skillMap, local, "local-skills");
 
         SkillReader.SkillInfo result = skillMap.get("quarkus-rest");
         assertNotNull(result);
@@ -546,14 +531,7 @@ class SkillReaderTest {
         }
 
         List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local-skills"));
-        for (SkillReader.SkillInfo skill : local) {
-            if (skillMap.containsKey(skill.name()) && skill.mode() == SkillReader.SkillMode.ENHANCE) {
-                SkillReader.SkillInfo baseSkill = skillMap.get(skill.name());
-                String merged = baseSkill.content() + "\n\n---\n\n" + skill.content();
-                String desc = skill.description() != null ? skill.description() : baseSkill.description();
-                skillMap.put(skill.name(), new SkillReader.SkillInfo(skill.name(), desc, merged, SkillReader.SkillMode.ENHANCE));
-            }
-        }
+        SkillReader.overlaySkills(skillMap, local, "local-skills");
 
         assertEquals("Enhanced description", skillMap.get("quarkus-rest").description());
     }
@@ -615,6 +593,39 @@ class SkillReaderTest {
 
         String content = Files.readString(written);
         assertTrue(content.contains("mode: override"));
+    }
+
+    @Test
+    void writeSkillRejectsPathTraversal() {
+        Path projectDir = tempDir.resolve("my-project");
+        assertThrows(IllegalArgumentException.class, () -> SkillReader.writeSkill(
+                "../etc", "content", null, SkillReader.SkillMode.ENHANCE,
+                projectDir.toString(), null, true));
+        assertThrows(IllegalArgumentException.class, () -> SkillReader.writeSkill(
+                "foo/bar", "content", null, SkillReader.SkillMode.ENHANCE,
+                projectDir.toString(), null, true));
+        assertThrows(IllegalArgumentException.class, () -> SkillReader.writeSkill(
+                "foo\\bar", "content", null, SkillReader.SkillMode.ENHANCE,
+                projectDir.toString(), null, true));
+        assertThrows(IllegalArgumentException.class, () -> SkillReader.writeSkill(
+                null, "content", null, SkillReader.SkillMode.ENHANCE,
+                projectDir.toString(), null, true));
+    }
+
+    @Test
+    void writeSkillEscapesQuotesInDescription() throws Exception {
+        Path projectDir = tempDir.resolve("my-project");
+        Files.createDirectories(projectDir);
+
+        Path written = SkillReader.writeSkill(
+                "quarkus-rest",
+                "### Patterns",
+                "A \"quoted\" description",
+                SkillReader.SkillMode.ENHANCE,
+                projectDir.toString(), null, true);
+
+        String content = Files.readString(written);
+        assertTrue(content.contains("description: \"A \\\"quoted\\\" description\""));
     }
 
     @Test


### PR DESCRIPTION
Skills now support two modes controlled by a `mode` field in the SKILL.md frontmatter:

- **`mode: enhance`** (default) — appends content to the base skill, preserving built-in guidance while layering on project conventions, team standards, or guardrails.
- **`mode: override`** — fully replaces the base skill for cases where complete control is needed.

A new `quarkus/updateSkill` MCP tool lets agents create or update skill customizations interactively. When invoked, it asks the user:
1. **Enhance or override?** — append to the base or fully replace it
2. **Project or global scope?** — save under `.quarkus/skills/` (this project) or `~/.quarkus/skills/` (all projects)

Closes #29