### PR TITLE
Allow configuring the Maven and Gradle commands used to start dev mode

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -7,8 +7,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.logging.Logger;
 
@@ -25,6 +27,12 @@ public class QuarkusProcessManager {
 
     @Inject
     ManagedExecutor executor;
+
+    @ConfigProperty(name = "agent-mcp.process.mvn-cmd")
+    Optional<String> mvnCmd;
+
+    @ConfigProperty(name = "agent-mcp.process.gradle-cmd")
+    Optional<String> gradleCmd;
 
     private static final Set<String> VALID_BUILD_TOOLS = Set.of("maven", "gradle");
 
@@ -153,26 +161,34 @@ public class QuarkusProcessManager {
     }
 
     private ProcessBuilder createMavenProcessBuilder(File projectDir) {
-        String mvnCmd;
-        File wrapper = isWindows() ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
-        if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
-            mvnCmd = isWindows() ? "mvnw.cmd" : "./mvnw";
+        String cmd;
+        if (mvnCmd.isPresent()) {
+            cmd = mvnCmd.get();
         } else {
-            mvnCmd = "mvn";
+            File wrapper = isWindows() ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
+            if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
+                cmd = isWindows() ? "mvnw.cmd" : "./mvnw";
+            } else {
+                cmd = "mvn";
+            }
         }
-        return new ProcessBuilder(mvnCmd, "quarkus:dev", "-Dquarkus.console.basic=true",
+        return new ProcessBuilder(cmd, "quarkus:dev", "-Dquarkus.console.basic=true",
                 "-Dquarkus.dev-mcp.enabled=true");
     }
 
     private ProcessBuilder createGradleProcessBuilder(File projectDir) {
-        String gradleCmd;
-        File wrapper = isWindows() ? new File(projectDir, "gradlew.bat") : new File(projectDir, "gradlew");
-        if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
-            gradleCmd = isWindows() ? "gradlew.bat" : "./gradlew";
+        String cmd;
+        if (gradleCmd.isPresent()) {
+            cmd = gradleCmd.get();
         } else {
-            gradleCmd = "gradle";
+            File wrapper = isWindows() ? new File(projectDir, "gradlew.bat") : new File(projectDir, "gradlew");
+            if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
+                cmd = isWindows() ? "gradlew.bat" : "./gradlew";
+            } else {
+                cmd = "gradle";
+            }
         }
-        return new ProcessBuilder(gradleCmd, "quarkusDev", "-Dquarkus.console.basic=true",
+        return new ProcessBuilder(cmd, "quarkusDev", "-Dquarkus.console.basic=true",
                 "-Dquarkus.dev-mcp.enabled=true");
     }
 


### PR DESCRIPTION
When starting Quarkus dev mode, the process manager auto-detects wrapper scripts (`mvnw`/`gradlew`) and verifies they are git-tracked before using them. If the wrapper exists but isn't tracked, it throws an error — which breaks the common case where the wrapper was generated by the archetype but the user hasn't committed it yet and just wants to use their system-installed `mvn`.

This adds two optional config properties that let users override the build command entirely:

- `agent-mcp.process.mvn-cmd` — e.g. set to `mvn` to skip wrapper detection
- `agent-mcp.process.gradle-cmd` — e.g. set to `gradle` to skip wrapper detection

When set, the configured command is used directly, bypassing wrapper detection and git trust verification. When not set, the existing behavior is preserved.

Closes #76