### PR TITLE
perf: load skill content lazily — only when needed

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -100,11 +100,16 @@ public class DevMcpProxyTools {
                     + "Examples: 'panache', 'rest', 'security', 'kafka'. "
                     + "If omitted, lists all available skills with their descriptions.", required = false) String query) {
         try {
-            List<SkillReader.SkillInfo> skills = SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null));
+            Path effectiveLocalDir = localSkillsDir.map(Path::of).orElse(null);
+            String queryLower = (query != null && !query.isBlank()) ? query.toLowerCase() : null;
+            boolean needsContent = queryLower != null;
+
+            // When a query is provided we need full content; otherwise read metadata only
+            List<SkillReader.SkillInfo> skills = SkillReader.readSkills(projectDir, effectiveLocalDir, !needsContent);
 
             // If no skills found, check if the app is still building and wait for it
             if (skills.isEmpty()) {
-                skills = waitForBuildAndRetry(projectDir);
+                skills = waitForBuildAndRetry(projectDir, !needsContent);
             }
 
             if (skills.isEmpty()) {
@@ -112,8 +117,6 @@ public class DevMcpProxyTools {
                         "No extension skills found. Ensure the project has been built at least once "
                                 + "and uses Quarkus extensions that provide skill files.");
             }
-
-            String queryLower = (query != null && !query.isBlank()) ? query.toLowerCase() : null;
 
             // Filter by query if provided
             List<SkillReader.SkillInfo> matched = skills;
@@ -128,28 +131,34 @@ public class DevMcpProxyTools {
                 return ToolResponse.success("No skills found matching: " + query);
             }
 
-            // If query matched or only one skill, return full content
-            if (queryLower != null || matched.size() == 1) {
+            // Multiple skills and no query — return summary list (no content needed)
+            if (queryLower == null && matched.size() > 1) {
                 StringBuilder sb = new StringBuilder();
+                sb.append("Available extension skills (use query parameter to read a specific skill):\n\n");
                 for (SkillReader.SkillInfo skill : matched) {
-                    if (!sb.isEmpty()) {
-                        sb.append("\n---\n\n");
+                    sb.append("- **").append(skill.name()).append("**");
+                    if (skill.description() != null) {
+                        sb.append(": ").append(skill.description());
                     }
-                    sb.append("# ").append(skill.name()).append("\n\n");
-                    sb.append(skill.content());
+                    sb.append("\n");
                 }
                 return ToolResponse.success(sb.toString());
             }
 
-            // Multiple skills and no query — return summary list
+            // Single skill without query — we only read metadata, so re-read with content
+            if (!needsContent) {
+                skills = SkillReader.readSkills(projectDir, effectiveLocalDir, false);
+                matched = skills;
+            }
+
+            // Return full content for matched skills
             StringBuilder sb = new StringBuilder();
-            sb.append("Available extension skills (use query parameter to read a specific skill):\n\n");
             for (SkillReader.SkillInfo skill : matched) {
-                sb.append("- **").append(skill.name()).append("**");
-                if (skill.description() != null) {
-                    sb.append(": ").append(skill.description());
+                if (!sb.isEmpty()) {
+                    sb.append("\n---\n\n");
                 }
-                sb.append("\n");
+                sb.append("# ").append(skill.name()).append("\n\n");
+                sb.append(skill.content());
             }
             return ToolResponse.success(sb.toString());
         } catch (Exception e) {
@@ -162,7 +171,7 @@ public class DevMcpProxyTools {
      * If the app is still building (STARTING state), wait for it to reach RUNNING
      * so that deployment JARs are available in the local Maven repository, then retry.
      */
-    private List<SkillReader.SkillInfo> waitForBuildAndRetry(String projectDir) {
+    private List<SkillReader.SkillInfo> waitForBuildAndRetry(String projectDir, boolean metadataOnly) {
         QuarkusInstance instance = processManager.getInstance(projectDir);
         if (instance == null || instance.getStatus() != QuarkusInstance.Status.STARTING) {
             return List.of();
@@ -173,7 +182,7 @@ public class DevMcpProxyTools {
             return List.of();
         }
         // RUNNING or timed out (still STARTING) — try reading skills either way
-        return SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null));
+        return SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null), metadataOnly);
     }
 
     @Tool(name = "quarkus/updateSkill", description = "Create or update a skill customization for a Quarkus extension. "

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -84,7 +84,7 @@ public final class SkillReader {
      * @see #readSkills(String, Path)
      */
     public static List<SkillInfo> readSkills(String projectDir) {
-        return readSkills(projectDir, null);
+        return readSkills(projectDir, null, false);
     }
 
     /**
@@ -95,6 +95,18 @@ public final class SkillReader {
      * @return list of available skills, never null
      */
     public static List<SkillInfo> readSkills(String projectDir, Path localSkillsDir) {
+        return readSkills(projectDir, localSkillsDir, false);
+    }
+
+    /**
+     * Reads available skills for a project using the three-layer override chain.
+     *
+     * @param projectDir     the absolute path to the Quarkus project
+     * @param localSkillsDir optional user-level directory to scan for SKILL.md files, or null for the default
+     * @param metadataOnly   if true, only extract frontmatter (name, description, mode) — content will be null
+     * @return list of available skills, never null
+     */
+    public static List<SkillInfo> readSkills(String projectDir, Path localSkillsDir, boolean metadataOnly) {
         // Use a map keyed by skill name so each layer can override the previous
         Map<String, SkillInfo> skillsByName = new LinkedHashMap<>();
 
@@ -111,7 +123,7 @@ public final class SkillReader {
 
             if (jarPath != null) {
                 try {
-                    for (SkillInfo skill : readSkillsFromJar(jarPath)) {
+                    for (SkillInfo skill : readSkillsFromJar(jarPath, metadataOnly)) {
                         skillsByName.put(skill.name(), skill);
                     }
                 } catch (IOException e) {
@@ -124,12 +136,12 @@ public final class SkillReader {
 
         // Layer 2: Overlay user-level skills (~/.quarkus/skills/ or configured dir)
         Path effectiveLocalDir = localSkillsDir != null ? localSkillsDir : DEFAULT_LOCAL_SKILLS_DIR;
-        overlaySkills(skillsByName, readLocalSkills(effectiveLocalDir), effectiveLocalDir.toString());
+        overlaySkills(skillsByName, readLocalSkills(effectiveLocalDir, metadataOnly), effectiveLocalDir.toString());
 
         // Layer 3: Overlay project-level skills (.quarkus/skills/)
         if (projectDir != null) {
             Path projectSkillsDir = Path.of(projectDir, ".quarkus", "skills");
-            overlaySkills(skillsByName, readLocalSkills(projectSkillsDir), projectSkillsDir.toString());
+            overlaySkills(skillsByName, readLocalSkills(projectSkillsDir, metadataOnly), projectSkillsDir.toString());
         }
 
         LOG.infof("Found %d skills for project %s (version %s)",
@@ -142,7 +154,7 @@ public final class SkillReader {
             if (target.containsKey(skill.name())) {
                 if (skill.mode() == SkillMode.ENHANCE) {
                     SkillInfo base = target.get(skill.name());
-                    String mergedContent = base.content() + "\n\n---\n\n" + skill.content();
+                    String mergedContent = mergeContent(base.content(), skill.content());
                     String desc = skill.description() != null ? skill.description() : base.description();
                     target.put(skill.name(), new SkillInfo(skill.name(), desc, mergedContent, SkillMode.ENHANCE));
                     LOG.infof("Skill '%s' enhanced by %s", skill.name(), source);
@@ -162,20 +174,44 @@ public final class SkillReader {
         }
     }
 
+    private static String mergeContent(String base, String overlay) {
+        if (base == null && overlay == null) {
+            return null;
+        }
+        if (base == null) {
+            return overlay;
+        }
+        if (overlay == null) {
+            return base;
+        }
+        return base + "\n\n---\n\n" + overlay;
+    }
+
     /**
      * Parses the YAML frontmatter from a SKILL.md file content.
      */
     static SkillInfo parseFrontmatter(String fullContent) {
+        return parseFrontmatter(fullContent, false);
+    }
+
+    /**
+     * Parses the YAML frontmatter from a SKILL.md file content.
+     *
+     * @param metadataOnly if true, only extract name/description/mode — content will be null
+     */
+    static SkillInfo parseFrontmatter(String fullContent, boolean metadataOnly) {
         String name = "unknown";
         String description = null;
-        String body = fullContent;
+        String body = metadataOnly ? null : fullContent;
         SkillMode mode = SkillMode.ENHANCE;
 
         if (fullContent.startsWith("---")) {
             int endIdx = fullContent.indexOf("---", 3);
             if (endIdx > 0) {
                 String frontmatter = fullContent.substring(3, endIdx);
-                body = fullContent.substring(endIdx + 3).trim();
+                if (!metadataOnly) {
+                    body = fullContent.substring(endIdx + 3).trim();
+                }
 
                 Matcher nameMatcher = FRONTMATTER_NAME.matcher(frontmatter);
                 if (nameMatcher.find()) {
@@ -201,6 +237,15 @@ public final class SkillReader {
      * Reads all SKILL.md files from a single JAR.
      */
     static List<SkillInfo> readSkillsFromJar(Path jarPath) throws IOException {
+        return readSkillsFromJar(jarPath, false);
+    }
+
+    /**
+     * Reads SKILL.md files from a single JAR.
+     *
+     * @param metadataOnly if true, only extract frontmatter — content will be null
+     */
+    static List<SkillInfo> readSkillsFromJar(Path jarPath, boolean metadataOnly) throws IOException {
         List<SkillInfo> skills = new ArrayList<>();
         try (JarFile jar = new JarFile(jarPath.toFile())) {
             Enumeration<JarEntry> entries = jar.entries();
@@ -212,7 +257,7 @@ public final class SkillReader {
                         && !entry.isDirectory()) {
                     try (InputStream is = jar.getInputStream(entry)) {
                         String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-                        skills.add(parseFrontmatter(content));
+                        skills.add(parseFrontmatter(content, metadataOnly));
                     }
                 }
             }
@@ -230,6 +275,17 @@ public final class SkillReader {
      * @return list of locally found skills, never null
      */
     static List<SkillInfo> readLocalSkills(Path skillsDir) {
+        return readLocalSkills(skillsDir, false);
+    }
+
+    /**
+     * Reads SKILL.md files from a local directory.
+     *
+     * @param skillsDir    the directory to scan for SKILL.md files
+     * @param metadataOnly if true, only extract frontmatter — content will be null
+     * @return list of locally found skills, never null
+     */
+    static List<SkillInfo> readLocalSkills(Path skillsDir, boolean metadataOnly) {
         if (!Files.isDirectory(skillsDir)) {
             return List.of();
         }
@@ -242,7 +298,7 @@ public final class SkillReader {
                     if (file.getFileName().toString().equals(SKILL_FILE_NAME)) {
                         try {
                             String content = Files.readString(file, StandardCharsets.UTF_8);
-                            SkillInfo skill = parseFrontmatter(content);
+                            SkillInfo skill = parseFrontmatter(content, metadataOnly);
                             skills.add(skill);
                             LOG.debugf("Found local skill '%s' at %s", skill.name(), file);
                         } catch (IOException e) {

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -627,6 +627,120 @@ class SkillReaderTest {
         assertTrue(content.contains("description: \"A \\\"quoted\\\" description\""));
     }
 
+    // --- Metadata-only (lazy content) tests ---
+
+    @Test
+    void parseFrontmatterMetadataOnlyReturnsNullContent() {
+        String content = """
+                ---
+                name: quarkus-rest
+                description: "REST extension"
+                mode: enhance
+                ---
+
+                ### REST Endpoints
+                Use @Path and @GET for endpoints.
+                """;
+
+        SkillReader.SkillInfo info = SkillReader.parseFrontmatter(content, true);
+
+        assertEquals("quarkus-rest", info.name());
+        assertEquals("REST extension", info.description());
+        assertNull(info.content());
+        assertEquals(SkillReader.SkillMode.ENHANCE, info.mode());
+    }
+
+    @Test
+    void readSkillsFromJarMetadataOnlyReturnsNullContent() throws Exception {
+        Path jarPath = tempDir.resolve("skills.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/quarkus-rest/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: quarkus-rest
+                    description: "REST extension"
+                    ---
+
+                    ### REST Endpoints
+                    Use @Path.
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readSkillsFromJar(jarPath, true);
+
+        assertEquals(1, skills.size());
+        assertEquals("quarkus-rest", skills.get(0).name());
+        assertEquals("REST extension", skills.get(0).description());
+        assertNull(skills.get(0).content());
+    }
+
+    @Test
+    void readLocalSkillsMetadataOnlyReturnsNullContent() throws Exception {
+        Path skillsDir = tempDir.resolve("skills");
+        Path restDir = skillsDir.resolve("quarkus-rest");
+        Files.createDirectories(restDir);
+        Files.writeString(restDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                description: "Local REST skill"
+                ---
+
+                ### Local REST
+                Local content.
+                """);
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readLocalSkills(skillsDir, true);
+
+        assertEquals(1, skills.size());
+        assertEquals("quarkus-rest", skills.get(0).name());
+        assertEquals("Local REST skill", skills.get(0).description());
+        assertNull(skills.get(0).content());
+    }
+
+    @Test
+    void enhanceModeMetadataOnlyMergesDescriptionNotContent() throws Exception {
+        Path jarPath = tempDir.resolve("skills.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/quarkus-rest/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: quarkus-rest
+                    description: "Base description"
+                    ---
+
+                    ### Base content
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        Path skillsDir = tempDir.resolve("local-skills/quarkus-rest");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                description: "Enhanced description"
+                mode: enhance
+                ---
+
+                ### Enhanced content
+                """);
+
+        List<SkillReader.SkillInfo> base = SkillReader.readSkillsFromJar(jarPath, true);
+        java.util.Map<String, SkillReader.SkillInfo> skillMap = new java.util.LinkedHashMap<>();
+        for (SkillReader.SkillInfo s : base) {
+            skillMap.put(s.name(), s);
+        }
+
+        List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local-skills"), true);
+        SkillReader.overlaySkills(skillMap, local, "local-skills");
+
+        SkillReader.SkillInfo result = skillMap.get("quarkus-rest");
+        assertNotNull(result);
+        assertEquals("Enhanced description", result.description());
+        assertNull(result.content());
+    }
+
     @Test
     void skillModeFromStringDefaultsToEnhance() {
         assertEquals(SkillReader.SkillMode.ENHANCE, SkillReader.SkillMode.fromString(null));


### PR DESCRIPTION
The `quarkus/skills` tool previously read full markdown bodies of all skills from JAR and local directories on every call, even when only a summary list of names and descriptions was returned to the client.

This adds a `metadataOnly` flag through the entire read chain (`parseFrontmatter`, `readSkillsFromJar`, `readLocalSkills`, `readSkills`, `overlaySkills`) so the listing path extracts only frontmatter (name, description, mode) and skips body content entirely. Full content is now loaded only when a query narrows the result or a single skill needs to be returned.

The overlay merge logic is also made null-safe for content via a `mergeContent` helper, so metadata-only mode correctly merges descriptions without attempting to concatenate null bodies.