### PR TITLE
Pin docker-java to 3.7.1 to prevent Quarkus BOM downgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,23 @@
                 <artifactId>tokenizers</artifactId>
                 <version>${djl.version}</version>
             </dependency>
+            <!-- Quarkus BOM pins docker-java at 3.7.0, but Testcontainers 2.x needs 3.7.1
+                 which fixes Docker API version negotiation on Docker Engine 29+ (Windows) -->
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-api</artifactId>
+                <version>3.7.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport-zerodep</artifactId>
+                <version>3.7.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-transport</artifactId>
+                <version>3.7.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
The Testcontainers 2.x upgrade in #78 was meant to fix Windows Docker detection by bringing in docker-java 3.7.1, which properly negotiates the Docker API version. However, the Quarkus BOM (3.34.2) manages all `com.github.docker-java` artifacts at version 3.7.0, silently downgrading them and re-introducing the original failure.

This adds explicit `<dependencyManagement>` entries to pin `docker-java-api`, `docker-java-transport-zerodep`, and `docker-java-transport` to 3.7.1, overriding the BOM.

Fixes #77