### PR TITLE
Upgrade Testcontainers to 2.x to fix Docker detection on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <langchain4j.version>1.12.2-beta22</langchain4j.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
-        <testcontainers.version>1.21.3</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
     </properties>
 
     <dependencyManagement>
@@ -103,7 +103,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <version>${testcontainers.version}</version>
         </dependency>
         <!-- Required for native image: docker-java's shaded HTTP client references


### PR DESCRIPTION
Testcontainers 1.x uses docker-java with API version 1.32, which Docker Engine 29+ rejects (minimum is now 1.44). On Windows with Docker Desktop, this causes `DockerClientFactory` to fail with a `BadRequestException` containing a zeroed-out `Info` response, disabling the documentation search feature entirely.

Testcontainers 2.x ships `docker-java:3.7.1` which properly negotiates the Docker API version. No Java code changes are needed — the project only uses `GenericContainer`, `DockerClientFactory`, `DockerImageName`, and `Wait`, all of which have the same API in 2.x. The only pom.xml changes are the version bump and the postgresql module artifact rename (`postgresql` → `testcontainers-postgresql`), which was renamed in the 2.0 release.

Closes #77