### PR TITLE
fix: correct README version references and auto-update on release

### DIFF
--- a/.github/workflows/hooks/pre-prepare-release.sh
+++ b/.github/workflows/hooks/pre-prepare-release.sh
@@ -2,9 +2,12 @@
 set -euo pipefail
 
 PLUGIN_JSON=".claude-plugin/plugin.json"
+README="README.md"
 
 jq --arg v "${CURRENT_VERSION}" '.version = $v' "${PLUGIN_JSON}" > "${PLUGIN_JSON}.tmp"
 mv "${PLUGIN_JSON}.tmp" "${PLUGIN_JSON}"
 
-git add "${PLUGIN_JSON}"
-git commit -m "Update plugin.json version to ${CURRENT_VERSION}"
+sed -i "s/quarkus-agent-mcp-[0-9][0-9.]*-runner/quarkus-agent-mcp-${CURRENT_VERSION}-runner/g" "${README}"
+
+git add "${PLUGIN_JSON}" "${README}"
+git commit -m "Update versions to ${CURRENT_VERSION}"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 Download the uber-jar from the [latest GitHub Release](https://github.com/quarkusio/quarkus-agent-mcp/releases/latest), then:
 
 ```bash
-claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp-1.0.0-runner.jar
+claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp-0.0.5-runner.jar
 ```
 
 ### Build from source
@@ -114,10 +114,10 @@ cd quarkus-agent-mcp
 ./mvnw package -DskipTests -Dquarkus.package.jar.type=uber-jar
 ```
 
-This produces the uber-jar at `target/quarkus-agent-mcp-1.0.0-SNAPSHOT-runner.jar`.
+This produces the uber-jar at `target/quarkus-agent-mcp-1.0.0-SNAPSHOT-runner.jar` (version may vary).
 
 ```bash
-claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp/target/quarkus-agent-mcp-1.0.0-SNAPSHOT-runner.jar
+claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp/target/quarkus-agent-mcp-*-runner.jar
 ```
 
 #### Verify


### PR DESCRIPTION
Fix the hardcoded 1.0.0 version in the README direct download section to match the current release (0.0.5). The build-from-source section now uses a glob pattern since that version changes with development.

The pre-prepare-release hook is extended to automatically update version references in both `plugin.json` and `README.md` on each release, so they never go stale again.