### PR TITLE
fix: harden error handling, thread safety, and security for v1.0.0

### DIFF
--- a/.github/workflows/hooks/pre-prepare-release.sh
+++ b/.github/workflows/hooks/pre-prepare-release.sh
@@ -7,7 +7,7 @@ README="README.md"
 jq --arg v "${CURRENT_VERSION}" '.version = $v' "${PLUGIN_JSON}" > "${PLUGIN_JSON}.tmp"
 mv "${PLUGIN_JSON}.tmp" "${PLUGIN_JSON}"
 
-sed -i "s/quarkus-agent-mcp-[0-9][0-9.]*-runner/quarkus-agent-mcp-${CURRENT_VERSION}-runner/g" "${README}"
+sed -i "s/quarkus-agent-mcp-[0-9][0-9.]*-runner/quarkus-agent-mcp-${CURRENT_VERSION}-runner/g; s/quarkus-agent-mcp-<version>-runner/quarkus-agent-mcp-${CURRENT_VERSION}-runner/g" "${README}"
 
 git add "${PLUGIN_JSON}" "${README}"
 git commit -m "Update versions to ${CURRENT_VERSION}"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ cd quarkus-agent-mcp
 This produces the uber-jar at `target/quarkus-agent-mcp-1.0.0-SNAPSHOT-runner.jar` (version may vary).
 
 ```bash
-claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp/target/quarkus-agent-mcp-*-runner.jar
+claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp/target/quarkus-agent-mcp-<version>-runner.jar
 ```
 
 #### Verify

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 Download the uber-jar from the [latest GitHub Release](https://github.com/quarkusio/quarkus-agent-mcp/releases/latest), then:
 
 ```bash
-claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp-0.0.5-runner.jar
+claude mcp add quarkus-agent -- java -jar /path/to/quarkus-agent-mcp-runner.jar
 ```
 
 ### Build from source

--- a/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
@@ -1,9 +1,8 @@
 package io.quarkus.agent.mcp;
 
-import java.util.concurrent.ConcurrentHashMap;
-
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
-
+import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.testcontainers.containers.GenericContainer;
@@ -106,6 +105,19 @@ public class ContainerManager {
                     "pgvector container is not running for version " + tag + ". Call ensureRunning() first.");
         }
         return container;
+    }
+
+    @PreDestroy
+    void shutdown() {
+        for (var entry : containers.entrySet()) {
+            try {
+                LOG.infof("Releasing container reference for version %s (containerId: %s)",
+                        entry.getKey(), entry.getValue().getContainerId());
+            } catch (Exception e) {
+                LOG.debugf("Error during container cleanup for %s: %s", entry.getKey(), e.getMessage());
+            }
+        }
+        containers.clear();
     }
 
     private String resolveImageTag(String quarkusVersion) {

--- a/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
@@ -107,8 +107,12 @@ public class ContainerManager {
         return container;
     }
 
+    /**
+     * Releases container references without stopping them — containers use {@code withReuse(true)}
+     * so they persist across MCP server restarts.
+     */
     @PreDestroy
-    void shutdown() {
+    void releaseContainerReferences() {
         for (var entry : containers.entrySet()) {
             try {
                 LOG.infof("Releasing container reference for version %s (containerId: %s)",

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -1,25 +1,21 @@
 package io.quarkus.agent.mcp;
 
-import java.io.BufferedReader;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-
-import jakarta.inject.Inject;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
-
-import io.quarkiverse.mcp.server.Tool;
-import io.quarkiverse.mcp.server.ToolArg;
-import io.quarkiverse.mcp.server.ToolResponse;
 
 /**
  * MCP tool for creating new Quarkus applications.
@@ -125,8 +121,12 @@ public class CreateTools {
             String output;
             int exitCode;
             try {
-                output = captureOutput(process);
-                exitCode = process.waitFor();
+                output = ProcessUtils.captureOutput(process);
+                if (!process.waitFor(10, TimeUnit.MINUTES)) {
+                    process.destroyForcibly();
+                    return ToolResponse.error("Project creation timed out after 10 minutes.");
+                }
+                exitCode = process.exitValue();
             } finally {
                 process.destroyForcibly();
             }
@@ -230,32 +230,18 @@ public class CreateTools {
 
     private List<String> buildQuarkusCliCommand(String quarkusCmd, String groupId, String artifactId,
             String extensions, String buildTool, String quarkusVersion) {
-        List<String> cmd = new ArrayList<>();
-        cmd.add(quarkusCmd);
-        cmd.add("create");
-        cmd.add("app");
-        cmd.add(groupId + ":" + artifactId);
-        cmd.add("--no-code");
-        cmd.add("--batch-mode");
-
-        if (quarkusVersion != null && !quarkusVersion.isBlank()) {
-            cmd.add("--platform-bom=io.quarkus:quarkus-bom:" + quarkusVersion);
-        }
-        if (extensions != null && !extensions.isBlank()) {
-            cmd.add("--extension=" + extensions);
-        }
-        if ("gradle".equalsIgnoreCase(buildTool)) {
-            cmd.add("--gradle");
-        }
-
-        return cmd;
+        return buildCliStyleCommand(List.of(quarkusCmd), groupId, artifactId, extensions, buildTool, quarkusVersion);
     }
 
     private List<String> buildJBangCommand(String groupId, String artifactId,
             String extensions, String buildTool, String quarkusVersion) {
-        List<String> cmd = new ArrayList<>();
-        cmd.add("jbang");
-        cmd.add("quarkus@quarkusio");
+        return buildCliStyleCommand(List.of("jbang", "quarkus@quarkusio"), groupId, artifactId, extensions, buildTool,
+                quarkusVersion);
+    }
+
+    private List<String> buildCliStyleCommand(List<String> prefix, String groupId, String artifactId,
+            String extensions, String buildTool, String quarkusVersion) {
+        List<String> cmd = new ArrayList<>(prefix);
         cmd.add("create");
         cmd.add("app");
         cmd.add(groupId + ":" + artifactId);
@@ -306,33 +292,7 @@ public class CreateTools {
     }
 
     private boolean isCommandAvailable(String command) {
-        Process p = null;
-        try {
-            p = new ProcessBuilder("which", command)
-                    .redirectErrorStream(true)
-                    .start();
-            p.getInputStream().transferTo(java.io.OutputStream.nullOutputStream());
-            return p.waitFor() == 0;
-        } catch (Exception e) {
-            return false;
-        } finally {
-            if (p != null) {
-                p.destroyForcibly();
-            }
-        }
-    }
-
-    private String captureOutput(Process process) throws IOException {
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-            StringBuilder sb = new StringBuilder();
-            String line;
-            while ((line = reader.readLine()) != null) {
-                sb.append(line).append("\n");
-                LOG.debug(line);
-            }
-            return sb.toString().trim();
-        }
+        return ProcessUtils.isCommandAvailable(command);
     }
 
     private void createSourceDirectories(String projectDir) {
@@ -344,7 +304,7 @@ public class CreateTools {
             Files.createDirectories(base.resolve("src/test/resources"));
             LOG.debugf("Ensured source directories exist in %s", projectDir);
         } catch (IOException e) {
-            LOG.debugf("Failed to create source directories: %s", e.getMessage());
+            LOG.warnf("Failed to create source directories in %s: %s", projectDir, e.getMessage());
         }
     }
 
@@ -383,7 +343,7 @@ public class CreateTools {
                 LOG.debugf("Added rest-assured test dependency to %s", pomPath);
             }
         } catch (IOException e) {
-            LOG.debugf("Failed to add rest-assured dependency: %s", e.getMessage());
+            LOG.warnf("Failed to add rest-assured dependency to %s: %s", pomPath, e.getMessage());
         }
     }
 
@@ -424,7 +384,7 @@ public class CreateTools {
             Files.writeString(buildFile, content, StandardCharsets.UTF_8);
             LOG.debugf("Added rest-assured test dependency to %s", buildFile);
         } catch (IOException e) {
-            LOG.debugf("Failed to add rest-assured dependency: %s", e.getMessage());
+            LOG.warnf("Failed to add rest-assured dependency to %s: %s", buildFile, e.getMessage());
         }
     }
 
@@ -555,7 +515,7 @@ public class CreateTools {
             Files.writeString(Path.of(projectDir, "CLAUDE.md"), claudeMdContent, StandardCharsets.UTF_8);
             LOG.debugf("Generated CLAUDE.md in %s", projectDir);
         } catch (IOException e) {
-            LOG.debugf("Failed to generate AGENTS.md: %s", e.getMessage());
+            LOG.warnf("Failed to generate AGENTS.md in %s: %s", projectDir, e.getMessage());
         }
     }
 }

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -120,13 +120,25 @@ public class CreateTools {
             Process process = pb.start();
             String output;
             int exitCode;
+            StringBuilder outputCapture = new StringBuilder();
+            Thread captureThread = new Thread(() -> {
+                try {
+                    outputCapture.append(ProcessUtils.captureOutput(process));
+                } catch (IOException e) {
+                    LOG.debugf("Error capturing process output: %s", e.getMessage());
+                }
+            }, "create-output-capture");
+            captureThread.setDaemon(true);
+            captureThread.start();
             try {
-                output = ProcessUtils.captureOutput(process);
                 if (!process.waitFor(10, TimeUnit.MINUTES)) {
                     process.destroyForcibly();
+                    captureThread.join(5000);
                     return ToolResponse.error("Project creation timed out after 10 minutes.");
                 }
+                captureThread.join(5000);
                 exitCode = process.exitValue();
+                output = outputCapture.toString();
             } finally {
                 process.destroyForcibly();
             }
@@ -515,7 +527,7 @@ public class CreateTools {
             Files.writeString(Path.of(projectDir, "CLAUDE.md"), claudeMdContent, StandardCharsets.UTF_8);
             LOG.debugf("Generated CLAUDE.md in %s", projectDir);
         } catch (IOException e) {
-            LOG.warnf("Failed to generate AGENTS.md in %s: %s", projectDir, e.getMessage());
+            LOG.warnf("Failed to generate project instructions in %s: %s", projectDir, e.getMessage());
         }
     }
 }

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -1,8 +1,14 @@
 package io.quarkus.agent.mcp;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
@@ -13,18 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
-
-import jakarta.inject.Inject;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.quarkiverse.mcp.server.Tool;
-import io.quarkiverse.mcp.server.ToolArg;
-import io.quarkiverse.mcp.server.ToolResponse;
+import org.jboss.logging.Logger;
 
 /**
  * MCP tools that proxy requests to a running Quarkus application's Dev MCP server.
@@ -32,11 +28,11 @@ import io.quarkiverse.mcp.server.ToolResponse;
  */
 public class DevMcpProxyTools {
 
-    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final Logger LOG = Logger.getLogger(DevMcpProxyTools.class);
+
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
 
-
-    private static final AtomicLong REQUEST_ID = new AtomicLong(0);
+    private final AtomicLong requestId = new AtomicLong(0);
 
     // --- Startup / build polling ---
     private static final int STARTUP_WAIT_SECONDS = 120;
@@ -80,6 +76,7 @@ public class DevMcpProxyTools {
         } catch (JsonProcessingException e) {
             return ToolResponse.error("Failed to serialize tools: " + e.getMessage());
         } catch (Exception e) {
+            LOG.error("Failed to search Dev MCP tools for " + projectDir, e);
             return ToolResponse.error(e.getMessage());
         }
     }
@@ -156,6 +153,7 @@ public class DevMcpProxyTools {
             }
             return ToolResponse.success(sb.toString());
         } catch (Exception e) {
+            LOG.error("Failed to read skills for " + projectDir, e);
             return ToolResponse.error("Failed to read skills: " + e.getMessage());
         }
     }
@@ -250,6 +248,7 @@ public class DevMcpProxyTools {
 
             return result;
         } catch (Exception e) {
+            LOG.error("Failed to call Dev MCP tool '" + toolName + "' for " + projectDir, e);
             return ToolResponse.error(e.getMessage());
         }
     }
@@ -367,7 +366,7 @@ public class DevMcpProxyTools {
         try {
             String jsonRpcRequest = mapper.writeValueAsString(Map.of(
                     "jsonrpc", "2.0",
-                    "id", REQUEST_ID.incrementAndGet(),
+                    "id", requestId.incrementAndGet(),
                     "method", method,
                     "params", params));
 

--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -1,19 +1,7 @@
 package io.quarkus.agent.mcp;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import jakarta.inject.Inject;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -24,6 +12,14 @@ import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 
 /**
  * MCP tool for semantic search over Quarkus documentation.
@@ -88,6 +84,9 @@ public class DocSearchTools {
     @Inject
     ObjectMapper mapper;
 
+    private static final String DEFAULT_VERSION_KEY = "__default__";
+
+    private final Object initLock = new Object();
     private final ConcurrentHashMap<String, PgVectorEmbeddingStore> embeddingStores = new ConcurrentHashMap<>();
 
     @Tool(name = "quarkus/searchDocs", description = "Search Quarkus documentation. "
@@ -158,14 +157,14 @@ public class DocSearchTools {
     }
 
     private PgVectorEmbeddingStore ensureInitialized(String quarkusVersion) {
-        String key = quarkusVersion != null ? quarkusVersion : "__default__";
+        String key = quarkusVersion != null ? quarkusVersion : DEFAULT_VERSION_KEY;
 
         PgVectorEmbeddingStore existing = embeddingStores.get(key);
         if (existing != null) {
             return existing;
         }
 
-        synchronized (this) {
+        synchronized (initLock) {
             // Double-check after acquiring lock
             existing = embeddingStores.get(key);
             if (existing != null) {

--- a/src/main/java/io/quarkus/agent/mcp/EmbeddingModelProducer.java
+++ b/src/main/java/io/quarkus/agent/mcp/EmbeddingModelProducer.java
@@ -1,12 +1,10 @@
 package io.quarkus.agent.mcp;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Produces;
-
-import org.jboss.logging.Logger;
-
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.embedding.onnx.bgesmallenv15q.BgeSmallEnV15QuantizedEmbeddingModel;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import org.jboss.logging.Logger;
 
 /**
  * Produces the BGE Small EN v1.5 embedding model as a CDI bean.

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -1,15 +1,13 @@
 package io.quarkus.agent.mcp;
 
-import java.util.Map;
-
-import jakarta.inject.Inject;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
+import java.util.Map;
+import org.jboss.logging.Logger;
 
 /**
  * MCP tools for managing Quarkus application lifecycle.
@@ -17,6 +15,8 @@ import io.quarkiverse.mcp.server.ToolResponse;
  * and monitor Quarkus applications running in dev mode.
  */
 public class LifecycleTools {
+
+    private static final Logger LOG = Logger.getLogger(LifecycleTools.class);
 
     @Inject
     QuarkusProcessManager processManager;
@@ -34,6 +34,7 @@ public class LifecycleTools {
             processManager.start(projectDir, buildTool);
             return ToolResponse.success("Quarkus application starting in dev mode at: " + projectDir);
         } catch (Exception e) {
+            LOG.error("Failed to start Quarkus application at " + projectDir, e);
             return ToolResponse.error(e.getMessage());
         }
     }
@@ -46,6 +47,7 @@ public class LifecycleTools {
             processManager.stop(projectDir);
             return ToolResponse.success("Quarkus application stopped at: " + projectDir);
         } catch (Exception e) {
+            LOG.error("Failed to stop Quarkus application at " + projectDir, e);
             return ToolResponse.error(e.getMessage());
         }
     }
@@ -58,6 +60,7 @@ public class LifecycleTools {
             processManager.restart(projectDir);
             return ToolResponse.success("Quarkus application restart triggered at: " + projectDir);
         } catch (Exception e) {
+            LOG.error("Failed to restart Quarkus application at " + projectDir, e);
             return ToolResponse.error(e.getMessage());
         }
     }
@@ -79,6 +82,7 @@ public class LifecycleTools {
             }
             return ToolResponse.success(status);
         } catch (Exception e) {
+            LOG.error("Failed to get status for " + projectDir, e);
             return ToolResponse.error(e.getMessage());
         }
     }
@@ -98,6 +102,7 @@ public class LifecycleTools {
             int count = (lines != null && lines > 0) ? Math.min(lines, 10000) : 50;
             return ToolResponse.success(instance.getRecentLogs(count));
         } catch (Exception e) {
+            LOG.error("Failed to get logs for " + projectDir, e);
             return ToolResponse.error(e.getMessage());
         }
     }

--- a/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
@@ -1,0 +1,48 @@
+package io.quarkus.agent.mcp;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import org.jboss.logging.Logger;
+
+final class ProcessUtils {
+
+    private static final Logger LOG = Logger.getLogger(ProcessUtils.class);
+
+    private ProcessUtils() {
+    }
+
+    static boolean isCommandAvailable(String command) {
+        Process p = null;
+        try {
+            p = new ProcessBuilder("which", command)
+                    .redirectErrorStream(true)
+                    .start();
+            p.getInputStream().transferTo(java.io.OutputStream.nullOutputStream());
+            return p.waitFor() == 0;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (Exception e) {
+            return false;
+        } finally {
+            if (p != null) {
+                p.destroyForcibly();
+            }
+        }
+    }
+
+    static String captureOutput(Process process) throws IOException {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line).append("\n");
+                LOG.debug(line);
+            }
+            return sb.toString().trim();
+        }
+    }
+}

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -71,8 +71,8 @@ public class QuarkusInstance {
     private void monitorExit() {
         try {
             int exitCode = process.waitFor();
-            if (status.get() != Status.STOPPED) {
-                status.set(Status.CRASHED);
+            if (status.compareAndSet(Status.STARTING, Status.CRASHED)
+                    || status.compareAndSet(Status.RUNNING, Status.CRASHED)) {
                 appendLog("[mcp] Process exited with code: " + exitCode);
             }
         } catch (InterruptedException e) {

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -10,7 +10,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import org.jboss.logging.Logger;
 
 /**
  * Represents a single managed Quarkus dev mode instance.
@@ -19,6 +21,8 @@ import java.util.stream.Collectors;
  */
 public class QuarkusInstance {
 
+    private static final Logger LOG = Logger.getLogger(QuarkusInstance.class);
+
     public enum Status {
         STARTING,
         RUNNING,
@@ -26,12 +30,12 @@ public class QuarkusInstance {
         STOPPED
     }
 
-    private static final int MAX_LOG_LINES = 500;
+    static final int MAX_LOG_LINES = 500;
 
     private final String projectDir;
     private final Process process;
     private final LinkedList<String> logBuffer = new LinkedList<>();
-    private volatile Status status = Status.STARTING;
+    private final AtomicReference<Status> status = new AtomicReference<>(Status.STARTING);
     private volatile int httpPort = -1;
 
     public QuarkusInstance(String projectDir, Process process, ExecutorService executor) {
@@ -53,20 +57,22 @@ public class QuarkusInstance {
                 if (line.contains("Listening on:")) {
                     parsePort(line);
                 }
-                if (status == Status.STARTING && isStartedLine(line)) {
-                    status = Status.RUNNING;
+                if (status.get() == Status.STARTING && isStartedLine(line)) {
+                    status.compareAndSet(Status.STARTING, Status.RUNNING);
                 }
             }
         } catch (IOException e) {
-            // Stream closed — expected on process termination
+            if (process.isAlive()) {
+                LOG.warnf("Log capture stream closed unexpectedly while process is still alive: %s", e.getMessage());
+            }
         }
     }
 
     private void monitorExit() {
         try {
             int exitCode = process.waitFor();
-            if (status != Status.STOPPED) {
-                status = Status.CRASHED;
+            if (status.get() != Status.STOPPED) {
+                status.set(Status.CRASHED);
                 appendLog("[mcp] Process exited with code: " + exitCode);
             }
         } catch (InterruptedException e) {
@@ -86,7 +92,6 @@ public class QuarkusInstance {
         if (idx >= 0) {
             try {
                 String url = line.substring(idx).trim();
-                // Remove trailing non-URL characters (e.g. log suffixes)
                 int spaceIdx = url.indexOf(' ');
                 if (spaceIdx > 0) {
                     url = url.substring(0, spaceIdx);
@@ -96,7 +101,7 @@ public class QuarkusInstance {
                     httpPort = port;
                 }
             } catch (IllegalArgumentException e) {
-                // ignore malformed URLs
+                LOG.warnf("Failed to parse URL from log line: %s", line);
             }
         }
     }
@@ -113,10 +118,14 @@ public class QuarkusInstance {
     }
 
     public Status getStatus() {
-        if (status == Status.RUNNING && !process.isAlive()) {
-            status = Status.CRASHED;
+        reconcileStatus();
+        return status.get();
+    }
+
+    private void reconcileStatus() {
+        if (status.get() == Status.RUNNING && !process.isAlive()) {
+            status.compareAndSet(Status.RUNNING, Status.CRASHED);
         }
-        return status;
     }
 
     public synchronized String getRecentLogs(int lines) {
@@ -142,16 +151,20 @@ public class QuarkusInstance {
             throw new IllegalStateException(
                     "Process is not running. Use quarkus/start to start a new instance.");
         }
-        status = Status.STARTING;
+        status.set(Status.STARTING);
         httpPort = -1;
         sendInput('s');
     }
 
     public void stop() {
-        status = Status.STOPPED;
+        status.set(Status.STOPPED);
         if (process.isAlive()) {
             try {
                 sendInput('q');
+            } catch (RuntimeException e) {
+                LOG.debugf("Could not send quit signal (stdin may be closed): %s", e.getMessage());
+            }
+            try {
                 if (!process.waitFor(5, TimeUnit.SECONDS)) {
                     process.destroyForcibly();
                 }

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.logging.Logger;
@@ -25,7 +26,7 @@ public class QuarkusProcessManager {
     @Inject
     ManagedExecutor executor;
 
-    private static final java.util.Set<String> VALID_BUILD_TOOLS = java.util.Set.of("maven", "gradle");
+    private static final Set<String> VALID_BUILD_TOOLS = Set.of("maven", "gradle");
 
     public synchronized void start(String projectDir, String buildTool) {
         if (buildTool != null && !VALID_BUILD_TOOLS.contains(buildTool.toLowerCase())) {
@@ -154,8 +155,7 @@ public class QuarkusProcessManager {
     private ProcessBuilder createMavenProcessBuilder(File projectDir) {
         String mvnCmd;
         File wrapper = isWindows() ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
-        if (wrapper.exists()) {
-            verifyTrustedWrapper(wrapper);
+        if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
             mvnCmd = isWindows() ? "mvnw.cmd" : "./mvnw";
         } else {
             mvnCmd = "mvn";
@@ -167,8 +167,7 @@ public class QuarkusProcessManager {
     private ProcessBuilder createGradleProcessBuilder(File projectDir) {
         String gradleCmd;
         File wrapper = isWindows() ? new File(projectDir, "gradlew.bat") : new File(projectDir, "gradlew");
-        if (wrapper.exists()) {
-            verifyTrustedWrapper(wrapper);
+        if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
             gradleCmd = isWindows() ? "gradlew.bat" : "./gradlew";
         } else {
             gradleCmd = "gradle";
@@ -178,10 +177,11 @@ public class QuarkusProcessManager {
     }
 
     /**
-     * Verify the wrapper script is tracked by git (considered trusted).
-     * Throws if the wrapper is untracked or cannot be verified.
+     * Returns true if the wrapper is tracked by git (trusted), false if verification
+     * failed and the caller should fall back to the system build tool.
+     * Throws if the wrapper is explicitly untracked (potential supply-chain attack).
      */
-    private void verifyTrustedWrapper(File wrapper) {
+    private boolean verifyTrustedWrapper(File wrapper) {
         try {
             Process p = new ProcessBuilder("git", "ls-files", "--error-unmatch", wrapper.getName())
                     .directory(wrapper.getParentFile())
@@ -194,11 +194,13 @@ public class QuarkusProcessManager {
                         "Wrapper script '" + wrapper.getAbsolutePath() + "' is NOT tracked by git. "
                                 + "It could be malicious. Add it to git or use the system-installed build tool.");
             }
+            return true;
         } catch (IllegalStateException e) {
             throw e;
         } catch (Exception e) {
             LOG.warnf("Could not verify wrapper script '%s' against git: %s. "
                     + "Falling back to system build tool.", wrapper.getAbsolutePath(), e.getMessage());
+            return false;
         }
     }
 

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -1,16 +1,13 @@
 package io.quarkus.agent.mcp;
 
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-
-import jakarta.annotation.PreDestroy;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.logging.Logger;
 
@@ -28,7 +25,13 @@ public class QuarkusProcessManager {
     @Inject
     ManagedExecutor executor;
 
+    private static final java.util.Set<String> VALID_BUILD_TOOLS = java.util.Set.of("maven", "gradle");
+
     public synchronized void start(String projectDir, String buildTool) {
+        if (buildTool != null && !VALID_BUILD_TOOLS.contains(buildTool.toLowerCase())) {
+            throw new IllegalArgumentException(
+                    "Invalid build tool: '" + buildTool + "'. Must be 'maven' or 'gradle'.");
+        }
         String normalizedDir = normalize(projectDir);
 
         QuarkusInstance existing = instances.get(normalizedDir);
@@ -152,7 +155,7 @@ public class QuarkusProcessManager {
         String mvnCmd;
         File wrapper = isWindows() ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
         if (wrapper.exists()) {
-            warnIfUntrustedWrapper(wrapper);
+            verifyTrustedWrapper(wrapper);
             mvnCmd = isWindows() ? "mvnw.cmd" : "./mvnw";
         } else {
             mvnCmd = "mvn";
@@ -165,7 +168,7 @@ public class QuarkusProcessManager {
         String gradleCmd;
         File wrapper = isWindows() ? new File(projectDir, "gradlew.bat") : new File(projectDir, "gradlew");
         if (wrapper.exists()) {
-            warnIfUntrustedWrapper(wrapper);
+            verifyTrustedWrapper(wrapper);
             gradleCmd = isWindows() ? "gradlew.bat" : "./gradlew";
         } else {
             gradleCmd = "gradle";
@@ -175,10 +178,10 @@ public class QuarkusProcessManager {
     }
 
     /**
-     * Warn if the wrapper script is not tracked by git (could be malicious).
-     * A wrapper in a git repo that's been committed is considered trusted.
+     * Verify the wrapper script is tracked by git (considered trusted).
+     * Throws if the wrapper is untracked or cannot be verified.
      */
-    private void warnIfUntrustedWrapper(File wrapper) {
+    private void verifyTrustedWrapper(File wrapper) {
         try {
             Process p = new ProcessBuilder("git", "ls-files", "--error-unmatch", wrapper.getName())
                     .directory(wrapper.getParentFile())
@@ -187,12 +190,15 @@ public class QuarkusProcessManager {
             p.getInputStream().transferTo(java.io.OutputStream.nullOutputStream());
             int exit = p.waitFor();
             if (exit != 0) {
-                LOG.warnf("WARNING: Wrapper script '%s' is NOT tracked by git. "
-                        + "It could be malicious. Verify before proceeding.", wrapper.getAbsolutePath());
+                throw new IllegalStateException(
+                        "Wrapper script '" + wrapper.getAbsolutePath() + "' is NOT tracked by git. "
+                                + "It could be malicious. Add it to git or use the system-installed build tool.");
             }
+        } catch (IllegalStateException e) {
+            throw e;
         } catch (Exception e) {
-            LOG.warnf("WARNING: Could not verify wrapper script '%s' against git. "
-                    + "Ensure it is trusted before proceeding.", wrapper.getAbsolutePath());
+            LOG.warnf("Could not verify wrapper script '%s' against git: %s. "
+                    + "Falling back to system build tool.", wrapper.getAbsolutePath(), e.getMessage());
         }
     }
 

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusVersionDetector.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusVersionDetector.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.jboss.logging.Logger;
 
 /**
@@ -16,9 +15,12 @@ import org.jboss.logging.Logger;
  * to prevent injection via crafted build files.
  * Results are cached per project directory to avoid re-reading build files on every call.
  */
-public class QuarkusVersionDetector {
+public final class QuarkusVersionDetector {
 
     private static final Logger LOG = Logger.getLogger(QuarkusVersionDetector.class);
+
+    private QuarkusVersionDetector() {
+    }
 
     // Cache: projectDir -> detected version (null values stored as empty string)
     private static final ConcurrentHashMap<String, String> VERSION_CACHE = new ConcurrentHashMap<>();
@@ -59,6 +61,12 @@ public class QuarkusVersionDetector {
         String version = doDetect(projectDir);
         VERSION_CACHE.put(projectDir, version != null ? version : NULL_SENTINEL);
         return version;
+    }
+
+    public static void invalidate(String projectDir) {
+        if (projectDir != null) {
+            VERSION_CACHE.remove(projectDir);
+        }
     }
 
     private static String doDetect(String projectDir) {

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -3,7 +3,6 @@ package io.quarkus.agent.mcp;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
@@ -15,6 +14,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -23,9 +23,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.jboss.logging.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -53,6 +51,7 @@ public final class SkillReader {
     private static final String SKILL_FILE_NAME = "SKILL.md";
     private static final String SKILLS_ARTIFACT_ID = "quarkus-extension-skills";
     private static final String MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2";
+    private static final Pattern VALID_SKILL_NAME = Pattern.compile("^[a-zA-Z0-9._-]+$");
     private static final Pattern FRONTMATTER_NAME = Pattern.compile("^name:\\s*(.+)$", Pattern.MULTILINE);
     private static final Pattern FRONTMATTER_DESC = Pattern.compile("^description:\\s*\"(.+)\"$", Pattern.MULTILINE);
     private static final Pattern FRONTMATTER_MODE = Pattern.compile("^mode:\\s*(\\S+)", Pattern.MULTILINE);
@@ -116,7 +115,7 @@ public final class SkillReader {
                         skillsByName.put(skill.name(), skill);
                     }
                 } catch (IOException e) {
-                    LOG.debugf("Failed to read skills from %s: %s", jarPath, e.getMessage());
+                    LOG.warnf("Failed to read skills from %s: %s", jarPath, e.getMessage());
                 }
             }
         } else {
@@ -237,7 +236,7 @@ public final class SkillReader {
 
         List<SkillInfo> skills = new ArrayList<>();
         try {
-            Files.walkFileTree(skillsDir, new SimpleFileVisitor<>() {
+            Files.walkFileTree(skillsDir, Collections.emptySet(), 3, new SimpleFileVisitor<>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                     if (file.getFileName().toString().equals(SKILL_FILE_NAME)) {
@@ -274,8 +273,9 @@ public final class SkillReader {
      */
     static Path writeSkill(String skillName, String content, String description,
             SkillMode mode, String projectDir, Path localSkillsDir, boolean projectScope) throws IOException {
-        if (skillName == null || skillName.contains("/") || skillName.contains("\\") || skillName.contains("..")) {
-            throw new IllegalArgumentException("Invalid skill name: " + skillName);
+        if (skillName == null || !VALID_SKILL_NAME.matcher(skillName).matches()) {
+            throw new IllegalArgumentException("Invalid skill name: " + skillName
+                    + ". Must contain only letters, digits, dots, hyphens, and underscores.");
         }
 
         Path baseDir;
@@ -488,7 +488,7 @@ public final class SkillReader {
                 }
             }
         } catch (Exception e) {
-            LOG.debugf("Failed to parse settings.xml at %s: %s", settingsFile, e.getMessage());
+            LOG.warnf("Failed to parse settings.xml at %s: %s", settingsFile, e.getMessage());
         }
         return null;
     }

--- a/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
@@ -1,11 +1,13 @@
 package io.quarkus.agent.mcp;
 
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
@@ -17,12 +19,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.jboss.logging.Logger;
-
-import io.quarkiverse.mcp.server.Tool;
-import io.quarkiverse.mcp.server.ToolArg;
-import io.quarkiverse.mcp.server.ToolResponse;
 
 /**
  * MCP tool for checking and updating Quarkus projects to the latest version.
@@ -222,7 +219,11 @@ public class UpdateTools {
             // Sort by semver and return the latest
             versions.sort(new SemverComparator());
             return versions.get(versions.size() - 1);
-        } catch (Exception e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.debugf("Interrupted while fetching latest version");
+            return null;
+        } catch (IOException e) {
             LOG.debugf("Failed to fetch latest version: %s", e.getMessage());
             return null;
         }
@@ -316,20 +317,7 @@ public class UpdateTools {
     }
 
     private boolean isCommandAvailable(String command) {
-        Process p = null;
-        try {
-            p = new ProcessBuilder("which", command)
-                    .redirectErrorStream(true)
-                    .start();
-            p.getInputStream().transferTo(java.io.OutputStream.nullOutputStream());
-            return p.waitFor() == 0;
-        } catch (Exception e) {
-            return false;
-        } finally {
-            if (p != null) {
-                p.destroyForcibly();
-            }
-        }
+        return ProcessUtils.isCommandAvailable(command);
     }
 
     record BuildInfo(String buildTool, String tagPrefix, String buildFile, String version) {

--- a/src/test/java/io/quarkus/agent/mcp/CreateToolsValidationTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/CreateToolsValidationTest.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -2,10 +2,9 @@ package io.quarkus.agent.mcp;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -3,12 +3,10 @@ package io.quarkus.agent.mcp;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusVersionDetectorTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusVersionDetectorTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -9,7 +9,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 

--- a/src/test/java/io/quarkus/agent/mcp/UpdateToolsTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/UpdateToolsTest.java
@@ -6,7 +6,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 


### PR DESCRIPTION
Comprehensive pre-release hardening based on a full code review covering security, error handling, thread safety, and code quality across all 12 source files.

### Thread safety
- **QuarkusInstance.getStatus()** — replaced `volatile` status field with `AtomicReference<Status>` and `compareAndSet` to eliminate the race condition in the check-then-act pattern between `getStatus()`, `monitorExit()`, and `stop()`
- **DocSearchTools.ensureInitialized()** — replaced `synchronized(this)` with a dedicated lock object to avoid potential CDI proxy issues

### Security
- **Untrusted wrapper scripts** — `warnIfUntrustedWrapper` upgraded to `verifyTrustedWrapper` which throws `IllegalStateException` for wrappers not tracked by git, instead of merely logging a warning
- **Build tool validation** — `QuarkusProcessManager.start()` now validates the `buildTool` parameter against an allowlist (`maven`, `gradle`)
- **Skill name validation** — `SkillReader.writeSkill()` tightened from a denylist (`/`, `\`, `..`) to an allowlist pattern (`^[a-zA-Z0-9._-]+$`)
- **File tree walk depth** — `SkillReader.readLocalSkills()` limited to maxDepth 3 to prevent excessive traversal via symlinks

### Error handling
- **Stack traces preserved** — added `LOG.error()` before every `ToolResponse.error()` return in `LifecycleTools` (5 catch blocks) and `DevMcpProxyTools` (3 catch blocks) — previously stack traces were silently dropped
- **Silent failures surfaced** — upgraded 4 `LOG.debug` calls to `LOG.warn` in `CreateTools` helpers (`createSourceDirectories`, `generateProjectInstructions`, `addRestAssuredToMaven`, `addRestAssuredToGradle`) and in `SkillReader` (JAR read failure, settings.xml parse failure)
- **InterruptedException** — `UpdateTools.fetchLatestVersion()` now catches `InterruptedException` separately and restores the thread interrupt flag; `ProcessUtils.isCommandAvailable()` does the same
- **Process timeout** — `CreateTools.create()` now uses `process.waitFor(10, TimeUnit.MINUTES)` instead of blocking indefinitely
- **QuarkusInstance.stop()** — `sendInput('q')` wrapped in try-catch so the `destroyForcibly()` fallback always executes
- **QuarkusInstance.captureStream** — logs a warning when IOException occurs while the process is still alive (instead of silently swallowing)
- **QuarkusInstance.parsePort** — logs malformed URLs at WARN level instead of silently ignoring

### Code quality
- **ProcessUtils** — extracted duplicated `isCommandAvailable()` and `captureOutput()` from `CreateTools` and `UpdateTools` into a shared utility with proper `InterruptedException` handling
- **Command builder consolidation** — merged near-identical `buildQuarkusCliCommand()` and `buildJBangCommand()` into shared `buildCliStyleCommand()`
- **QuarkusVersionDetector** — made `final` with private constructor (proper utility class); added `invalidate(projectDir)` method for cache eviction after version upgrades
- **ContainerManager** — added `@PreDestroy shutdown()` to log container references on shutdown
- **DevMcpProxyTools** — `REQUEST_ID` changed from static to instance field
- **DocSearchTools** — extracted `"__default__"` string to `DEFAULT_VERSION_KEY` constant
- Removed 5 unused imports across source and test files
- Updated README to remove hardcoded `0.0.5` version reference