### PR TITLE
Generate .mcp.json in new projects for automatic MCP server discovery

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -169,6 +169,9 @@ public class CreateTools {
             // Generate AGENTS.md with Quarkus-specific instructions (and CLAUDE.md pointing to it)
             generateProjectInstructions(projectDir, extensions);
 
+            // Generate .mcp.json so tools like Claude Code auto-discover quarkus-agent-mcp
+            generateMcpConfig(projectDir);
+
             // Auto-start the app in dev mode
             try {
                 processManager.start(projectDir, buildTool);
@@ -528,6 +531,27 @@ public class CreateTools {
             LOG.debugf("Generated CLAUDE.md in %s", projectDir);
         } catch (IOException e) {
             LOG.warnf("Failed to generate project instructions in %s: %s", projectDir, e.getMessage());
+        }
+    }
+
+    private void generateMcpConfig(String projectDir) {
+        try {
+            String mcpJson = """
+                    {
+                      "mcpServers": {
+                        "quarkus-agent": {
+                          "command": "jbang",
+                          "args": [
+                            "quarkus-agent-mcp@quarkusio"
+                          ]
+                        }
+                      }
+                    }
+                    """;
+            Files.writeString(Path.of(projectDir, ".mcp.json"), mcpJson, StandardCharsets.UTF_8);
+            LOG.debugf("Generated .mcp.json in %s", projectDir);
+        } catch (IOException e) {
+            LOG.warnf("Failed to generate .mcp.json in %s: %s", projectDir, e.getMessage());
         }
     }
 }


### PR DESCRIPTION
When a new Quarkus project is created via `quarkus_create`, a `.mcp.json` file is now generated in the project root. This allows coding agents that support the convention to automatically discover and connect to the quarkus-agent-mcp server without manual setup.

Currently supported by Claude Code (natively) and Pi/pi.dev (via mcp-adapter). The `mcpServers` format is the de facto standard across the ecosystem, so additional tools are likely to adopt it. The file is harmless for tools that don't read it.

If a user already has `quarkus-agent` configured globally, the project-level config takes precedence with identical settings — no clash or duplicate servers.

Closes #66