### PR TITLE
fix: use bare version for release tag format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/quarkusio/quarkus-agent-mcp.git</connection>
-        <developerConnection>scm:git:ssh://github.com:quarkusio/quarkus-agent-mcp.git</developerConnection>
+        <connection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</connection>
+        <developerConnection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</developerConnection>
         <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,12 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
                 <executions>


### PR DESCRIPTION
The maven-release-plugin defaults to `artifactId-version` tag names (e.g. `quarkus-agent-mcp-0.0.4`), which JReleaser rejects as not following the semver spec. This configures `tagNameFormat` to use the bare version number, matching the convention of previous releases (`0.0.1`, `0.0.2`).