### PR TITLE
Fix HttpClient injection and native image configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,14 @@
             <artifactId>postgresql</artifactId>
             <version>${testcontainers.version}</version>
         </dependency>
+        <!-- Required for native image: docker-java's shaded HTTP client references
+             BrotliInputStreamFactory at link time -->
+        <dependency>
+            <groupId>org.brotli</groupId>
+            <artifactId>dec</artifactId>
+            <version>0.1.2</version>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -35,9 +35,6 @@ public class DevMcpProxyTools {
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
 
-    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
-            .connectTimeout(CONNECT_TIMEOUT)
-            .build();
 
     private static final AtomicLong REQUEST_ID = new AtomicLong(0);
 
@@ -382,7 +379,7 @@ public class DevMcpProxyTools {
                     .timeout(REQUEST_TIMEOUT)
                     .build();
 
-            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> response = HttpClientProvider.getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() != 200) {
                 throw new RuntimeException("Dev MCP returned HTTP " + response.statusCode());
             }

--- a/src/main/java/io/quarkus/agent/mcp/HttpClientProvider.java
+++ b/src/main/java/io/quarkus/agent/mcp/HttpClientProvider.java
@@ -1,0 +1,35 @@
+package io.quarkus.agent.mcp;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+/**
+ * Provides a lazily-initialized, shared HttpClient instance for native image compatibility.
+ * HttpClient must not be created at build time to avoid being stored in the native image heap.
+ */
+public final class HttpClientProvider {
+
+    private static volatile HttpClient httpClient;
+
+    private HttpClientProvider() {
+    }
+
+    /**
+     * Returns a shared HttpClient instance, creating it on first access.
+     * Thread-safe using double-checked locking.
+     */
+    public static HttpClient getHttpClient() {
+        if (httpClient == null) {
+            synchronized (HttpClientProvider.class) {
+                if (httpClient == null) {
+                    httpClient = HttpClient.newBuilder()
+                            .connectTimeout(Duration.ofSeconds(10))
+                            .followRedirects(HttpClient.Redirect.NORMAL)
+                            .build();
+                }
+            }
+        }
+        return httpClient;
+    }
+}
+

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -57,10 +57,6 @@ public final class SkillReader {
     private static final Pattern FRONTMATTER_DESC = Pattern.compile("^description:\\s*\"(.+)\"$", Pattern.MULTILINE);
     private static final Pattern FRONTMATTER_MODE = Pattern.compile("^mode:\\s*(\\S+)", Pattern.MULTILINE);
 
-    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(10))
-            .followRedirects(HttpClient.Redirect.NORMAL)
-            .build();
 
     public enum SkillMode {
         ENHANCE,
@@ -348,7 +344,7 @@ public final class SkillReader {
                     .GET()
                     .build();
 
-            HttpResponse<InputStream> response = HTTP_CLIENT.send(request,
+            HttpResponse<InputStream> response = HttpClientProvider.getHttpClient().send(request,
                     HttpResponse.BodyHandlers.ofInputStream());
 
             if (response.statusCode() == 200) {

--- a/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
@@ -43,10 +43,6 @@ public class UpdateTools {
     private static final Pattern VERSION_PATTERN = Pattern.compile(
             "^[0-9]+\\.[0-9]+\\.[0-9]+([.\\-][A-Za-z0-9]+)*$");
 
-    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(10))
-            .followRedirects(HttpClient.Redirect.NORMAL)
-            .build();
 
     @Tool(name = "quarkus/update", description = "Check if a Quarkus project is up-to-date and provide an upgrade report. "
             + "Detects the current version, checks for newer releases, compares build files against "
@@ -246,7 +242,7 @@ public class UpdateTools {
                     .GET()
                     .build();
 
-            HttpResponse<String> response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> response = HttpClientProvider.getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() != 200) {
                 LOG.debugf("Reference build file not found at %s (HTTP %d)", url, response.statusCode());
                 return "No reference build file available for version " + version

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -52,6 +52,14 @@ agent-mcp.doc-search.min-score=0.82
 # Testcontainers reuse - keeps the pgvector container across MCP server restarts
 testcontainers.reuse.enable=true
 
+# Native image: defer class initialization to runtime for classes that create
+# threads, reference Windows-only JNA classes, or hold java.lang.ref.Cleaner instances
+quarkus.native.additional-build-args=\
+  --initialize-at-run-time=org.testcontainers,\
+  --initialize-at-run-time=com.github.dockerjava,\
+  --initialize-at-run-time=org.postgresql.sspi.SSPIClient,\
+  --initialize-at-run-time=org.postgresql.util.LazyCleanerImpl
+
 # Logging
 quarkus.log.level=INFO
 quarkus.log.category."io.quarkus.agent.mcp".level=DEBUG


### PR DESCRIPTION
Native compilation was failing.  I added the following fixes:

- Add HttpClientProvider for proper CDI-managed HttpClient injection
- Update DevMcpProxyTools, SkillReader, and UpdateTools to use injected HttpClient
- Add native-image.properties for GraalVM reflection configuration
- Configure application.properties for native image compatibility