### PR TITLE
feat: add custom startup banner

### DIFF
--- a/.github/workflows/hooks/pre-prepare-release.sh
+++ b/.github/workflows/hooks/pre-prepare-release.sh
@@ -2,9 +2,12 @@
 set -euo pipefail
 
 PLUGIN_JSON=".claude-plugin/plugin.json"
+README="README.md"
 
 jq --arg v "${CURRENT_VERSION}" '.version = $v' "${PLUGIN_JSON}" > "${PLUGIN_JSON}.tmp"
 mv "${PLUGIN_JSON}.tmp" "${PLUGIN_JSON}"
 
-git add "${PLUGIN_JSON}"
-git commit -m "Update plugin.json version to ${CURRENT_VERSION}"
+sed -i "s/quarkus-agent-mcp-[0-9][0-9.]*-runner/quarkus-agent-mcp-${CURRENT_VERSION}-runner/g" "${README}"
+
+git add "${PLUGIN_JSON}" "${README}"
+git commit -m "Update versions to ${CURRENT_VERSION}"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 Download the uber-jar from the [latest GitHub Release](https://github.com/quarkusio/quarkus-agent-mcp/releases/latest), then:
 
 ```bash
-claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp-1.0.0-runner.jar
+claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp-0.0.5-runner.jar
 ```
 
 ### Build from source
@@ -114,10 +114,10 @@ cd quarkus-agent-mcp
 ./mvnw package -DskipTests -Dquarkus.package.jar.type=uber-jar
 ```
 
-This produces the uber-jar at `target/quarkus-agent-mcp-1.0.0-SNAPSHOT-runner.jar`.
+This produces the uber-jar at `target/quarkus-agent-mcp-1.0.0-SNAPSHOT-runner.jar` (version may vary).
 
 ```bash
-claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp/target/quarkus-agent-mcp-1.0.0-SNAPSHOT-runner.jar
+claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp/target/quarkus-agent-mcp-*-runner.jar
 ```
 
 #### Verify

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 # Quarkus Agent MCP Server Configuration
+quarkus.banner.path=banner.txt
 
 # MCP server identity and instructions
 quarkus.mcp.server.server-info.name=quarkus-agent

--- a/src/main/resources/banner.txt
+++ b/src/main/resources/banner.txt
@@ -1,0 +1,5 @@
+┌───────┐
+│Quarkus│
+│ Agent │ MCP server for AI coding agents
+│  MCP  │
+└───────┘


### PR DESCRIPTION
Add a custom banner displayed when the MCP server starts, replacing the default Quarkus ASCII art.