### PR TITLE
feat: categorized skill index for agent discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ replay_pid*
 
 # Agents
 .claude
+.cachebro/

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -1,5 +1,12 @@
 package io.quarkus.agent.mcp;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -7,23 +14,15 @@ import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
-
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.quarkiverse.mcp.server.Tool;
-import io.quarkiverse.mcp.server.ToolArg;
-import io.quarkiverse.mcp.server.ToolResponse;
-import jakarta.inject.Inject;
 
 /**
  * MCP tools that proxy requests to a running Quarkus application's Dev MCP server.
@@ -34,6 +33,25 @@ public class DevMcpProxyTools {
     private static final Logger LOG = Logger.getLogger(DevMcpProxyTools.class);
 
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+    static final List<String> CATEGORY_ORDER = List.of(
+            "web", "data", "security", "core", "messaging", "observability",
+            "cloud", "reactive", "serialization", "compatibility", "ai", "alt-languages", "miscellaneous");
+
+    private static final Set<String> ACRONYMS = Set.of("ai", "api", "cdi", "jpa", "ui");
+
+    static final Map<String, String> DEFAULT_CATEGORIES = Map.ofEntries(
+            Map.entry("quarkus-rest", "web"),
+            Map.entry("quarkus-rest-client", "web"),
+            Map.entry("quarkus-smallrye-openapi", "web"),
+            Map.entry("quarkus-web-dependency-locator", "web"),
+            Map.entry("quarkus-hibernate-orm", "data"),
+            Map.entry("quarkus-hibernate-orm-panache", "data"),
+            Map.entry("quarkus-hibernate-validator", "data"),
+            Map.entry("quarkus-oidc", "security"),
+            Map.entry("quarkus-security", "security"),
+            Map.entry("quarkus-arc", "core"),
+            Map.entry("quarkus-scheduler", "core"));
 
     private final AtomicLong requestId = new AtomicLong(0);
 
@@ -137,18 +155,9 @@ public class DevMcpProxyTools {
                 return ToolResponse.success("No skills found matching: " + query);
             }
 
-            // Multiple skills and no query — return summary list (no content needed)
+            // Multiple skills and no query — return categorized index
             if (queryLower == null && matched.size() > 1) {
-                StringBuilder sb = new StringBuilder();
-                sb.append("Available extension skills (use query parameter to read a specific skill):\n\n");
-                for (SkillReader.SkillInfo skill : matched) {
-                    sb.append("- **").append(skill.name()).append("**");
-                    if (skill.description() != null) {
-                        sb.append(": ").append(skill.description());
-                    }
-                    sb.append("\n");
-                }
-                return ToolResponse.success(sb.toString());
+                return ToolResponse.success(formatSkillIndex(matched));
             }
 
             // Single skill without query — we only read metadata, so re-read with content
@@ -191,6 +200,70 @@ public class DevMcpProxyTools {
         return SkillReader.readSkills(projectDir, localSkillsDir.map(Path::of).orElse(null), metadataOnly);
     }
 
+    static String formatSkillIndex(List<SkillReader.SkillInfo> skills) {
+        Map<String, List<SkillReader.SkillInfo>> grouped = new LinkedHashMap<>();
+        for (SkillReader.SkillInfo skill : skills) {
+            for (String category : resolveCategories(skill)) {
+                grouped.computeIfAbsent(category, k -> new ArrayList<>()).add(skill);
+            }
+        }
+
+        // Known categories first in defined order, then any unknown alphabetically
+        List<String> sortedCategories = new ArrayList<>();
+        Set<String> added = new HashSet<>();
+        for (String cat : CATEGORY_ORDER) {
+            if (grouped.containsKey(cat)) {
+                sortedCategories.add(cat);
+                added.add(cat);
+            }
+        }
+        grouped.keySet().stream()
+                .filter(c -> !added.contains(c))
+                .sorted()
+                .forEach(sortedCategories::add);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Available extension skills (use query parameter to read a specific skill):\n");
+        for (String category : sortedCategories) {
+            sb.append("\n### ").append(titleCase(category)).append("\n");
+            for (SkillReader.SkillInfo skill : grouped.get(category)) {
+                sb.append("- **").append(skill.name()).append("**");
+                if (skill.description() != null) {
+                    sb.append(": ").append(skill.description());
+                }
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    static List<String> resolveCategories(SkillReader.SkillInfo skill) {
+        if (skill.categories() != null && !skill.categories().isEmpty()) {
+            return skill.categories();
+        }
+        String defaultCat = DEFAULT_CATEGORIES.get(skill.name());
+        return List.of(defaultCat != null ? defaultCat : "miscellaneous");
+    }
+
+    static String titleCase(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        String[] parts = value.split("-");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            if (i > 0) {
+                sb.append("-");
+            }
+            if (ACRONYMS.contains(parts[i])) {
+                sb.append(parts[i].toUpperCase());
+            } else {
+                sb.append(Character.toUpperCase(parts[i].charAt(0))).append(parts[i].substring(1));
+            }
+        }
+        return sb.toString();
+    }
+
     @Tool(name = "quarkus_updateSkill", description = "Create or update a skill customization for a Quarkus extension. "
             + "Use this when the user wants to add project conventions, team standards, or guardrails to an extension skill. "
             + "IMPORTANT: Before writing, ask the user two questions: "
@@ -206,6 +279,7 @@ public class DevMcpProxyTools {
             @ToolArg(description = "The extension skill name (e.g. 'quarkus-rest', 'quarkus-hibernate-orm-panache')") String skillName,
             @ToolArg(description = "The skill content in markdown (without frontmatter -- it will be generated)") String content,
             @ToolArg(description = "Optional description for the skill", required = false) String description,
+            @ToolArg(description = "Optional comma-separated categories for the skill index (e.g. 'web', 'data', 'security', 'core')", required = false) String categories,
             @ToolArg(description = "Mode: 'enhance' (default) appends to the base skill, 'override' fully replaces it", required = false) String mode,
             @ToolArg(description = "Scope: 'project' (default) saves under .quarkus/skills/ in the project, "
                     + "'global' saves under ~/.quarkus/skills/", required = false) String scope) {
@@ -213,8 +287,9 @@ public class DevMcpProxyTools {
             SkillReader.SkillMode skillMode = SkillReader.SkillMode.fromString(mode);
             boolean projectScope = !"global".equalsIgnoreCase(scope);
 
+            List<String> parsedCategories = categories != null ? SkillReader.parseCategories(categories) : null;
             Path written = SkillReader.writeSkill(
-                    skillName, content, description, skillMode,
+                    skillName, content, description, parsedCategories, skillMode,
                     projectDir, localSkillsDir.map(Path::of).orElse(null), projectScope);
 
             String modeLabel = skillMode == SkillReader.SkillMode.ENHANCE ? "enhance" : "override";

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -55,7 +55,8 @@ public final class SkillReader {
     private static final Pattern FRONTMATTER_NAME = Pattern.compile("^name:\\s*(.+)$", Pattern.MULTILINE);
     private static final Pattern FRONTMATTER_DESC = Pattern.compile("^description:\\s*\"(.+)\"$", Pattern.MULTILINE);
     private static final Pattern FRONTMATTER_MODE = Pattern.compile("^mode:\\s*(\\S+)", Pattern.MULTILINE);
-
+    private static final Pattern FRONTMATTER_CATEGORIES = Pattern.compile(
+            "^categor(?:y|ies):\\s*\"?([^\"\\n]+?)\"?\\s*$", Pattern.MULTILINE);
 
     public enum SkillMode {
         ENHANCE,
@@ -69,7 +70,7 @@ public final class SkillReader {
         }
     }
 
-    public record SkillInfo(String name, String description, String content, SkillMode mode) {
+    public record SkillInfo(String name, String description, String content, SkillMode mode, List<String> categories) {
     }
 
     private SkillReader() {
@@ -156,7 +157,10 @@ public final class SkillReader {
                     SkillInfo base = target.get(skill.name());
                     String mergedContent = mergeContent(base.content(), skill.content());
                     String desc = skill.description() != null ? skill.description() : base.description();
-                    target.put(skill.name(), new SkillInfo(skill.name(), desc, mergedContent, SkillMode.ENHANCE));
+                    List<String> cats = skill.categories() != null && !skill.categories().isEmpty()
+                            ? skill.categories()
+                            : base.categories();
+                    target.put(skill.name(), new SkillInfo(skill.name(), desc, mergedContent, SkillMode.ENHANCE, cats));
                     LOG.infof("Skill '%s' enhanced by %s", skill.name(), source);
                 } else {
                     target.put(skill.name(), skill);
@@ -204,6 +208,7 @@ public final class SkillReader {
         String description = null;
         String body = metadataOnly ? null : fullContent;
         SkillMode mode = SkillMode.ENHANCE;
+        List<String> categories = null;
 
         if (fullContent.startsWith("---")) {
             int endIdx = fullContent.indexOf("---", 3);
@@ -227,10 +232,26 @@ public final class SkillReader {
                 if (modeMatcher.find()) {
                     mode = SkillMode.fromString(modeMatcher.group(1));
                 }
+
+                Matcher catMatcher = FRONTMATTER_CATEGORIES.matcher(frontmatter);
+                if (catMatcher.find()) {
+                    categories = parseCategories(catMatcher.group(1).trim());
+                }
             }
         }
 
-        return new SkillInfo(name, description, body, mode);
+        return new SkillInfo(name, description, body, mode, categories);
+    }
+
+    static List<String> parseCategories(String value) {
+        List<String> result = new ArrayList<>();
+        for (String part : value.split(",")) {
+            String trimmed = part.trim().toLowerCase();
+            if (!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        return result.isEmpty() ? null : List.copyOf(result);
     }
 
     /**
@@ -320,6 +341,7 @@ public final class SkillReader {
      * @param skillName    the extension name (e.g. "quarkus-rest")
      * @param content      the markdown content (without frontmatter)
      * @param description  optional description for the frontmatter
+     * @param categories   optional list of categories for the skill index, or null
      * @param mode         ENHANCE or OVERRIDE
      * @param projectDir   the project directory (used for project-scope writes)
      * @param localSkillsDir user-level skills directory, or null for the default
@@ -327,7 +349,7 @@ public final class SkillReader {
      *                     false to write under the user-level directory
      * @return the path the file was written to
      */
-    static Path writeSkill(String skillName, String content, String description,
+    static Path writeSkill(String skillName, String content, String description, List<String> categories,
             SkillMode mode, String projectDir, Path localSkillsDir, boolean projectScope) throws IOException {
         if (skillName == null || !VALID_SKILL_NAME.matcher(skillName).matches()) {
             throw new IllegalArgumentException("Invalid skill name: " + skillName
@@ -349,6 +371,9 @@ public final class SkillReader {
         sb.append("name: ").append(skillName).append("\n");
         if (description != null && !description.isBlank()) {
             sb.append("description: \"").append(description.replace("\"", "\\\"")).append("\"\n");
+        }
+        if (categories != null && !categories.isEmpty()) {
+            sb.append("categories: \"").append(String.join(", ", categories)).append("\"\n");
         }
         sb.append("mode: ").append(mode.name().toLowerCase()).append("\n");
         sb.append("---\n\n");

--- a/src/test/java/io/quarkus/agent/mcp/DevMcpProxyToolsTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/DevMcpProxyToolsTest.java
@@ -1,0 +1,184 @@
+package io.quarkus.agent.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DevMcpProxyToolsTest {
+
+    @Test
+    void formatSkillIndexGroupsByCategory() {
+        List<SkillReader.SkillInfo> skills = List.of(
+                new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE,
+                        List.of("web")),
+                new SkillReader.SkillInfo("quarkus-hibernate-orm", "ORM extension", null, SkillReader.SkillMode.ENHANCE,
+                        List.of("data")),
+                new SkillReader.SkillInfo("quarkus-rest-client", "REST client", null, SkillReader.SkillMode.ENHANCE,
+                        List.of("web")));
+
+        String index = DevMcpProxyTools.formatSkillIndex(skills);
+
+        assertTrue(index.contains("### Web"));
+        assertTrue(index.contains("### Data"));
+        assertTrue(index.contains("- **quarkus-rest**: REST extension"));
+        assertTrue(index.contains("- **quarkus-rest-client**: REST client"));
+        assertTrue(index.contains("- **quarkus-hibernate-orm**: ORM extension"));
+        assertTrue(index.indexOf("### Web") < index.indexOf("### Data"));
+    }
+
+    @Test
+    void formatSkillIndexUsesDefaultCategoriesForUncategorizedSkills() {
+        List<SkillReader.SkillInfo> skills = List.of(
+                new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE, null),
+                new SkillReader.SkillInfo("quarkus-security", "Security framework", null,
+                        SkillReader.SkillMode.ENHANCE, null));
+
+        String index = DevMcpProxyTools.formatSkillIndex(skills);
+
+        assertTrue(index.contains("### Web"));
+        assertTrue(index.contains("### Security"));
+    }
+
+    @Test
+    void formatSkillIndexPutsUnknownSkillsInMiscellaneous() {
+        List<SkillReader.SkillInfo> skills = List.of(
+                new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE,
+                        List.of("web")),
+                new SkillReader.SkillInfo("quarkus-custom", "Custom extension", null, SkillReader.SkillMode.ENHANCE,
+                        null));
+
+        String index = DevMcpProxyTools.formatSkillIndex(skills);
+
+        assertTrue(index.contains("### Web"));
+        assertTrue(index.contains("### Miscellaneous"));
+        assertTrue(index.contains("- **quarkus-custom**: Custom extension"));
+    }
+
+    @Test
+    void formatSkillIndexOrdersCategoriesCorrectly() {
+        List<SkillReader.SkillInfo> skills = List.of(
+                new SkillReader.SkillInfo("s1", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("security")),
+                new SkillReader.SkillInfo("s2", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("core")),
+                new SkillReader.SkillInfo("s3", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("web")),
+                new SkillReader.SkillInfo("s4", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("data")));
+
+        String index = DevMcpProxyTools.formatSkillIndex(skills);
+
+        int webIdx = index.indexOf("### Web");
+        int dataIdx = index.indexOf("### Data");
+        int secIdx = index.indexOf("### Security");
+        int coreIdx = index.indexOf("### Core");
+        assertTrue(webIdx < dataIdx);
+        assertTrue(dataIdx < secIdx);
+        assertTrue(secIdx < coreIdx);
+    }
+
+    @Test
+    void formatSkillIndexFrontmatterCategoryOverridesDefault() {
+        List<SkillReader.SkillInfo> skills = List.of(
+                new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE,
+                        List.of("messaging")));
+
+        String index = DevMcpProxyTools.formatSkillIndex(skills);
+
+        assertTrue(index.contains("### Messaging"));
+        assertFalse(index.contains("### Web"));
+    }
+
+    @Test
+    void formatSkillIndexListsSkillUnderAllCategories() {
+        List<SkillReader.SkillInfo> skills = List.of(
+                new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE,
+                        List.of("web", "reactive")));
+
+        String index = DevMcpProxyTools.formatSkillIndex(skills);
+
+        assertTrue(index.contains("### Web"));
+        assertTrue(index.contains("### Reactive"));
+        int webSection = index.indexOf("### Web");
+        int reactiveSection = index.indexOf("### Reactive");
+        String webBlock = index.substring(webSection, reactiveSection);
+        assertTrue(webBlock.contains("- **quarkus-rest**: REST extension"));
+        String reactiveBlock = index.substring(reactiveSection);
+        assertTrue(reactiveBlock.contains("- **quarkus-rest**: REST extension"));
+    }
+
+    @Test
+    void formatSkillIndexMultiCategoryPreservesOrder() {
+        List<SkillReader.SkillInfo> skills = List.of(
+                new SkillReader.SkillInfo("quarkus-reactive-rest", "Reactive REST", null,
+                        SkillReader.SkillMode.ENHANCE, List.of("reactive", "web")),
+                new SkillReader.SkillInfo("quarkus-hibernate-orm", "ORM", null,
+                        SkillReader.SkillMode.ENHANCE, List.of("data")));
+
+        String index = DevMcpProxyTools.formatSkillIndex(skills);
+
+        int webIdx = index.indexOf("### Web");
+        int dataIdx = index.indexOf("### Data");
+        int reactiveIdx = index.indexOf("### Reactive");
+        assertTrue(webIdx < dataIdx);
+        assertTrue(dataIdx < reactiveIdx);
+    }
+
+    @Test
+    void formatSkillIndexOmitsDescriptionWhenNull() {
+        List<SkillReader.SkillInfo> skills = List.of(
+                new SkillReader.SkillInfo("quarkus-rest", null, null, SkillReader.SkillMode.ENHANCE, List.of("web")),
+                new SkillReader.SkillInfo("quarkus-arc", "CDI framework", null, SkillReader.SkillMode.ENHANCE,
+                        List.of("core")));
+
+        String index = DevMcpProxyTools.formatSkillIndex(skills);
+
+        assertTrue(index.contains("- **quarkus-rest**\n"));
+        assertFalse(index.contains("- **quarkus-rest**:"));
+        assertTrue(index.contains("- **quarkus-arc**: CDI framework"));
+    }
+
+    @Test
+    void resolveCategoriesReturnsAllExplicitCategories() {
+        SkillReader.SkillInfo skill = new SkillReader.SkillInfo("quarkus-rest", "REST", null,
+                SkillReader.SkillMode.ENHANCE, List.of("web", "reactive"));
+
+        assertEquals(List.of("web", "reactive"), DevMcpProxyTools.resolveCategories(skill));
+    }
+
+    @Test
+    void resolveCategoriesFallsBackToDefaultMap() {
+        SkillReader.SkillInfo skill = new SkillReader.SkillInfo("quarkus-rest", "REST", null,
+                SkillReader.SkillMode.ENHANCE, null);
+
+        assertEquals(List.of("web"), DevMcpProxyTools.resolveCategories(skill));
+    }
+
+    @Test
+    void resolveCategoriesReturnsMiscellaneousForUnknownSkill() {
+        SkillReader.SkillInfo skill = new SkillReader.SkillInfo("quarkus-custom", "Custom", null,
+                SkillReader.SkillMode.ENHANCE, null);
+
+        assertEquals(List.of("miscellaneous"), DevMcpProxyTools.resolveCategories(skill));
+    }
+
+    @Test
+    void titleCaseCapitalizesFirstLetter() {
+        assertEquals("Web", DevMcpProxyTools.titleCase("web"));
+        assertEquals("Core", DevMcpProxyTools.titleCase("core"));
+    }
+
+    @Test
+    void titleCaseCapitalizesEachHyphenatedSegment() {
+        assertEquals("Alt-Languages", DevMcpProxyTools.titleCase("alt-languages"));
+    }
+
+    @Test
+    void titleCaseUppercasesKnownAcronyms() {
+        assertEquals("AI", DevMcpProxyTools.titleCase("ai"));
+        assertEquals("API", DevMcpProxyTools.titleCase("api"));
+    }
+
+    @Test
+    void titleCaseHandlesNullAndEmpty() {
+        assertNull(DevMcpProxyTools.titleCase(null));
+        assertEquals("", DevMcpProxyTools.titleCase(""));
+    }
+}

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -546,6 +546,7 @@ class SkillReaderTest {
                 "quarkus-rest",
                 "### My custom patterns\nUse records for DTOs.",
                 "Custom REST skill",
+                null,
                 SkillReader.SkillMode.ENHANCE,
                 projectDir.toString(), null, true);
 
@@ -568,6 +569,7 @@ class SkillReaderTest {
                 "quarkus-rest",
                 "### Global patterns",
                 null,
+                null,
                 SkillReader.SkillMode.ENHANCE,
                 projectDir.toString(), globalDir, false);
 
@@ -587,6 +589,7 @@ class SkillReaderTest {
                 "quarkus-rest",
                 "### Full replacement",
                 "Override skill",
+                null,
                 SkillReader.SkillMode.OVERRIDE,
                 projectDir.toString(), null, true);
 
@@ -598,16 +601,16 @@ class SkillReaderTest {
     void writeSkillRejectsPathTraversal() {
         Path projectDir = tempDir.resolve("my-project");
         assertThrows(IllegalArgumentException.class, () -> SkillReader.writeSkill(
-                "../etc", "content", null, SkillReader.SkillMode.ENHANCE,
+                "../etc", "content", null, null, SkillReader.SkillMode.ENHANCE,
                 projectDir.toString(), null, true));
         assertThrows(IllegalArgumentException.class, () -> SkillReader.writeSkill(
-                "foo/bar", "content", null, SkillReader.SkillMode.ENHANCE,
+                "foo/bar", "content", null, null, SkillReader.SkillMode.ENHANCE,
                 projectDir.toString(), null, true));
         assertThrows(IllegalArgumentException.class, () -> SkillReader.writeSkill(
-                "foo\\bar", "content", null, SkillReader.SkillMode.ENHANCE,
+                "foo\\bar", "content", null, null, SkillReader.SkillMode.ENHANCE,
                 projectDir.toString(), null, true));
         assertThrows(IllegalArgumentException.class, () -> SkillReader.writeSkill(
-                null, "content", null, SkillReader.SkillMode.ENHANCE,
+                null, "content", null, null, SkillReader.SkillMode.ENHANCE,
                 projectDir.toString(), null, true));
     }
 
@@ -620,6 +623,7 @@ class SkillReaderTest {
                 "quarkus-rest",
                 "### Patterns",
                 "A \"quoted\" description",
+                null,
                 SkillReader.SkillMode.ENHANCE,
                 projectDir.toString(), null, true);
 
@@ -749,5 +753,216 @@ class SkillReaderTest {
         assertEquals(SkillReader.SkillMode.ENHANCE, SkillReader.SkillMode.fromString("anything-else"));
         assertEquals(SkillReader.SkillMode.OVERRIDE, SkillReader.SkillMode.fromString("override"));
         assertEquals(SkillReader.SkillMode.OVERRIDE, SkillReader.SkillMode.fromString("OVERRIDE"));
+    }
+
+    // --- Categories tests ---
+
+    @Test
+    void parseFrontmatterExtractsCategories() {
+        String content = """
+                ---
+                name: quarkus-rest
+                description: "REST extension"
+                categories: "web, reactive"
+                ---
+
+                ### REST
+                """;
+
+        SkillReader.SkillInfo info = SkillReader.parseFrontmatter(content);
+
+        assertEquals("quarkus-rest", info.name());
+        assertEquals(List.of("web", "reactive"), info.categories());
+    }
+
+    @Test
+    void parseFrontmatterExtractsSingleCategory() {
+        String content = """
+                ---
+                name: quarkus-rest
+                category: web
+                ---
+
+                ### REST
+                """;
+
+        SkillReader.SkillInfo info = SkillReader.parseFrontmatter(content);
+
+        assertEquals(List.of("web"), info.categories());
+    }
+
+    @Test
+    void parseFrontmatterExtractsCategoriesUnquoted() {
+        String content = """
+                ---
+                name: quarkus-rest
+                categories: web
+                ---
+
+                ### REST
+                """;
+
+        SkillReader.SkillInfo info = SkillReader.parseFrontmatter(content);
+
+        assertEquals(List.of("web"), info.categories());
+    }
+
+    @Test
+    void parseFrontmatterReturnsNullCategoriesWhenMissing() {
+        String content = """
+                ---
+                name: quarkus-rest
+                description: "REST extension"
+                ---
+
+                ### REST
+                """;
+
+        SkillReader.SkillInfo info = SkillReader.parseFrontmatter(content);
+
+        assertNull(info.categories());
+    }
+
+    @Test
+    void enhanceModeMergesCategories() throws Exception {
+        Path jarPath = tempDir.resolve("skills.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/quarkus-rest/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: quarkus-rest
+                    description: "REST extension"
+                    categories: "web, reactive"
+                    ---
+
+                    ### Base REST
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        Path skillsDir = tempDir.resolve("local-skills/quarkus-rest");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                mode: enhance
+                ---
+
+                ### Extra patterns
+                """);
+
+        List<SkillReader.SkillInfo> base = SkillReader.readSkillsFromJar(jarPath);
+        java.util.Map<String, SkillReader.SkillInfo> skillMap = new java.util.LinkedHashMap<>();
+        for (SkillReader.SkillInfo s : base) {
+            skillMap.put(s.name(), s);
+        }
+
+        List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local-skills"));
+        SkillReader.overlaySkills(skillMap, local, "local-skills");
+
+        assertEquals(List.of("web", "reactive"), skillMap.get("quarkus-rest").categories());
+    }
+
+    @Test
+    void enhanceModeOverlayCanOverrideCategories() throws Exception {
+        Path jarPath = tempDir.resolve("skills.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/quarkus-rest/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: quarkus-rest
+                    categories: "web"
+                    ---
+
+                    ### Base REST
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        Path skillsDir = tempDir.resolve("local-skills/quarkus-rest");
+        Files.createDirectories(skillsDir);
+        Files.writeString(skillsDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                categories: "messaging, reactive"
+                mode: enhance
+                ---
+
+                ### Extra patterns
+                """);
+
+        List<SkillReader.SkillInfo> base = SkillReader.readSkillsFromJar(jarPath);
+        java.util.Map<String, SkillReader.SkillInfo> skillMap = new java.util.LinkedHashMap<>();
+        for (SkillReader.SkillInfo s : base) {
+            skillMap.put(s.name(), s);
+        }
+
+        List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local-skills"));
+        SkillReader.overlaySkills(skillMap, local, "local-skills");
+
+        assertEquals(List.of("messaging", "reactive"), skillMap.get("quarkus-rest").categories());
+    }
+
+    @Test
+    void writeSkillIncludesCategories() throws Exception {
+        Path projectDir = tempDir.resolve("my-project");
+        Files.createDirectories(projectDir);
+
+        Path written = SkillReader.writeSkill(
+                "quarkus-rest",
+                "### Patterns",
+                "REST skill",
+                List.of("web", "reactive"),
+                SkillReader.SkillMode.ENHANCE,
+                projectDir.toString(), null, true);
+
+        String content = Files.readString(written);
+        assertTrue(content.contains("categories: \"web, reactive\""));
+    }
+
+    @Test
+    void writeSkillOmitsCategoriesWhenNull() throws Exception {
+        Path projectDir = tempDir.resolve("my-project");
+        Files.createDirectories(projectDir);
+
+        Path written = SkillReader.writeSkill(
+                "quarkus-rest",
+                "### Patterns",
+                "REST skill",
+                null,
+                SkillReader.SkillMode.ENHANCE,
+                projectDir.toString(), null, true);
+
+        String content = Files.readString(written);
+        assertFalse(content.contains("categories:"));
+    }
+
+    @Test
+    void parseCategoriesHandlesCommaSeparated() {
+        assertEquals(List.of("web", "reactive"), SkillReader.parseCategories("web, reactive"));
+        assertEquals(List.of("web"), SkillReader.parseCategories("web"));
+        assertNull(SkillReader.parseCategories("  "));
+    }
+
+    @Test
+    void parseCategoriesNormalizesToLowercase() {
+        assertEquals(List.of("web", "reactive"), SkillReader.parseCategories("Web, Reactive"));
+        assertEquals(List.of("data"), SkillReader.parseCategories("DATA"));
+    }
+
+    @Test
+    void parseFrontmatterNormalizesCategoriesToLowercase() {
+        String content = """
+                ---
+                name: quarkus-rest
+                categories: "Web, Reactive"
+                ---
+
+                ### REST
+                """;
+
+        SkillReader.SkillInfo info = SkillReader.parseFrontmatter(content);
+
+        assertEquals(List.of("web", "reactive"), info.categories());
     }
 }


### PR DESCRIPTION
When `quarkus_skills` is called without a query and multiple skills are available, the response is now organized by category (Web, Data, Security, Core, etc.) instead of a flat list. This makes it easier for agents to discover relevant skills at a glance and understand the landscape of available knowledge.

### How it works

A new optional `category` field in SKILL.md frontmatter lets skills self-categorize:

```yaml
---
name: quarkus-rest
description: "Build RESTful web services"
category: "Web"
---
```

For existing skills that don't have the field yet, a default category map provides immediate categorization of all 11 current skills. The frontmatter value takes precedence when present.

The categorized output looks like:

```
Available extension skills (use query parameter to read a specific skill):

### Web
- **quarkus-rest**: Build RESTful web services and APIs...
- **quarkus-rest-client**: Type-safe HTTP client for consuming REST APIs...

### Data
- **quarkus-hibernate-orm**: Object-relational mapping with JPA/Hibernate...

### Security
- **quarkus-oidc**: Secure applications with OpenID Connect...

### Core
- **quarkus-arc**: Build-time oriented CDI Lite implementation...
```

Categories are preserved through the three-layer override chain (JAR → user → project), and `quarkus_updateSkill` now accepts an optional `category` parameter.

Inspired by [Karpathy's LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) index pattern and [stalep/llm_knowledge](https://github.com/stalep/llm_knowledge) shared topic organization.

Closes #62