### PR TITLE
fix: change the tool names, added title to Tool.Annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ After registering, ask your agent something like:
 
 > "Search the Quarkus docs for how to create a REST endpoint"
 
-If the MCP server is working, the agent will use `quarkus/searchDocs` and return documentation results.
+If the MCP server is working, the agent will use `quarkus_searchDocs` and return documentation results.
 
 ## Usage
 
@@ -138,13 +138,13 @@ Ask your agent to build a Quarkus application using natural language. The agent 
 
 > **You:** Create a Quarkus REST API with a greeting endpoint and a PostgreSQL database
 >
-> **Agent:** _(uses `quarkus/create` to scaffold the project with `rest-jackson,jdbc-postgresql,hibernate-orm-panache` extensions — the app starts automatically in dev mode, and a `CLAUDE.md` is generated with project-specific workflow instructions)_
+> **Agent:** _(uses `quarkus_create` to scaffold the project with `rest-jackson,jdbc-postgresql,hibernate-orm-panache` extensions — the app starts automatically in dev mode, and a `CLAUDE.md` is generated with project-specific workflow instructions)_
 >
-> **Agent:** _(calls `quarkus/skills` to learn the correct patterns for Panache, REST, and other extensions before writing any code)_
+> **Agent:** _(calls `quarkus_skills` to learn the correct patterns for Panache, REST, and other extensions before writing any code)_
 >
 > **You:** Add a `Greeting` entity and a REST endpoint that stores and retrieves greetings
 >
-> **Agent:** _(writes the code following patterns from skills, then runs tests via a subagent using `quarkus/callTool`)_
+> **Agent:** _(writes the code following patterns from skills, then runs tests via a subagent using `quarkus_callTool`)_
 
 ### Development workflow
 
@@ -153,22 +153,22 @@ The MCP server guides the agent through the optimal Quarkus development workflow
 ```
 NEW PROJECT                           EXISTING PROJECT
 
-1. quarkus/create                     1. quarkus/update (via subagent)
+1. quarkus_create                     1. quarkus_update (via subagent)
    → scaffolds + auto-starts             → checks version, suggests upgrades
    → generates CLAUDE.md
-                                      2. quarkus/start
-2. quarkus/skills                        → starts dev mode
+                                      2. quarkus_start
+2. quarkus_skills                        → starts dev mode
    → learn extension patterns
-                                      3. quarkus/skills
-3. quarkus/searchDocs                    → learn extension patterns
+                                      3. quarkus_skills
+3. quarkus_searchDocs                    → learn extension patterns
    → look up APIs, config
-                                      4. quarkus/searchDocs
+                                      4. quarkus_searchDocs
 4. Write code + tests                    → look up APIs, config
 
 5. Run tests (via subagent)           5. Write code + tests
-   → quarkus/callTool
+   → quarkus_callTool
    → devui-testing_runTests           6. Run tests (via subagent)
-                                         → quarkus/callTool
+                                         → quarkus_callTool
 6. Iterate                               → devui-testing_runTests
 ```
 
@@ -177,26 +177,26 @@ NEW PROJECT                           EXISTING PROJECT
 - **Hot reload** is automatic in Quarkus dev mode — triggered on the next access (HTTP request or test run), not on file save.
 - **Skills before code** — the agent reads extension-specific skills to learn correct patterns, testing approaches, and common pitfalls before writing any code.
 - **Tests via subagents** — test execution is dispatched to a subagent so the main conversation stays responsive.
-- **The MCP server survives crashes** — if the app crashes due to a code error, the agent can use `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location) and fix it. Use `quarkus/logs` for broader context.
+- **The MCP server survives crashes** — if the app crashes due to a code error, the agent can use `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location) and fix it. Use `quarkus_logs` for broader context.
 - **CLAUDE.md** — every new project gets a `CLAUDE.md` with Quarkus-specific workflow instructions that guide the agent.
 
 ### What the agent can do with a running app
 
-Once a Quarkus app is running in dev mode, the agent can discover and use all Dev MCP tools via `quarkus/searchTools` and `quarkus/callTool`. The tool list is **dynamic** — it changes when extensions are added or removed, so the agent should re-discover tools after any extension change. Typical tools include:
+Once a Quarkus app is running in dev mode, the agent can discover and use all Dev MCP tools via `quarkus_searchTools` and `quarkus_callTool`. The tool list is **dynamic** — it changes when extensions are added or removed, so the agent should re-discover tools after any extension change. Typical tools include:
 
 | Capability | How to discover | Example |
 |-----------|----------------|---------|
-| Testing | `quarkus/searchTools` query: `test` | Run all tests, run a specific test class |
-| Configuration | `quarkus/searchTools` query: `config` | View and change config properties |
-| Extensions | `quarkus/searchTools` query: `extension` | Add or remove extensions at runtime |
-| Endpoints | `quarkus/searchTools` query: `endpoint` | List all REST endpoints and their URLs |
-| Dev Services | `quarkus/searchTools` query: `dev-services` | View database URLs, container info |
-| Log levels | `quarkus/searchTools` query: `log` | Change log levels at runtime |
+| Testing | `quarkus_searchTools` query: `test` | Run all tests, run a specific test class |
+| Configuration | `quarkus_searchTools` query: `config` | View and change config properties |
+| Extensions | `quarkus_searchTools` query: `extension` | Add or remove extensions at runtime |
+| Endpoints | `quarkus_searchTools` query: `endpoint` | List all REST endpoints and their URLs |
+| Dev Services | `quarkus_searchTools` query: `dev-services` | View database URLs, container info |
+| Log levels | `quarkus_searchTools` query: `log` | Change log levels at runtime |
 | Exceptions | `devui-exceptions_getLastException` | Get last compilation/deployment/runtime exception with stack trace and source location |
 
 ### Extension skills
 
-The agent can read extension-specific coding skills using `quarkus/skills`. Skills contain patterns, testing guidelines, and common pitfalls for each extension — things like "always use `@Transactional` for write operations with Panache" or "don't create REST clients manually, let CDI inject them."
+The agent can read extension-specific coding skills using `quarkus_skills`. Skills contain patterns, testing guidelines, and common pitfalls for each extension — things like "always use `@Transactional` for write operations with Panache" or "don't create REST clients manually, let CDI inject them."
 
 Skills are loaded using a three-layer chain (most specific wins):
 
@@ -209,19 +209,19 @@ Each layer can either **enhance** (default) or **override** the previous layer, 
 - **`mode: enhance`** (default) — appends content to the base skill. The base content is preserved and the customization is added after a separator. This is ideal for adding project conventions or team standards without losing the built-in guidance.
 - **`mode: override`** — fully replaces the base skill. Use this when you need complete control over a skill's content.
 
-The agent can also create or update skill customizations using `quarkus/updateSkill`. When the user asks to customize a skill, the agent will ask:
+The agent can also create or update skill customizations using `quarkus_updateSkill`. When the user asks to customize a skill, the agent will ask:
 1. **Enhance or override?** — append to the base skill or fully replace it.
 2. **Project or global scope?** — save under `.quarkus/skills/` (this project only) or `~/.quarkus/skills/` (all projects).
 
 ### Documentation search
 
-The agent can search Quarkus documentation at any time using `quarkus/searchDocs`. This uses semantic search (BGE embeddings + pgvector) over the full Quarkus documentation.
+The agent can search Quarkus documentation at any time using `quarkus_searchDocs`. This uses semantic search (BGE embeddings + pgvector) over the full Quarkus documentation.
 
 On first use, a Docker/Podman container with the pre-indexed documentation is started automatically. If a project directory is provided, the documentation version matches the project's Quarkus version.
 
 ### Update checking
 
-For existing projects, `quarkus/update` checks if the Quarkus version is current and provides a full upgrade report:
+For existing projects, `quarkus_update` checks if the Quarkus version is current and provides a full upgrade report:
 
 - Compares build files against [reference projects](https://github.com/quarkusio/code-with-quarkus-compare)
 - Runs `quarkus update --dry-run` (if CLI available) to preview automated migrations
@@ -234,44 +234,44 @@ For existing projects, `quarkus/update` checks if the Quarkus version is current
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `quarkus/create` | Create a new Quarkus app, auto-start in dev mode, generate CLAUDE.md | `outputDir` (required), `groupId`, `artifactId`, `extensions`, `buildTool`, `quarkusVersion` |
+| `quarkus_create` | Create a new Quarkus app, auto-start in dev mode, generate CLAUDE.md | `outputDir` (required), `groupId`, `artifactId`, `extensions`, `buildTool`, `quarkusVersion` |
 
 ### Update Checking
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `quarkus/update` | Check if project is up-to-date, provide upgrade report | `projectDir` (required) |
+| `quarkus_update` | Check if project is up-to-date, provide upgrade report | `projectDir` (required) |
 
 ### Extension Skills
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `quarkus/skills` | Get coding patterns, testing guidelines, and pitfalls for project extensions | `projectDir` (required), `query` |
-| `quarkus/updateSkill` | Create or update a skill customization (enhance or override) | `projectDir` (required), `skillName` (required), `content` (required), `description`, `mode`, `scope` |
+| `quarkus_skills` | Get coding patterns, testing guidelines, and pitfalls for project extensions | `projectDir` (required), `query` |
+| `quarkus_updateSkill` | Create or update a skill customization (enhance or override) | `projectDir` (required), `skillName` (required), `content` (required), `description`, `mode`, `scope` |
 
 ### Lifecycle Management
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `quarkus/start` | Start a Quarkus app in dev mode | `projectDir` (required), `buildTool` |
-| `quarkus/stop` | Graceful shutdown | `projectDir` (required) |
-| `quarkus/restart` | Force restart (usually not needed — hot reload is automatic) | `projectDir` (required) |
-| `quarkus/status` | Get app state | `projectDir` (required) |
-| `quarkus/logs` | Get recent log output | `projectDir` (required), `lines` |
-| `quarkus/list` | List all managed instances | _(none)_ |
+| `quarkus_start` | Start a Quarkus app in dev mode | `projectDir` (required), `buildTool` |
+| `quarkus_stop` | Graceful shutdown | `projectDir` (required) |
+| `quarkus_restart` | Force restart (usually not needed — hot reload is automatic) | `projectDir` (required) |
+| `quarkus_status` | Get app state | `projectDir` (required) |
+| `quarkus_logs` | Get recent log output | `projectDir` (required), `lines` |
+| `quarkus_list` | List all managed instances | _(none)_ |
 
 ### Dev MCP Proxy
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `quarkus/searchTools` | Discover tools on the running app's Dev MCP server | `projectDir` (required), `query` |
-| `quarkus/callTool` | Invoke a Dev MCP tool by name | `projectDir` (required), `toolName` (required), `toolArguments` |
+| `quarkus_searchTools` | Discover tools on the running app's Dev MCP server | `projectDir` (required), `query` |
+| `quarkus_callTool` | Invoke a Dev MCP tool by name | `projectDir` (required), `toolName` (required), `toolArguments` |
 
 ### Documentation Search
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `quarkus/searchDocs` | Semantic search over Quarkus documentation | `query` (required), `maxResults`, `projectDir` |
+| `quarkus_searchDocs` | Semantic search over Quarkus documentation | `query` (required), `maxResults`, `projectDir` |
 
 ## Architecture
 

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -41,18 +41,18 @@ public class CreateTools {
     // Extensions: comma-separated list of extension short names
     private static final Pattern VALID_EXTENSIONS = Pattern.compile("^[a-zA-Z0-9._,:-]+$");
 
-    // Cache which command is available — doesn't change during the lifetime of the server
+    // Cache which command is available -- doesn't change during the lifetime of the server
     private volatile String cachedCreateCommand;
 
-    @Tool(name = "quarkus/create", description = "Create a new Quarkus application and auto-start it in dev mode. "
-            + "RULES: 1) NEVER implement features manually when a Quarkus extension exists — "
+    @Tool(name = "quarkus_create", description = "Create a new Quarkus application and auto-start it in dev mode. "
+            + "RULES: 1) NEVER implement features manually when a Quarkus extension exists -- "
             + "always search for and add the right extension first. "
             + "2) BEFORE creating the app or writing ANY code, present the user with extension choices for each capability. "
             + "When multiple extensions can fulfill a capability (e.g. REST: quarkus-rest vs resteasy-classic vs spring-web; "
             + "Web UI: Qute vs Web Bundler vs Quinoa vs Web Dependency Locator; "
             + "Persistence: Hibernate ORM with Panache vs Hibernate Reactive vs JDBC), "
             + "list ALL options with a recommended default and WAIT for the user to choose. NEVER silently pick one. "
-            + "3) Use quarkus/skills for each chosen extension BEFORE writing any code — this is mandatory, not optional. "
+            + "3) Use quarkus_skills for each chosen extension BEFORE writing any code -- this is mandatory, not optional. "
             + "4) ALWAYS write tests for every feature if it makes sense and unless the user explicitly requested you not to. "
             + "5) Keep README.md updated with app description, features, endpoints, and Quarkus guide links after every change.")
     ToolResponse create(
@@ -175,29 +175,29 @@ public class CreateTools {
                 LOG.infof("Auto-started Quarkus app at: %s", projectDir);
                 return ToolResponse.success("Quarkus project created and starting in dev mode at: " + projectDir
                         + "\n\nNEXT STEPS (follow this order strictly):"
-                        + "\n1. STOP — do NOT write any code yet. For each capability the user requested, "
-                        + "search for Quarkus extensions that provide it using quarkus/searchDocs. "
+                        + "\n1. STOP -- do NOT write any code yet. For each capability the user requested, "
+                        + "search for Quarkus extensions that provide it using quarkus_searchDocs. "
                         + "NEVER roll your own solution when an extension exists."
-                        + "\n2. PRESENT OPTIONS — when multiple extensions can fulfill a capability, "
+                        + "\n2. PRESENT OPTIONS -- when multiple extensions can fulfill a capability, "
                         + "list ALL options to the user with a recommended default marked. "
                         + "Wait for the user to choose before proceeding. Never silently pick one."
-                        + "\n3. LOAD SKILLS — call quarkus/skills for each chosen extension BEFORE writing any code. "
+                        + "\n3. LOAD SKILLS -- call quarkus_skills for each chosen extension BEFORE writing any code. "
                         + "This is mandatory, not optional."
-                        + "\n4. Add chosen extensions via quarkus/searchTools query='extension' → quarkus/callTool."
-                        + "\n5. Use quarkus/searchDocs to look up additional Quarkus APIs and best practices."
+                        + "\n4. Add chosen extensions via quarkus_searchTools query='extension' -> quarkus_callTool."
+                        + "\n5. Use quarkus_searchDocs to look up additional Quarkus APIs and best practices."
                         + "\n6. Write your code AND tests. Always include tests for every feature."
-                        + "\n7. Run tests with quarkus/callTool: use 'devui-testing_runTests' to run all tests, "
+                        + "\n7. Run tests with quarkus_callTool: use 'devui-testing_runTests' to run all tests, "
                         + "'devui-testing_runAffectedTests' to run only tests affected by your changes, "
                         + "or 'devui-testing_runTest' with arguments {\"className\":\"com.example.MyTest\"} for a specific test."
-                        + "\n8. After code changes, trigger a reload via quarkus/callTool with toolName 'devui-logstream_forceRestart'. Do NOT restart the app manually."
-                        + "\n   IMPORTANT: After pom.xml/build.gradle changes (adding dependencies or extensions), you MUST do a full quarkus/stop + quarkus/start. forceRestart only recompiles source — it does NOT re-resolve dependencies."
+                        + "\n8. After code changes, trigger a reload via quarkus_callTool with toolName 'devui-logstream_forceRestart'. Do NOT restart the app manually."
+                        + "\n   IMPORTANT: After pom.xml/build.gradle changes (adding dependencies or extensions), you MUST do a full quarkus_stop + quarkus_start. forceRestart only recompiles source -- it does NOT re-resolve dependencies."
                         + "\n9. Update README.md with: app description, features, endpoints, how to run, and links to Quarkus guides."
                         + "\n10. After core features work, suggest to the user: security, observability, health checks, OpenAPI.");
             } catch (Exception startError) {
                 LOG.warnf("Project created but failed to auto-start: %s", startError.getMessage());
                 return ToolResponse.success("Quarkus project created at: " + projectDir
                         + "\nAuto-start failed: " + startError.getMessage()
-                        + "\nUse quarkus/start with projectDir='" + projectDir + "' to start it manually.");
+                        + "\nUse quarkus_start with projectDir='" + projectDir + "' to start it manually.");
             }
         } catch (Exception e) {
             LOG.error("Failed to create Quarkus project", e);
@@ -434,45 +434,45 @@ public class CreateTools {
     private void generateProjectInstructions(String projectDir, String extensions) {
         try {
             String agentsMdContent = """
-                    # AGENTS.md — Quarkus Project Instructions
+                    # AGENTS.md -- Quarkus Project Instructions
 
                     This is a Quarkus application. Follow these rules when working on this project.
 
-                    ## CRITICAL — Extension-First Rule (NEVER skip this)
+                    ## CRITICAL -- Extension-First Rule (NEVER skip this)
 
                     **STOP before writing ANY code.** For every feature or capability the user requests:
 
-                    1. **Search for Quarkus extensions** that provide the capability using `quarkus/searchDocs` and `quarkus/searchTools query='extension'`.
+                    1. **Search for Quarkus extensions** that provide the capability using `quarkus_searchDocs` and `quarkus_searchTools query='extension'`.
                     2. **Present ALL matching options to the user** with a recommended default marked. Examples:
-                       - User asks for REST → present: **quarkus-rest** (recommended), resteasy-classic, spring-web
-                       - User asks for web UI → present: **Qute** (recommended), Web Bundler, Quinoa, Web Dependency Locator
-                       - User asks for persistence → present: **Hibernate ORM with Panache** (recommended), Hibernate Reactive, JDBC directly
-                       - User asks for security → present: **OIDC** (recommended), Security JDBC, Security JPA, Security Properties
+                       - User asks for REST -> present: **quarkus-rest** (recommended), resteasy-classic, spring-web
+                       - User asks for web UI -> present: **Qute** (recommended), Web Bundler, Quinoa, Web Dependency Locator
+                       - User asks for persistence -> present: **Hibernate ORM with Panache** (recommended), Hibernate Reactive, JDBC directly
+                       - User asks for security -> present: **OIDC** (recommended), Security JDBC, Security JPA, Security Properties
                     3. **Wait for the user to choose** before proceeding. Do NOT silently pick an extension.
-                    4. **Load skills** with `quarkus/skills` for the chosen extension BEFORE writing any code.
+                    4. **Load skills** with `quarkus_skills` for the chosen extension BEFORE writing any code.
 
                     Skipping any of these steps is a violation. NEVER implement a feature by hand-coding HTML, JavaScript, REST endpoints, or other functionality when a Quarkus extension exists for it.
 
                     ## Required Workflow
 
-                    1. **Use quarkus/update (via subagent) when returning to this project** — checks if the Quarkus version is up-to-date and suggests upgrades.
-                    2. **Use quarkus/skills BEFORE writing any code or tests** — it contains extension-specific patterns, testing approaches, and common pitfalls that prevent mistakes. Skills may also list **Available Dev MCP Tools** specific to each extension (e.g. OpenAPI schema retrieval, scheduler job management) — use these via `quarkus/callTool`. Call this EVERY time you are about to add or modify a feature, not just at project creation.
-                    3. **Use quarkus/searchDocs for Quarkus documentation** — do NOT use generic documentation tools (Context7, web search). The Quarkus doc search is version-aware and more accurate.
-                    4. **Use quarkus/searchTools to discover Dev MCP tools** on the running app for testing, config changes, and extension management. The tool list is **dynamic** — it changes when extensions are added or removed. Re-call `quarkus/searchTools` after any extension change to discover newly available tools. Note: some extension-specific tools are also documented in the skills output (see step 2).
-                    5. **Use quarkus/callTool to invoke Dev MCP tools** — run tests, add extensions, update configuration. Do NOT run Maven/Gradle commands manually.
-                    6. **After code changes, trigger a reload** via `quarkus/callTool` with toolName `devui-logstream_forceRestart`. Do NOT restart the app manually.
-                    7. **After pom.xml / build.gradle changes** (adding dependencies or extensions), you MUST do a full `quarkus/stop` + `quarkus/start` cycle. A `forceRestart` only recompiles source files — it does NOT re-resolve dependencies.
+                    1. **Use quarkus_update (via subagent) when returning to this project** -- checks if the Quarkus version is up-to-date and suggests upgrades.
+                    2. **Use quarkus_skills BEFORE writing any code or tests** -- it contains extension-specific patterns, testing approaches, and common pitfalls that prevent mistakes. Skills may also list **Available Dev MCP Tools** specific to each extension (e.g. OpenAPI schema retrieval, scheduler job management) -- use these via `quarkus_callTool`. Call this EVERY time you are about to add or modify a feature, not just at project creation.
+                    3. **Use quarkus_searchDocs for Quarkus documentation** -- do NOT use generic documentation tools (Context7, web search). The Quarkus doc search is version-aware and more accurate.
+                    4. **Use quarkus_searchTools to discover Dev MCP tools** on the running app for testing, config changes, and extension management. The tool list is **dynamic** -- it changes when extensions are added or removed. Re-call `quarkus_searchTools` after any extension change to discover newly available tools. Note: some extension-specific tools are also documented in the skills output (see step 2).
+                    5. **Use quarkus_callTool to invoke Dev MCP tools** -- run tests, add extensions, update configuration. Do NOT run Maven/Gradle commands manually.
+                    6. **After code changes, trigger a reload** via `quarkus_callTool` with toolName `devui-logstream_forceRestart`. Do NOT restart the app manually.
+                    7. **After pom.xml / build.gradle changes** (adding dependencies or extensions), you MUST do a full `quarkus_stop` + `quarkus_start` cycle. A `forceRestart` only recompiles source files -- it does NOT re-resolve dependencies.
 
                     ## Rules
 
-                    - NEVER implement features manually when a Quarkus extension exists — search for and add the right extension first.
-                    - NEVER silently pick an extension when multiple options exist — ALWAYS present options to the user and wait for their choice.
-                    - NEVER write code for a feature without first loading its skill via `quarkus/skills`.
-                    - ALWAYS write tests for every feature — no exceptions.
+                    - NEVER implement features manually when a Quarkus extension exists -- search for and add the right extension first.
+                    - NEVER silently pick an extension when multiple options exist -- ALWAYS present options to the user and wait for their choice.
+                    - NEVER write code for a feature without first loading its skill via `quarkus_skills`.
+                    - ALWAYS write tests for every feature -- no exceptions.
                     - ALWAYS keep README.md updated with app description, features, endpoints, and Quarkus guide links.
-                    - ALWAYS summarize after completing work — when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment).
-                    - Use `@QuarkusTest` for integration tests — Dev Services auto-starts backing services (databases, messaging, etc.).
-                    - Use `%dev.` and `%test.` profile prefixes for dev/test configuration — never hardcode connection URLs without a profile prefix.
+                    - ALWAYS summarize after completing work -- when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment).
+                    - Use `@QuarkusTest` for integration tests -- Dev Services auto-starts backing services (databases, messaging, etc.).
+                    - Use `%dev.` and `%test.` profile prefixes for dev/test configuration -- never hardcode connection URLs without a profile prefix.
 
                     ## Testing
 
@@ -480,7 +480,7 @@ public class CreateTools {
 
                     ```
                     Use the Agent tool to launch a subagent with this prompt:
-                      "Run the Quarkus tests for project <projectDir> using quarkus/callTool
+                      "Run the Quarkus tests for project <projectDir> using quarkus_callTool
                        with toolName 'devui-testing_runTests'. Analyze the results and report
                        which tests passed, failed, or errored. If tests fail, include the
                        failure messages and suggest fixes."
@@ -488,30 +488,30 @@ public class CreateTools {
 
                     - Use `devui-testing_runTests` to run all tests.
                     - Use `devui-testing_runTest` with arguments `{"className":"com.example.MyTest"}` to run a specific test class.
-                    - Do NOT run Maven/Gradle test commands manually — the Dev MCP test tools handle compilation, hot reload, and result reporting.
+                    - Do NOT run Maven/Gradle test commands manually -- the Dev MCP test tools handle compilation, hot reload, and result reporting.
                     - After fixing test failures, re-run tests with a subagent to verify the fix.
 
                     ## Error Handling
 
                     When something goes wrong (compilation error, deployment failure, runtime exception):
 
-                    1. Use `quarkus/callTool` with toolName `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location).
+                    1. Use `quarkus_callTool` with toolName `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location).
                     2. Fix the issue based on the exception details.
                     3. Call `devui-exceptions_clearLastException` to clear the recorded exception.
-                    4. Use `quarkus/logs` only when you need broader log context beyond the exception itself.
+                    4. Use `quarkus_logs` only when you need broader log context beyond the exception itself.
 
-                    **Note:** If the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet — fall back to `quarkus/logs` in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy.
+                    **Note:** If the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet -- fall back to `quarkus_logs` in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy.
 
                     ## Customizing Skills
 
-                    Extension skills can be customized per-project or globally using `quarkus/updateSkill`.
+                    Extension skills can be customized per-project or globally using `quarkus_updateSkill`.
                     When the user asks to update or customize a skill, ask them:
-                    1. **Enhance or override?** — Enhance (default) appends content to the base skill.
+                    1. **Enhance or override?** -- Enhance (default) appends content to the base skill.
                        Override fully replaces the base skill.
-                    2. **Project or global scope?** — Project scope (`.quarkus/skills/`) affects only this project.
+                    2. **Project or global scope?** -- Project scope (`.quarkus/skills/`) affects only this project.
                        Global scope (`~/.quarkus/skills/`) affects all projects.
 
-                    Skills use a three-layer chain: JAR defaults → global customizations → project customizations.
+                    Skills use a three-layer chain: JAR defaults -> global customizations -> project customizations.
                     Each layer can either enhance (append to) or override (replace) the previous layer.
 
                     You can also manually place SKILL.md files under `.quarkus/skills/<extension-name>/SKILL.md`.

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -1,12 +1,5 @@
 package io.quarkus.agent.mcp;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.quarkiverse.mcp.server.Tool;
-import io.quarkiverse.mcp.server.ToolArg;
-import io.quarkiverse.mcp.server.ToolResponse;
-import jakarta.inject.Inject;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -19,8 +12,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
 
 /**
  * MCP tools that proxy requests to a running Quarkus application's Dev MCP server.
@@ -49,12 +52,14 @@ public class DevMcpProxyTools {
     @ConfigProperty(name = "agent-mcp.local-skills-dir")
     Optional<String> localSkillsDir;
 
-    @Tool(name = "quarkus/searchTools", description = "Discover available tools on the running Quarkus app's Dev MCP server. "
-            + "Use this before interacting with the running app — for testing, config, extensions, "
-            + "endpoints, dev services, etc. Then use quarkus/callTool to invoke the discovered tool. "
-            + "The tool list is DYNAMIC — it changes when extensions are added or removed. "
+    @Tool(name = "quarkus_searchTools", description = "Discover available tools on the running Quarkus app's Dev MCP server. "
+            + "Use this before interacting with the running app -- for testing, config, extensions, "
+            + "endpoints, dev services, etc. Then use quarkus_callTool to invoke the discovered tool. "
+            + "The tool list is DYNAMIC -- it changes when extensions are added or removed. "
             + "Re-call this after any extension change to discover newly available tools.",
-            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false, idempotentHint = true))
+            // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
+            // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
+            annotations = @Tool.Annotations(title = "quarkus_searchTools", readOnlyHint = true, destructiveHint = false, idempotentHint = true))
     ToolResponse searchTools(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
             @ToolArg(description = "Search query to filter tools by name or description (case-insensitive). "
@@ -81,19 +86,20 @@ public class DevMcpProxyTools {
         }
     }
 
-    @Tool(name = "quarkus/skills", description = "Get coding skills, patterns, testing guidelines, and configuration reference "
+    @Tool(name = "quarkus_skills", description = "Get coding skills, patterns, testing guidelines, and configuration reference "
             + "for the Quarkus extensions used in the project. "
             + "ALWAYS call this BEFORE writing code or tests to learn the correct Quarkus patterns for each extension. "
-            + "Does NOT require the app to be running — reads from built extension JARs. "
+            + "Does NOT require the app to be running -- reads from built extension JARs. "
             + "If the app is still building (just created), this will wait for the build to complete. "
             + "Skills may include an 'Available Dev MCP Tools' section listing extension-specific Dev MCP tools "
-            + "that can be invoked via quarkus/callTool (e.g. OpenAPI schema retrieval, scheduler job management). "
-            + "Skills can be customized using quarkus/updateSkill. Customizations use a three-layer chain: "
-            + "JAR defaults → global (~/.quarkus/skills/) → project (.quarkus/skills/). "
+            + "that can be invoked via quarkus_callTool (e.g. OpenAPI schema retrieval, scheduler job management). "
+            + "Skills can be customized using quarkus_updateSkill. Customizations use a three-layer chain: "
+            + "JAR defaults -> global (~/.quarkus/skills/) -> project (.quarkus/skills/). "
             + "By default, customizations ENHANCE (append to) the base skill. "
             + "Use mode 'override' to fully replace a base skill.",
-            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false,
-                    idempotentHint = true, openWorldHint = false))
+            // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
+            // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
+            annotations = @Tool.Annotations(title = "quarkus_skills", readOnlyHint = true, destructiveHint = false, idempotentHint = true, openWorldHint = false))
     ToolResponse skills(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
             @ToolArg(description = "Optional query to filter skills by extension name (case-insensitive). "
@@ -181,25 +187,26 @@ public class DevMcpProxyTools {
         if (status == QuarkusInstance.Status.CRASHED || status == QuarkusInstance.Status.STOPPED) {
             return List.of();
         }
-        // RUNNING or timed out (still STARTING) — try reading skills either way
+        // RUNNING or timed out (still STARTING) -- try reading skills either way
         return SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null), metadataOnly);
     }
 
-    @Tool(name = "quarkus/updateSkill", description = "Create or update a skill customization for a Quarkus extension. "
+    @Tool(name = "quarkus_updateSkill", description = "Create or update a skill customization for a Quarkus extension. "
             + "Use this when the user wants to add project conventions, team standards, or guardrails to an extension skill. "
             + "IMPORTANT: Before writing, ask the user two questions: "
             + "(1) Should this ENHANCE the existing skill (append your content to the base) or OVERRIDE it (fully replace the base)? "
             + "Enhance is the default and recommended for most cases. "
             + "(2) Should this be saved at PROJECT scope (.quarkus/skills/ in the project, affects only this project) "
             + "or GLOBAL scope (~/.quarkus/skills/, affects all projects)?",
-            annotations = @Tool.Annotations(readOnlyHint = false, destructiveHint = false, idempotentHint = true))
+            // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
+            // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
+            annotations = @Tool.Annotations(title = "quarkus_updateSkill", readOnlyHint = false, destructiveHint = false, idempotentHint = true))
     ToolResponse updateSkill(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
             @ToolArg(description = "The extension skill name (e.g. 'quarkus-rest', 'quarkus-hibernate-orm-panache')") String skillName,
-            @ToolArg(description = "The skill content in markdown (without frontmatter — it will be generated)") String content,
+            @ToolArg(description = "The skill content in markdown (without frontmatter -- it will be generated)") String content,
             @ToolArg(description = "Optional description for the skill", required = false) String description,
-            @ToolArg(description = "Mode: 'enhance' (default) appends to the base skill, 'override' fully replaces it",
-                    required = false) String mode,
+            @ToolArg(description = "Mode: 'enhance' (default) appends to the base skill, 'override' fully replaces it", required = false) String mode,
             @ToolArg(description = "Scope: 'project' (default) saves under .quarkus/skills/ in the project, "
                     + "'global' saves under ~/.quarkus/skills/", required = false) String scope) {
         try {
@@ -217,18 +224,18 @@ public class DevMcpProxyTools {
                             + "- **Mode**: " + modeLabel + "\n"
                             + "- **Scope**: " + scopeLabel + "\n"
                             + "- **Path**: " + written + "\n\n"
-                            + "The skill will take effect on the next call to `quarkus/skills`.");
+                            + "The skill will take effect on the next call to `quarkus_skills`.");
         } catch (Exception e) {
             return ToolResponse.error("Failed to write skill: " + e.getMessage());
         }
     }
 
-    @Tool(name = "quarkus/callTool", description = "Invoke a Dev MCP tool by name on the running Quarkus app. "
-            + "Use quarkus/searchTools first to discover tool names and parameters. "
+    @Tool(name = "quarkus_callTool", description = "Invoke a Dev MCP tool by name on the running Quarkus app. "
+            + "Use quarkus_searchTools first to discover tool names and parameters. "
             + "After structural changes (adding extensions, endpoints), update README.md.")
     ToolResponse callTool(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
-            @ToolArg(description = "The name of the Dev MCP tool to call (as returned by quarkus/searchTools)") String toolName,
+            @ToolArg(description = "The name of the Dev MCP tool to call (as returned by quarkus_searchTools)") String toolName,
             @ToolArg(description = "Arguments to pass to the tool as a JSON string (matching the tool's inputSchema). "
                     + "Omit if the tool takes no arguments.", required = false) String toolArguments) {
         try {
@@ -266,7 +273,7 @@ public class DevMcpProxyTools {
         QuarkusInstance instance = processManager.getInstance(projectDir);
         if (instance == null) {
             throw new IllegalStateException(
-                    "Quarkus application is not running at: " + projectDir + ". Start it first with quarkus/start.");
+                    "Quarkus application is not running at: " + projectDir + ". Start it first with quarkus_start.");
         }
 
         // If the app is still starting, wait for it to become ready
@@ -280,7 +287,7 @@ public class DevMcpProxyTools {
         if (instance.getStatus() != QuarkusInstance.Status.RUNNING) {
             throw new IllegalStateException(
                     "Quarkus application is not running at: " + projectDir
-                            + " (status: " + instance.getStatus() + "). Start it first with quarkus/start.");
+                            + " (status: " + instance.getStatus() + "). Start it first with quarkus_start.");
         }
 
         int port = instance.getHttpPort();
@@ -387,7 +394,8 @@ public class DevMcpProxyTools {
                     .timeout(REQUEST_TIMEOUT)
                     .build();
 
-            HttpResponse<String> response = HttpClientProvider.getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> response = HttpClientProvider.getHttpClient().send(request,
+                    HttpResponse.BodyHandlers.ofString());
             if (response.statusCode() != 200) {
                 throw new RuntimeException("Dev MCP returned HTTP " + response.statusCode());
             }

--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -89,10 +89,12 @@ public class DocSearchTools {
     private final Object initLock = new Object();
     private final ConcurrentHashMap<String, PgVectorEmbeddingStore> embeddingStores = new ConcurrentHashMap<>();
 
-    @Tool(name = "quarkus/searchDocs", description = "Search Quarkus documentation. "
+    @Tool(name = "quarkus_searchDocs", description = "Search Quarkus documentation. "
             + "Always use this BEFORE writing Quarkus code to look up correct APIs, annotations, "
             + "configuration, and best practices. First call may take a moment to start the doc database.",
-            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false, idempotentHint = true))
+            // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
+            // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
+            annotations = @Tool.Annotations(title = "quarkus_searchDocs", readOnlyHint = true, destructiveHint = false, idempotentHint = true))
     ToolResponse searchDocs(
             @ToolArg(description = "The search query describing what documentation you're looking for. "
                     + "Examples: 'how to configure datasource', 'CDI dependency injection', "

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -24,7 +24,7 @@ public class LifecycleTools {
     @Inject
     ObjectMapper mapper;
 
-    @Tool(name = "quarkus/start", description = "Start a Quarkus application in dev mode. "
+    @Tool(name = "quarkus_start", description = "Start a Quarkus application in dev mode. "
             + "Auto-detects Maven or Gradle. Hot reload is triggered when the app is accessed. "
             + "RULES: Always write tests. Always keep README.md updated after changes.")
     ToolResponse start(
@@ -39,7 +39,7 @@ public class LifecycleTools {
         }
     }
 
-    @Tool(name = "quarkus/stop", description = "Stop a running Quarkus application. "
+    @Tool(name = "quarkus_stop", description = "Stop a running Quarkus application. "
             + "Sends a graceful shutdown signal, then force-kills if needed.")
     ToolResponse stop(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir) {
@@ -52,7 +52,7 @@ public class LifecycleTools {
         }
     }
 
-    @Tool(name = "quarkus/restart", description = "Force restart a Quarkus application. "
+    @Tool(name = "quarkus_restart", description = "Force restart a Quarkus application. "
             + "Only use if the app is unresponsive. Normally hot reload handles changes automatically.")
     ToolResponse restart(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir) {
@@ -65,9 +65,11 @@ public class LifecycleTools {
         }
     }
 
-    @Tool(name = "quarkus/status", description = "Get the status of a Quarkus application. "
+    @Tool(name = "quarkus_status", description = "Get the status of a Quarkus application. "
             + "Returns: not_started, starting, running (with port), crashed, or stopped.",
-            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false,
+            // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
+            // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
+            annotations = @Tool.Annotations(title = "quarkus_status", readOnlyHint = true, destructiveHint = false,
                     idempotentHint = true, openWorldHint = false))
     ToolResponse status(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir) {
@@ -87,10 +89,12 @@ public class LifecycleTools {
         }
     }
 
-    @Tool(name = "quarkus/logs", description = "Get recent log output from a managed Quarkus application. "
+    @Tool(name = "quarkus_logs", description = "Get recent log output from a managed Quarkus application. "
             + "For structured exception details (class, message, stack trace, user code location), "
-            + "prefer quarkus/callTool with toolName 'devui-exceptions_getLastException' instead.",
-            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false, openWorldHint = false))
+            + "prefer quarkus_callTool with toolName 'devui-exceptions_getLastException' instead.",
+            // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
+            // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
+            annotations = @Tool.Annotations(title = "quarkus_logs", readOnlyHint = true, destructiveHint = false, openWorldHint = false))
     ToolResponse logs(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
             @ToolArg(description = "Number of recent lines to return (default: 50)", required = false) Integer lines) {
@@ -107,8 +111,10 @@ public class LifecycleTools {
         }
     }
 
-    @Tool(name = "quarkus/list", description = "List all managed Quarkus application instances and their current status.",
-            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false,
+    @Tool(name = "quarkus_list", description = "List all managed Quarkus application instances and their current status.",
+            // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
+            // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
+            annotations = @Tool.Annotations(title = "quarkus_list", readOnlyHint = true, destructiveHint = false,
                     idempotentHint = true, openWorldHint = false))
     ToolResponse list() {
         try {

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -149,7 +149,7 @@ public class QuarkusInstance {
     public void restart() {
         if (!process.isAlive()) {
             throw new IllegalStateException(
-                    "Process is not running. Use quarkus/start to start a new instance.");
+                    "Process is not running. Use quarkus_start to start a new instance.");
         }
         status.set(Status.STARTING);
         httpPort = -1;

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -74,7 +74,7 @@ public class QuarkusProcessManager {
         QuarkusInstance instance = instances.get(normalizedDir);
         if (instance == null) {
             throw new IllegalStateException(
-                    "No Quarkus instance found at: " + normalizedDir + ". Use quarkus/start first.");
+                    "No Quarkus instance found at: " + normalizedDir + ". Use quarkus_start first.");
         }
 
         if (!instance.isAlive()) {

--- a/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
@@ -41,12 +41,14 @@ public class UpdateTools {
             "^[0-9]+\\.[0-9]+\\.[0-9]+([.\\-][A-Za-z0-9]+)*$");
 
 
-    @Tool(name = "quarkus/update", description = "Check if a Quarkus project is up-to-date and provide an upgrade report. "
+    @Tool(name = "quarkus_update", description = "Check if a Quarkus project is up-to-date and provide an upgrade report. "
             + "Detects the current version, checks for newer releases, compares build files against "
             + "reference projects, and optionally runs 'quarkus update --dry-run' to preview migrations. "
             + "IMPORTANT: For existing Quarkus projects, ALWAYS call this tool using a subagent BEFORE "
             + "starting any development work to ensure the project is on the latest version.",
-            annotations = @Tool.Annotations(readOnlyHint = true, destructiveHint = false, idempotentHint = true))
+            // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
+            // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
+            annotations = @Tool.Annotations(title = "quarkus_update", readOnlyHint = true, destructiveHint = false, idempotentHint = true))
     ToolResponse update(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir) {
         try {
@@ -89,7 +91,7 @@ public class UpdateTools {
                 return ToolResponse.success(report.toString());
             }
 
-            // Step 3: Project is outdated — full upgrade analysis
+            // Step 3: Project is outdated -- full upgrade analysis
             report.append("**A newer Quarkus version is available!**\n\n");
 
             // Step 3a: Compare build files against current version reference

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,37 +5,40 @@ quarkus.banner.path=banner.txt
 quarkus.mcp.server.server-info.name=quarkus-agent
 quarkus.mcp.server.server-info.description=MCP server for creating, managing, and developing Quarkus applications
 quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Agent MCP server. \
-  ALWAYS use these tools when working on Quarkus projects — they are purpose-built and superior to generic alternatives.\n\n\
+  ALWAYS use these tools when working on Quarkus projects -- they are purpose-built and superior to generic alternatives.\n\n\
   WORKFLOW for new projects:\n\
-  1. quarkus/create — create and auto-start a Quarkus app (NEVER use 'mvn' or CLI manually)\n\
-  2. quarkus/skills — MUST call before writing ANY code or tests to learn correct patterns for each extension\n\
-  3. quarkus/searchDocs — search Quarkus documentation for APIs, config, and best practices (prefer this over generic doc tools like Context7)\n\
-  4. quarkus/searchTools — discover Dev MCP tools on the running app (testing, config, extensions)\n\
-  5. quarkus/callTool — invoke discovered tools (run tests, add extensions, update config)\n\n\
+  1. quarkus_create -- create and auto-start a Quarkus app (NEVER use 'mvn' or CLI manually)\n\
+  2. quarkus_skills -- MUST call before writing ANY code or tests to learn correct patterns for each extension\n\
+  3. quarkus_searchDocs -- search Quarkus documentation for APIs, config, and best practices (prefer this over generic doc tools like Context7)\n\
+  4. quarkus_searchTools -- discover Dev MCP tools on the running app (testing, config, extensions)\n\
+  5. quarkus_callTool -- invoke discovered tools (run tests, add extensions, update config)\n\n\
   WORKFLOW for existing projects:\n\
-  1. quarkus/update — ALWAYS call first (via a subagent) to check if the project is up-to-date and suggest upgrades\n\
-  2. quarkus/start — start the app in dev mode if not running\n\
-  3. quarkus/skills — MUST call before writing code to learn extension-specific patterns\n\
-  4. quarkus/searchDocs — look up Quarkus APIs and configuration\n\
+  1. quarkus_update -- ALWAYS call first (via a subagent) to check if the project is up-to-date and suggest upgrades\n\
+  2. quarkus_start -- start the app in dev mode if not running\n\
+  3. quarkus_skills -- MUST call before writing code to learn extension-specific patterns\n\
+  4. quarkus_searchDocs -- look up Quarkus APIs and configuration\n\
   5. Write code following the patterns from skills and docs\n\
-  6. quarkus/searchTools + quarkus/callTool — run tests, manage extensions\n\n\
+  6. quarkus_searchTools + quarkus_callTool -- run tests, manage extensions\n\n\
   TESTING:\n\
   - ALWAYS run tests using a subagent (via the Agent tool) so the main conversation stays responsive\n\
-  - Use quarkus/callTool with toolName 'devui-testing_runTests' to run all tests\n\
-  - Use quarkus/callTool with toolName 'devui-testing_runTest' and toolArguments '{"className":"com.example.MyTest"}' to run a specific test\n\
+  - Use quarkus_callTool with toolName 'devui-testing_runTests' to run all tests\n\
+  - Use quarkus_callTool with toolName 'devui-testing_runTest' and toolArguments '{"className":"com.example.MyTest"}' to run a specific test\n\
   - Do NOT run Maven/Gradle test commands manually\n\n\
   ERROR HANDLING:\n\
-  - When something goes wrong (compilation error, deployment failure, runtime exception), use quarkus/callTool with toolName 'devui-exceptions_getLastException' to get structured exception details (class, message, stack trace, user code location)\n\
+  - When something goes wrong (compilation error, deployment failure, runtime exception), use quarkus_callTool with toolName 'devui-exceptions_getLastException' to get structured exception details (class, message, stack trace, user code location)\n\
   - After fixing the issue, call 'devui-exceptions_clearLastException' to clear the recorded exception\n\
-  - NOTE: if the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet — fall back to quarkus/logs in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy\n\
-  - Use quarkus/logs only when you need broader log context beyond the exception itself\n\n\
+  - NOTE: if the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet -- fall back to quarkus_logs in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy\n\
+  - Use quarkus_logs only when you need broader log context beyond the exception itself\n\n\
   KEY RULES:\n\
-  - NEVER skip quarkus/skills — it contains critical patterns that prevent common mistakes\n\
-  - NEVER use generic documentation tools (Context7, web search) for Quarkus unless the user asks you to or until you're sure quarkus/searchDocs doesn't yield what you need\n\
-  - NEVER run build commands manually — use quarkus/start, quarkus/callTool for testing\n\
+  - NEVER skip quarkus_skills -- it contains critical patterns that prevent common mistakes\n\
+  - NEVER use generic documentation tools (Context7, web search) for Quarkus unless the user asks you to or until you're sure quarkus_searchDocs doesn't yield what you need\n\
+  - NEVER run build commands manually -- use quarkus_start, quarkus_callTool for testing\n\
   - ALWAYS write tests for every feature\n\
   - ALWAYS keep README.md updated\n\
-  - ALWAYS summarize after completing work — when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment)
+  - ALWAYS summarize after completing work -- when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment)
+
+# Make sure the tool names follow the spec rules
+quarkus.mcp.server.tools.name-pattern=^[A-Za-z0-9_.-]{1,128}$
 
 # Default Quarkus version for created projects (omit to use latest release)
 # Uncomment for local testing against a SNAPSHOT build:
@@ -64,3 +67,9 @@ quarkus.native.additional-build-args=\
 # Logging
 quarkus.log.level=INFO
 quarkus.log.category."io.quarkus.agent.mcp".level=DEBUG
+
+# Debugging
+#quarkus.log.file.enabled=true
+#quarkus.log.file.path=agent-mcp.log
+#quarkus.mcp.server.traffic-logging.enabled=true 
+#quarkus.mcp.server.traffic-logging.text-limit=5000


### PR DESCRIPTION
- renamed all MCP tool names from slash to underscore to follow the spec rules: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-names
- replaced non-ASCII characters in descriptions
- added title to Tool.Annotations as a workaround until https://github.com/quarkiverse/quarkus-mcp-server/issues/748 is resolved