### PR TITLE
Make subagent usage optional since not all coding agents support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Ask your agent to build a Quarkus application using natural language. The agent 
 >
 > **You:** Add a `Greeting` entity and a REST endpoint that stores and retrieves greetings
 >
-> **Agent:** _(writes the code following patterns from skills, then runs tests via a subagent using `quarkus_callTool`)_
+> **Agent:** _(writes the code following patterns from skills, then runs tests using `quarkus_callTool` — via a subagent if supported)_
 
 ### Development workflow
 
@@ -185,7 +185,7 @@ The MCP server guides the agent through the optimal Quarkus development workflow
 ```
 NEW PROJECT                           EXISTING PROJECT
 
-1. quarkus_create                     1. quarkus_update (via subagent)
+1. quarkus_create                     1. quarkus_update
    → scaffolds + auto-starts             → checks version, suggests upgrades
    → generates CLAUDE.md
                                       2. quarkus_start
@@ -197,9 +197,9 @@ NEW PROJECT                           EXISTING PROJECT
                                       4. quarkus_searchDocs
 4. Write code + tests                    → look up APIs, config
 
-5. Run tests (via subagent)           5. Write code + tests
+5. Run tests                          5. Write code + tests
    → quarkus_callTool
-   → devui-testing_runTests           6. Run tests (via subagent)
+   → devui-testing_runTests           6. Run tests
                                          → quarkus_callTool
 6. Iterate                               → devui-testing_runTests
 ```
@@ -208,7 +208,7 @@ NEW PROJECT                           EXISTING PROJECT
 
 - **Hot reload** is automatic in Quarkus dev mode — triggered on the next access (HTTP request or test run), not on file save.
 - **Skills before code** — the agent reads extension-specific skills to learn correct patterns, testing approaches, and common pitfalls before writing any code.
-- **Tests via subagents** — test execution is dispatched to a subagent so the main conversation stays responsive.
+- **Tests via subagents** — if your agent supports subagents, test execution can be dispatched to one so the main conversation stays responsive.
 - **The MCP server survives crashes** — if the app crashes due to a code error, the agent can use `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location) and fix it. Use `quarkus_logs` for broader context.
 - **CLAUDE.md** — every new project gets a `CLAUDE.md` with Quarkus-specific workflow instructions that guide the agent.
 

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -455,7 +455,7 @@ public class CreateTools {
 
                     ## Required Workflow
 
-                    1. **Use quarkus_update (via subagent) when returning to this project** -- checks if the Quarkus version is up-to-date and suggests upgrades.
+                    1. **Use quarkus_update (via a subagent if supported) when returning to this project** -- checks if the Quarkus version is up-to-date and suggests upgrades.
                     2. **Use quarkus_skills BEFORE writing any code or tests** -- it contains extension-specific patterns, testing approaches, and common pitfalls that prevent mistakes. Skills may also list **Available Dev MCP Tools** specific to each extension (e.g. OpenAPI schema retrieval, scheduler job management) -- use these via `quarkus_callTool`. Call this EVERY time you are about to add or modify a feature, not just at project creation.
                     3. **Use quarkus_searchDocs for Quarkus documentation** -- do NOT use generic documentation tools (Context7, web search). The Quarkus doc search is version-aware and more accurate.
                     4. **Use quarkus_searchTools to discover Dev MCP tools** on the running app for testing, config changes, and extension management. The tool list is **dynamic** -- it changes when extensions are added or removed. Re-call `quarkus_searchTools` after any extension change to discover newly available tools. Note: some extension-specific tools are also documented in the skills output (see step 2).
@@ -476,10 +476,10 @@ public class CreateTools {
 
                     ## Testing
 
-                    ALWAYS run tests using a **subagent** so the main conversation stays responsive:
+                    If your agent supports subagents, run tests in a **subagent** so the main conversation stays responsive:
 
                     ```
-                    Use the Agent tool to launch a subagent with this prompt:
+                    If supported, use the Agent tool to launch a subagent with this prompt:
                       "Run the Quarkus tests for project <projectDir> using quarkus_callTool
                        with toolName 'devui-testing_runTests'. Analyze the results and report
                        which tests passed, failed, or errored. If tests fail, include the
@@ -489,7 +489,7 @@ public class CreateTools {
                     - Use `devui-testing_runTests` to run all tests.
                     - Use `devui-testing_runTest` with arguments `{"className":"com.example.MyTest"}` to run a specific test class.
                     - Do NOT run Maven/Gradle test commands manually -- the Dev MCP test tools handle compilation, hot reload, and result reporting.
-                    - After fixing test failures, re-run tests with a subagent to verify the fix.
+                    - After fixing test failures, re-run tests (via a subagent if supported) to verify the fix.
 
                     ## Error Handling
 

--- a/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
@@ -44,7 +44,7 @@ public class UpdateTools {
     @Tool(name = "quarkus_update", description = "Check if a Quarkus project is up-to-date and provide an upgrade report. "
             + "Detects the current version, checks for newer releases, compares build files against "
             + "reference projects, and optionally runs 'quarkus update --dry-run' to preview migrations. "
-            + "IMPORTANT: For existing Quarkus projects, ALWAYS call this tool using a subagent BEFORE "
+            + "IMPORTANT: For existing Quarkus projects, ALWAYS call this tool (via a subagent if supported) BEFORE "
             + "starting any development work to ensure the project is on the latest version.",
             // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
             // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,14 +13,14 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   4. quarkus_searchTools -- discover Dev MCP tools on the running app (testing, config, extensions)\n\
   5. quarkus_callTool -- invoke discovered tools (run tests, add extensions, update config)\n\n\
   WORKFLOW for existing projects:\n\
-  1. quarkus_update -- ALWAYS call first (via a subagent) to check if the project is up-to-date and suggest upgrades\n\
+  1. quarkus_update -- ALWAYS call first (via a subagent if supported) to check if the project is up-to-date and suggest upgrades\n\
   2. quarkus_start -- start the app in dev mode if not running\n\
   3. quarkus_skills -- MUST call before writing code to learn extension-specific patterns\n\
   4. quarkus_searchDocs -- look up Quarkus APIs and configuration\n\
   5. Write code following the patterns from skills and docs\n\
   6. quarkus_searchTools + quarkus_callTool -- run tests, manage extensions\n\n\
   TESTING:\n\
-  - ALWAYS run tests using a subagent (via the Agent tool) so the main conversation stays responsive\n\
+  - If your agent supports subagents, run tests in a subagent so the main conversation stays responsive\n\
   - Use quarkus_callTool with toolName 'devui-testing_runTests' to run all tests\n\
   - Use quarkus_callTool with toolName 'devui-testing_runTest' and toolArguments '{"className":"com.example.MyTest"}' to run a specific test\n\
   - Do NOT run Maven/Gradle test commands manually\n\n\


### PR DESCRIPTION
The instructions and documentation currently treat subagent dispatch as a hard requirement (e.g. "ALWAYS run tests using a subagent"). Not all coding agents support subagents — this is a Claude Code / Agent tool concept.

This softens all 12 occurrences across README, MCP server instructions, tool descriptions, and the generated AGENTS.md to use qualifying language like "if supported" or "if your agent supports subagents", making the guidance applicable to any MCP-compatible coding agent.

Closes #69