### PR TITLE
feat: support creating projects in the current directory

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -452,10 +452,11 @@ public class CreateTools {
         File[] files = subDir.listFiles();
         if (files != null) {
             for (File file : files) {
-                Files.move(file.toPath(), targetDir.toPath().resolve(file.getName()));
+                Files.move(file.toPath(), targetDir.toPath().resolve(file.getName()),
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
             }
         }
-        Files.deleteIfExists(subDir.toPath());
+        Files.delete(subDir.toPath());
     }
 
     private void generateProjectInstructions(String projectDir, String extensions) {

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -61,14 +61,21 @@ public class CreateTools {
             + "5) Keep README.md updated with app description, features, endpoints, and Quarkus guide links after every change.")
     ToolResponse create(
             @ToolArg(description = "Absolute path to the directory where the project will be created. "
-                    + "A subdirectory named after the artifactId will be created inside this directory.") String outputDir,
+                    + "By default, a subdirectory named after the artifactId will be created inside this directory. "
+                    + "If the directory name matches the artifactId and the directory is empty, "
+                    + "the project is created directly in this directory instead.") String outputDir,
             @ToolArg(description = "The Maven groupId for the project (e.g. 'com.example')", required = false) String groupId,
             @ToolArg(description = "The Maven artifactId for the project (e.g. 'my-app').", required = false) String artifactId,
             @ToolArg(description = "Comma-separated list of Quarkus extensions to include "
                     + "(e.g. 'rest-jackson,hibernate-orm-panache,jdbc-postgresql')", required = false) String extensions,
             @ToolArg(description = "Build tool to use: 'maven' or 'gradle' (default: maven)", required = false) String buildTool,
             @ToolArg(description = "Quarkus platform version to use (e.g. '3.21.2', '999-SNAPSHOT'). "
-                    + "If omitted, uses the latest release.", required = false) String quarkusVersion) {
+                    + "If omitted, uses the latest release.", required = false) String quarkusVersion,
+            @ToolArg(description = "If true, create the project directly in outputDir instead of a subdirectory. "
+                    + "Set to true when the user asks to create the project 'here', 'in the current directory', "
+                    + "or 'in this directory'. If omitted, auto-detects: when the outputDir name matches "
+                    + "the artifactId and the directory is empty, the project is created in-place.",
+                    required = false) Boolean createInCurrentDir) {
         try {
             String resolvedGroupId = (groupId != null && !groupId.isBlank()) ? groupId : "org.acme";
             String resolvedArtifactId = (artifactId != null && !artifactId.isBlank()) ? artifactId : "quarkus-app";
@@ -96,6 +103,16 @@ public class CreateTools {
                 return ToolResponse.error("Output directory does not exist: " + outputDir);
             }
 
+            boolean createInPlace = shouldCreateInPlace(createInCurrentDir, outDir, resolvedArtifactId);
+            if (createInPlace && !isDirectoryEmptyEnough(outDir)) {
+                if (createInCurrentDir != null && createInCurrentDir) {
+                    return ToolResponse.error(
+                            "Cannot create project in current directory: it contains non-hidden files. "
+                                    + "Use an empty directory or remove existing files first.");
+                }
+                createInPlace = false;
+            }
+
             List<String> command = buildCommand(outDir, resolvedGroupId, resolvedArtifactId, extensions, buildTool,
                     resolvedVersion);
             LOG.infof("Creating Quarkus app: %s", String.join(" ", command));
@@ -118,7 +135,15 @@ public class CreateTools {
                 return ToolResponse.error("Project creation failed (exit " + exitCode + "):\n" + output);
             }
 
-            String projectDir = new File(outDir, resolvedArtifactId).getAbsolutePath();
+            String projectDir;
+            if (createInPlace) {
+                File subDir = new File(outDir, resolvedArtifactId);
+                moveContentsUp(subDir, outDir);
+                projectDir = outDir.getAbsolutePath();
+                LOG.infof("Created project in-place at: %s", projectDir);
+            } else {
+                projectDir = new File(outDir, resolvedArtifactId).getAbsolutePath();
+            }
 
             // Ensure rest-assured is available for testing (--no-code skips it)
             addRestAssuredIfMissing(projectDir);
@@ -401,6 +426,36 @@ public class CreateTools {
         } catch (IOException e) {
             LOG.debugf("Failed to add rest-assured dependency: %s", e.getMessage());
         }
+    }
+
+    private boolean shouldCreateInPlace(Boolean createInCurrentDir, File outDir, String artifactId) {
+        if (createInCurrentDir != null) {
+            return createInCurrentDir;
+        }
+        return outDir.getName().equals(artifactId);
+    }
+
+    private boolean isDirectoryEmptyEnough(File dir) {
+        File[] files = dir.listFiles();
+        if (files == null) {
+            return true;
+        }
+        for (File f : files) {
+            if (!f.getName().startsWith(".")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void moveContentsUp(File subDir, File targetDir) throws IOException {
+        File[] files = subDir.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                Files.move(file.toPath(), targetDir.toPath().resolve(file.getName()));
+            }
+        }
+        Files.deleteIfExists(subDir.toPath());
     }
 
     private void generateProjectInstructions(String projectDir, String extensions) {

--- a/src/test/java/io/quarkus/agent/mcp/CreateToolsValidationTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/CreateToolsValidationTest.java
@@ -139,6 +139,21 @@ class CreateToolsValidationTest {
         assertFalse(Files.exists(subDir), "subdirectory should be removed");
     }
 
+    @Test
+    void moveContentsUp_replacesExistingDotfiles(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve(".gitignore"), "old-content");
+
+        Path subDir = Files.createDirectory(tempDir.resolve("my-app"));
+        Files.writeString(subDir.resolve(".gitignore"), "project-content");
+        Files.writeString(subDir.resolve("pom.xml"), "<project/>");
+
+        moveContentsUp(subDir.toFile(), tempDir.toFile());
+
+        assertEquals("project-content", Files.readString(tempDir.resolve(".gitignore")));
+        assertTrue(Files.exists(tempDir.resolve("pom.xml")));
+        assertFalse(Files.exists(subDir), "subdirectory should be removed");
+    }
+
     private static boolean shouldCreateInPlace(Boolean createInCurrentDir, File outDir, String artifactId) {
         if (createInCurrentDir != null) {
             return createInCurrentDir;
@@ -163,10 +178,11 @@ class CreateToolsValidationTest {
         File[] files = subDir.listFiles();
         if (files != null) {
             for (File file : files) {
-                Files.move(file.toPath(), targetDir.toPath().resolve(file.getName()));
+                Files.move(file.toPath(), targetDir.toPath().resolve(file.getName()),
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING);
             }
         }
-        Files.deleteIfExists(subDir.toPath());
+        Files.delete(subDir.toPath());
     }
 
     @Test

--- a/src/test/java/io/quarkus/agent/mcp/CreateToolsValidationTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/CreateToolsValidationTest.java
@@ -2,9 +2,14 @@ package io.quarkus.agent.mcp;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -68,6 +73,100 @@ class CreateToolsValidationTest {
     })
     void invalidExtensions(String ext) {
         assertFalse(VALID_EXTENSIONS.matcher(ext).matches(), ext + " should be invalid");
+    }
+
+    @Test
+    void inPlaceDetection_explicitTrue() {
+        File dir = new File("/some/path/my-app");
+        assertTrue(shouldCreateInPlace(true, dir, "other-name"));
+    }
+
+    @Test
+    void inPlaceDetection_explicitFalse() {
+        File dir = new File("/some/path/my-app");
+        assertFalse(shouldCreateInPlace(false, dir, "my-app"));
+    }
+
+    @Test
+    void inPlaceDetection_autoMatchingName() {
+        File dir = new File("/some/path/my-app");
+        assertTrue(shouldCreateInPlace(null, dir, "my-app"));
+    }
+
+    @Test
+    void inPlaceDetection_autoNonMatchingName() {
+        File dir = new File("/some/path/projects");
+        assertFalse(shouldCreateInPlace(null, dir, "my-app"));
+    }
+
+    @Test
+    void directoryEmptyEnough_emptyDir(@TempDir Path tempDir) {
+        assertTrue(isDirectoryEmptyEnough(tempDir.toFile()));
+    }
+
+    @Test
+    void directoryEmptyEnough_onlyDotFiles(@TempDir Path tempDir) throws IOException {
+        Files.createFile(tempDir.resolve(".gitignore"));
+        Files.createDirectory(tempDir.resolve(".git"));
+        Files.createDirectory(tempDir.resolve(".claude"));
+        assertTrue(isDirectoryEmptyEnough(tempDir.toFile()));
+    }
+
+    @Test
+    void directoryEmptyEnough_hasNonHiddenFiles(@TempDir Path tempDir) throws IOException {
+        Files.createFile(tempDir.resolve("README.md"));
+        assertFalse(isDirectoryEmptyEnough(tempDir.toFile()));
+    }
+
+    @Test
+    void directoryEmptyEnough_hasNonHiddenDir(@TempDir Path tempDir) throws IOException {
+        Files.createDirectory(tempDir.resolve("src"));
+        assertFalse(isDirectoryEmptyEnough(tempDir.toFile()));
+    }
+
+    @Test
+    void moveContentsUp(@TempDir Path tempDir) throws IOException {
+        Path subDir = Files.createDirectory(tempDir.resolve("my-app"));
+        Files.writeString(subDir.resolve("pom.xml"), "<project/>");
+        Files.createDirectory(subDir.resolve("src"));
+        Files.writeString(subDir.resolve("src").resolve("Main.java"), "class Main {}");
+
+        moveContentsUp(subDir.toFile(), tempDir.toFile());
+
+        assertTrue(Files.exists(tempDir.resolve("pom.xml")));
+        assertTrue(Files.exists(tempDir.resolve("src")));
+        assertTrue(Files.exists(tempDir.resolve("src").resolve("Main.java")));
+        assertFalse(Files.exists(subDir), "subdirectory should be removed");
+    }
+
+    private static boolean shouldCreateInPlace(Boolean createInCurrentDir, File outDir, String artifactId) {
+        if (createInCurrentDir != null) {
+            return createInCurrentDir;
+        }
+        return outDir.getName().equals(artifactId);
+    }
+
+    private static boolean isDirectoryEmptyEnough(File dir) {
+        File[] files = dir.listFiles();
+        if (files == null) {
+            return true;
+        }
+        for (File f : files) {
+            if (!f.getName().startsWith(".")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void moveContentsUp(File subDir, File targetDir) throws IOException {
+        File[] files = subDir.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                Files.move(file.toPath(), targetDir.toPath().resolve(file.getName()));
+            }
+        }
+        Files.deleteIfExists(subDir.toPath());
     }
 
     @Test


### PR DESCRIPTION
When a user creates a new workspace directory (e.g. `my-app`), opens their IDE/agent there, and asks to create a Quarkus project with the same name, the project ends up at `my-app/my-app` — forcing them to stop the agent and restart from the subdirectory.

This adds in-place project creation via two mechanisms:

- **Auto-detection**: when the `outputDir` basename matches the `artifactId` and the directory only contains dotfiles (`.git`, `.claude`, etc.), the project is created directly in `outputDir` instead of a subdirectory. If the directory has non-hidden files, it silently falls back to subdirectory behavior.
- **Explicit parameter**: a new optional `createInCurrentDir` boolean lets the LLM set it to `true` when the user says things like "create it here" or "in this directory". If set to `true` but the directory isn't empty, an error is returned.

The implementation lets the CLI tool create the subdirectory as usual, then moves the contents up and removes the empty subdirectory — so it works identically regardless of which backend (Quarkus CLI, Maven, JBang) is used.

Closes #5