### PR TITLE
fix(.mcp.json): wrap server entries in mcpServers key

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,10 @@
 {
-  "quarkus-agent": {
-    "command": "jbang",
-    "args": ["quarkus-agent-mcp@quarkusio"]
+  "mcpServers": {
+    "quarkus-agent": {
+      "command": "jbang",
+      "args": [
+        "quarkus-agent-mcp@quarkusio"
+      ]
+    }
   }
 }

--- a/plugins/quarkus-agent/.mcp.json
+++ b/plugins/quarkus-agent/.mcp.json
@@ -1,6 +1,10 @@
 {
-  "quarkus-agent": {
-    "command": "jbang",
-    "args": ["quarkus-agent-mcp@quarkusio"]
+  "mcpServers": {
+    "quarkus-agent": {
+      "command": "jbang",
+      "args": [
+        "quarkus-agent-mcp@quarkusio"
+      ]
+    }
   }
 }


### PR DESCRIPTION
The `.mcp.json` files in this repo declare the MCP server directly at the top level:

```json
{
  "quarkus-agent": {
    "command": "jbang",
    "args": ["quarkus-agent-mcp@quarkusio"]
  }
}
```

The Claude Code plugin format expects server entries nested under an `mcpServers` key:

```json
{
  "mcpServers": {
    "quarkus-agent": {
      "command": "jbang",
      "args": ["quarkus-agent-mcp@quarkusio"]
    }
  }
}
```

Without that wrapper, `claude plugin install` loads the plugin but doesn't register the MCP server, so the `quarkus-agent` tools aren't available to the model after install. This PR adds the wrapper to both:

- `.mcp.json` (repo root)
- `plugins/quarkus-agent/.mcp.json` (the one `marketplace.json` points to)

Ref: https://docs.anthropic.com/en/docs/claude-code/plugins#mcp-servers

No other changes — `plugin.json`, `marketplace.json`, skills, and the MCP server itself are untouched.
