### PR TITLE
Add on-demand file logging tools for stdio mode

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/AgentLogTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/AgentLogTools.java
@@ -4,8 +4,12 @@ import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.ToolResponse;
 import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import org.jboss.logmanager.formatters.PatternFormatter;
@@ -22,14 +26,14 @@ public class AgentLogTools {
     @Tool(name = "quarkus_agent_log_enable", description = "Enable file logging for the Quarkus Agent MCP server. "
             + "Use this when running in stdio mode to capture log output that would otherwise be invisible. "
             + "Logs are written to ~/.quarkus/agent-mcp/agent-mcp.log.")
-    ToolResponse enableLogging() {
+    synchronized ToolResponse enableLogging() {
         if (activeHandler != null) {
             return ToolResponse.success("File logging is already enabled. Log file: " + LOG_FILE);
         }
         try {
             Files.createDirectories(LOG_DIR);
 
-            FileHandler handler = new FileHandler(LOG_FILE.toString(), false);
+            FileHandler handler = new FileHandler(LOG_FILE.toString(), true);
             handler.setFormatter(new PatternFormatter("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n"));
 
             Logger rootLogger = Logger.getLogger("");
@@ -46,7 +50,7 @@ public class AgentLogTools {
 
     @Tool(name = "quarkus_agent_log_disable", description = "Disable file logging for the Quarkus Agent MCP server. "
             + "The log file is preserved on disk for later inspection.")
-    ToolResponse disableLogging() {
+    synchronized ToolResponse disableLogging() {
         FileHandler handler = activeHandler;
         if (handler == null) {
             return ToolResponse.success("File logging is not enabled.");
@@ -56,7 +60,6 @@ public class AgentLogTools {
         handler.close();
         activeHandler = null;
 
-        LOG.info("File logging disabled");
         return ToolResponse.success("File logging disabled. Log file preserved at: " + LOG_FILE);
     }
 
@@ -71,14 +74,51 @@ public class AgentLogTools {
             return ToolResponse.error("No log file found. Call quarkus_agent_log_enable first to start logging.");
         }
         try {
-            List<String> allLines = Files.readAllLines(LOG_FILE);
             int count = (lines != null && lines > 0) ? Math.min(lines, 10000) : 100;
-            int start = Math.max(0, allLines.size() - count);
-            List<String> tail = allLines.subList(start, allLines.size());
+            List<String> tail = readTail(LOG_FILE, count);
             return ToolResponse.success(String.join("\n", tail));
         } catch (IOException e) {
             LOG.error("Failed to read log file", e);
             return ToolResponse.error("Failed to read log file: " + e.getMessage());
         }
+    }
+
+    private static List<String> readTail(Path file, int lineCount) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "r")) {
+            long length = raf.length();
+            if (length == 0) {
+                return List.of();
+            }
+
+            List<String> result = new ArrayList<>();
+            long pos = length - 1;
+
+            // Skip trailing newline if present
+            raf.seek(pos);
+            if (raf.readByte() == '\n') {
+                pos--;
+            }
+
+            while (pos >= 0 && result.size() < lineCount) {
+                raf.seek(pos);
+                if (raf.readByte() == '\n') {
+                    result.add(readLineAt(raf, pos + 1));
+                }
+                pos--;
+            }
+            // First line (or only line if no newline found)
+            if (result.size() < lineCount) {
+                result.add(readLineAt(raf, 0));
+            }
+
+            Collections.reverse(result);
+            return result;
+        }
+    }
+
+    private static String readLineAt(RandomAccessFile raf, long start) throws IOException {
+        raf.seek(start);
+        String line = raf.readLine();
+        return line != null ? new String(line.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8) : "";
     }
 }

--- a/src/main/java/io/quarkus/agent/mcp/AgentLogTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/AgentLogTools.java
@@ -1,0 +1,84 @@
+package io.quarkus.agent.mcp;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Logger;
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.handlers.FileHandler;
+
+public class AgentLogTools {
+
+    private static final org.jboss.logging.Logger LOG = org.jboss.logging.Logger.getLogger(AgentLogTools.class);
+
+    private static final Path LOG_DIR = Path.of(System.getProperty("user.home"), ".quarkus", "agent-mcp");
+    private static final Path LOG_FILE = LOG_DIR.resolve("agent-mcp.log");
+    private static volatile FileHandler activeHandler;
+
+    @Tool(name = "quarkus_agent_log_enable", description = "Enable file logging for the Quarkus Agent MCP server. "
+            + "Use this when running in stdio mode to capture log output that would otherwise be invisible. "
+            + "Logs are written to ~/.quarkus/agent-mcp/agent-mcp.log.")
+    ToolResponse enableLogging() {
+        if (activeHandler != null) {
+            return ToolResponse.success("File logging is already enabled. Log file: " + LOG_FILE);
+        }
+        try {
+            Files.createDirectories(LOG_DIR);
+
+            FileHandler handler = new FileHandler(LOG_FILE.toString(), false);
+            handler.setFormatter(new PatternFormatter("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] (%t) %s%e%n"));
+
+            Logger rootLogger = Logger.getLogger("");
+            rootLogger.addHandler(handler);
+            activeHandler = handler;
+
+            LOG.info("File logging enabled: " + LOG_FILE);
+            return ToolResponse.success("File logging enabled. Log file: " + LOG_FILE);
+        } catch (IOException e) {
+            LOG.error("Failed to enable file logging", e);
+            return ToolResponse.error("Failed to enable file logging: " + e.getMessage());
+        }
+    }
+
+    @Tool(name = "quarkus_agent_log_disable", description = "Disable file logging for the Quarkus Agent MCP server. "
+            + "The log file is preserved on disk for later inspection.")
+    ToolResponse disableLogging() {
+        FileHandler handler = activeHandler;
+        if (handler == null) {
+            return ToolResponse.success("File logging is not enabled.");
+        }
+        Logger rootLogger = Logger.getLogger("");
+        rootLogger.removeHandler(handler);
+        handler.close();
+        activeHandler = null;
+
+        LOG.info("File logging disabled");
+        return ToolResponse.success("File logging disabled. Log file preserved at: " + LOG_FILE);
+    }
+
+    @Tool(name = "quarkus_agent_log", description = "Read the Quarkus Agent MCP server's own log file. "
+            + "Returns the most recent lines from ~/.quarkus/agent-mcp/agent-mcp.log. "
+            + "The log file exists if quarkus_agent_log_enable was called previously.",
+            annotations = @Tool.Annotations(title = "quarkus_agent_log", readOnlyHint = true, destructiveHint = false,
+                    idempotentHint = true, openWorldHint = false))
+    ToolResponse readLog(
+            @ToolArg(description = "Number of recent lines to return (default: 100)", required = false) Integer lines) {
+        if (!Files.exists(LOG_FILE)) {
+            return ToolResponse.error("No log file found. Call quarkus_agent_log_enable first to start logging.");
+        }
+        try {
+            List<String> allLines = Files.readAllLines(LOG_FILE);
+            int count = (lines != null && lines > 0) ? Math.min(lines, 10000) : 100;
+            int start = Math.max(0, allLines.size() - count);
+            List<String> tail = allLines.subList(start, allLines.size());
+            return ToolResponse.success(String.join("\n", tail));
+        } catch (IOException e) {
+            LOG.error("Failed to read log file", e);
+            return ToolResponse.error("Failed to read log file: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,6 +29,11 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   - After fixing the issue, call 'devui-exceptions_clearLastException' to clear the recorded exception\n\
   - NOTE: if the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet -- fall back to quarkus_logs in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy\n\
   - Use quarkus_logs only when you need broader log context beyond the exception itself\n\n\
+  AGENT SERVER LOGGING (stdio mode):\n\
+  - In stdio mode, MCP server logs are not visible because stdout/stderr are used by the protocol\n\
+  - Call quarkus_agent_log_enable to start writing server logs to ~/.quarkus/agent-mcp/agent-mcp.log\n\
+  - Call quarkus_agent_log to read recent log output from the server\n\
+  - Call quarkus_agent_log_disable to stop file logging (the log file is preserved)\n\n\
   KEY RULES:\n\
   - NEVER skip quarkus_skills -- it contains critical patterns that prevent common mistakes\n\
   - NEVER use generic documentation tools (Context7, web search) for Quarkus unless the user asks you to or until you're sure quarkus_searchDocs doesn't yield what you need\n\


### PR DESCRIPTION
In stdio mode, stdout/stderr are consumed by the MCP protocol so server logs are invisible. This adds three MCP tools that let an AI agent toggle file logging at runtime without any upfront configuration:

- **`quarkus_agent_log_enable`** — dynamically attaches a JBoss `FileHandler` to the root logger, writing to `~/.quarkus/agent-mcp/agent-mcp.log`
- **`quarkus_agent_log_disable`** — removes the handler (the log file is preserved for later inspection)
- **`quarkus_agent_log`** — reads the last N lines from the log file

No logging overhead is incurred until the agent explicitly enables it.

The server instructions in `application.properties` are updated so AI agents know these tools exist when debugging in stdio mode.

Closes #81