### PR TITLE
feat: add Claude plugin manifest and auto-version sync

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "quarkus-agent",
+  "description": "MCP server for AI coding agents to create, manage, and interact with Quarkus applications. Provides tools for project scaffolding, dev mode lifecycle, extension skills, Dev MCP proxy, and documentation search.",
+  "version": "0.0.4",
+  "author": {
+    "name": "Quarkus",
+    "url": "https://quarkus.io"
+  },
+  "homepage": "https://github.com/quarkusio/quarkus-agent-mcp",
+  "repository": "https://github.com/quarkusio/quarkus-agent-mcp",
+  "license": "Apache-2.0",
+  "keywords": ["quarkus", "java", "mcp", "dev-mode", "scaffolding"]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agent",
   "description": "MCP server for AI coding agents to create, manage, and interact with Quarkus applications. Provides tools for project scaffolding, dev mode lifecycle, extension skills, Dev MCP proxy, and documentation search.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": {
     "name": "Quarkus",
     "url": "https://quarkus.io"

--- a/.github/workflows/hooks/pre-prepare-release.sh
+++ b/.github/workflows/hooks/pre-prepare-release.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_JSON=".claude-plugin/plugin.json"
+
+jq --arg v "${CURRENT_VERSION}" '.version = $v' "${PLUGIN_JSON}" > "${PLUGIN_JSON}.tmp"
+mv "${PLUGIN_JSON}.tmp" "${PLUGIN_JSON}"
+
+git add "${PLUGIN_JSON}"
+git commit -m "Update plugin.json version to ${CURRENT_VERSION}"

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/quarkusio/quarkus-agent-mcp.git</connection>
-        <developerConnection>scm:git:ssh://github.com:quarkusio/quarkus-agent-mcp.git</developerConnection>
+        <connection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</connection>
+        <developerConnection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</developerConnection>
         <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,12 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
                 <executions>


### PR DESCRIPTION
Add `.claude-plugin/plugin.json` required for Claude plugin marketplace submission. Also add a pre-prepare-release hook (`.github/workflows/hooks/pre-prepare-release.sh`) that automatically updates the plugin.json version to match the release version before the maven release commit, so they stay in sync on every release.