### PR TITLE
fix: use HTTPS URLs in SCM configuration for CI release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/quarkusio/quarkus-agent-mcp.git</connection>
-        <developerConnection>scm:git:ssh://github.com:quarkusio/quarkus-agent-mcp.git</developerConnection>
+        <connection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</connection>
+        <developerConnection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</developerConnection>
         <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
     </scm>
 


### PR DESCRIPTION
The `developerConnection` used an invalid `ssh://github.com:org` SCP-style URL inside a URI scheme, causing maven-release-plugin to fail resolving the hostname during `git push`. CI authenticates via HTTPS token, so both SCM URLs should use HTTPS.