### PR TITLE
Add quarkus_saveSkill tool to materialize skills locally

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -114,7 +115,9 @@ public class DevMcpProxyTools {
             + "Skills can be customized using quarkus_updateSkill. Customizations use a three-layer chain: "
             + "JAR defaults -> global (~/.quarkus/skills/) -> project (.quarkus/skills/). "
             + "By default, customizations ENHANCE (append to) the base skill. "
-            + "Use mode 'override' to fully replace a base skill.",
+            + "Use mode 'override' to fully replace a base skill. "
+            + "After presenting skills, you can offer the user to save them locally "
+            + "using quarkus_saveSkill for version control and direct editing.",
             // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
             // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
             annotations = @Tool.Annotations(title = "quarkus_skills", readOnlyHint = true, destructiveHint = false, idempotentHint = true, openWorldHint = false))
@@ -302,6 +305,53 @@ public class DevMcpProxyTools {
                             + "The skill will take effect on the next call to `quarkus_skills`.");
         } catch (Exception e) {
             return ToolResponse.error("Failed to write skill: " + e.getMessage());
+        }
+    }
+
+    @Tool(name = "quarkus_saveSkill", description = "Save/materialize a composed extension skill as a local file "
+            + "in the project's .quarkus/skills/ directory. This creates a local copy of the full skill "
+            + "(including any existing user/project customizations) that the user can then see, "
+            + "version-control, and edit directly. The saved file uses OVERRIDE mode. "
+            + "Use this when the user wants to inspect, customize, or version-control an extension skill. "
+            + "NOTE: If a local project skill already exists for this name, the tool will NOT overwrite it.",
+            annotations = @Tool.Annotations(title = "quarkus_saveSkill", readOnlyHint = false, destructiveHint = false, idempotentHint = true))
+    ToolResponse saveSkill(
+            @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
+            @ToolArg(description = "The extension skill name to save locally "
+                    + "(e.g. 'quarkus-rest', 'quarkus-hibernate-orm-panache')") String skillName) {
+        try {
+            Path projectSkillFile = Path.of(projectDir, ".quarkus", "skills", skillName, "SKILL.md");
+            if (Files.exists(projectSkillFile)) {
+                return ToolResponse.success(
+                        "A local skill for '" + skillName + "' already exists at " + projectSkillFile + ".\n"
+                                + "To modify it, edit the file directly or use quarkus_updateSkill.");
+            }
+
+            Path effectiveLocalDir = localSkillsDir.map(Path::of).orElse(null);
+            List<SkillReader.SkillInfo> skills = SkillReader.readSkills(projectDir, effectiveLocalDir, false);
+            SkillReader.SkillInfo matched = skills.stream()
+                    .filter(s -> s.name().equalsIgnoreCase(skillName))
+                    .findFirst()
+                    .orElse(null);
+
+            if (matched == null) {
+                return ToolResponse.error(
+                        "No extension skill found with name '" + skillName
+                                + "'. Use quarkus_skills to see available skills.");
+            }
+
+            Path written = SkillReader.writeSkill(
+                    matched.name(), matched.content(), matched.description(), matched.categories(),
+                    SkillReader.SkillMode.OVERRIDE, projectDir, effectiveLocalDir, true);
+
+            return ToolResponse.success(
+                    "Skill '" + matched.name() + "' saved successfully.\n"
+                            + "- **Mode**: override\n"
+                            + "- **Path**: " + written + "\n\n"
+                            + "You can now edit this file directly. "
+                            + "The skill will take effect on the next call to `quarkus_skills`.");
+        } catch (Exception e) {
+            return ToolResponse.error("Failed to save skill: " + e.getMessage());
         }
     }
 

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -115,9 +116,7 @@ public class DevMcpProxyTools {
             + "Skills can be customized using quarkus_updateSkill. Customizations use a three-layer chain: "
             + "JAR defaults -> global (~/.quarkus/skills/) -> project (.quarkus/skills/). "
             + "By default, customizations ENHANCE (append to) the base skill. "
-            + "Use mode 'override' to fully replace a base skill. "
-            + "After presenting skills, you can offer the user to save them locally "
-            + "using quarkus_saveSkill for version control and direct editing.",
+            + "Use mode 'override' to fully replace a base skill.",
             // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
             // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
             annotations = @Tool.Annotations(title = "quarkus_skills", readOnlyHint = true, destructiveHint = false, idempotentHint = true, openWorldHint = false))
@@ -314,19 +313,12 @@ public class DevMcpProxyTools {
             + "version-control, and edit directly. The saved file uses OVERRIDE mode. "
             + "Use this when the user wants to inspect, customize, or version-control an extension skill. "
             + "NOTE: If a local project skill already exists for this name, the tool will NOT overwrite it.",
-            annotations = @Tool.Annotations(title = "quarkus_saveSkill", readOnlyHint = false, destructiveHint = false, idempotentHint = true))
+            annotations = @Tool.Annotations(title = "quarkus_saveSkill", readOnlyHint = false, destructiveHint = false, idempotentHint = false))
     ToolResponse saveSkill(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
             @ToolArg(description = "The extension skill name to save locally "
                     + "(e.g. 'quarkus-rest', 'quarkus-hibernate-orm-panache')") String skillName) {
         try {
-            Path projectSkillFile = Path.of(projectDir, ".quarkus", "skills", skillName, "SKILL.md");
-            if (Files.exists(projectSkillFile)) {
-                return ToolResponse.success(
-                        "A local skill for '" + skillName + "' already exists at " + projectSkillFile + ".\n"
-                                + "To modify it, edit the file directly or use quarkus_updateSkill.");
-            }
-
             Path effectiveLocalDir = localSkillsDir.map(Path::of).orElse(null);
             List<SkillReader.SkillInfo> skills = SkillReader.readSkills(projectDir, effectiveLocalDir, false);
             SkillReader.SkillInfo matched = skills.stream()
@@ -342,7 +334,7 @@ public class DevMcpProxyTools {
 
             Path written = SkillReader.writeSkill(
                     matched.name(), matched.content(), matched.description(), matched.categories(),
-                    SkillReader.SkillMode.OVERRIDE, projectDir, effectiveLocalDir, true);
+                    SkillReader.SkillMode.OVERRIDE, projectDir, effectiveLocalDir, true, true);
 
             return ToolResponse.success(
                     "Skill '" + matched.name() + "' saved successfully.\n"
@@ -350,6 +342,10 @@ public class DevMcpProxyTools {
                             + "- **Path**: " + written + "\n\n"
                             + "You can now edit this file directly. "
                             + "The skill will take effect on the next call to `quarkus_skills`.");
+        } catch (FileAlreadyExistsException e) {
+            return ToolResponse.success(
+                    "A local skill for '" + skillName + "' already exists at " + e.getFile() + ".\n"
+                            + "To modify it, edit the file directly or use quarkus_updateSkill.");
         } catch (Exception e) {
             return ToolResponse.error("Failed to save skill: " + e.getMessage());
         }

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -959,6 +960,13 @@ public final class SkillReader {
      */
     static Path writeSkill(String skillName, String content, String description, List<String> categories,
             SkillMode mode, String projectDir, Path localSkillsDir, boolean projectScope) throws IOException {
+        return writeSkill(skillName, content, description, categories, mode, projectDir, localSkillsDir, projectScope,
+                false);
+    }
+
+    static Path writeSkill(String skillName, String content, String description, List<String> categories,
+            SkillMode mode, String projectDir, Path localSkillsDir, boolean projectScope, boolean createOnly)
+            throws IOException {
         if (skillName == null || !VALID_SKILL_NAME.matcher(skillName).matches()) {
             throw new IllegalArgumentException("Invalid skill name: " + skillName
                     + ". Must contain only letters, digits, dots, hyphens, and underscores.");
@@ -988,7 +996,12 @@ public final class SkillReader {
         sb.append(content);
 
         Path skillFile = skillDir.resolve(SKILL_FILE_NAME);
-        Files.writeString(skillFile, sb.toString(), StandardCharsets.UTF_8);
+        if (createOnly) {
+            Files.writeString(skillFile, sb.toString(), StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+        } else {
+            Files.writeString(skillFile, sb.toString(), StandardCharsets.UTF_8);
+        }
         LOG.infof("Wrote skill '%s' to %s", skillName, skillFile);
         return skillFile;
     }

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.FileOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -1603,5 +1604,46 @@ class SkillReaderTest {
         SkillReader.SkillInfo result = skillMap.get("quarkus-arc");
         assertNotNull(result);
         assertEquals(SkillReader.SkillMode.OVERRIDE, result.mode());
+    }
+
+    @Test
+    void saveSkillCreateOnlyRefusesToOverwriteExistingFile() throws Exception {
+        Path m2Repo = tempDir.resolve("m2-repo");
+        createCoreExtension(m2Repo, "quarkus-arc", "3.21.2",
+                "### CDI patterns\nUse @Inject for DI.",
+                "name: \"ArC\"\ndescription: \"Build time CDI\"\n");
+
+        List<SkillReader.SkillInfo> skills = SkillReader.scanCoreExtensionSkills("3.21.2", m2Repo, false);
+        SkillReader.SkillInfo skill = skills.get(0);
+
+        Path projectDir = tempDir.resolve("my-project");
+        Files.createDirectories(projectDir);
+
+        SkillReader.writeSkill(
+                skill.name(), skill.content(), skill.description(), skill.categories(),
+                SkillReader.SkillMode.OVERRIDE, projectDir.toString(), null, true, true);
+
+        assertThrows(FileAlreadyExistsException.class, () -> SkillReader.writeSkill(
+                skill.name(), skill.content(), skill.description(), skill.categories(),
+                SkillReader.SkillMode.OVERRIDE, projectDir.toString(), null, true, true));
+    }
+
+    @Test
+    void saveSkillWithoutCreateOnlyOverwritesExistingFile() throws Exception {
+        Path projectDir = tempDir.resolve("my-project");
+        Files.createDirectories(projectDir);
+
+        SkillReader.writeSkill(
+                "quarkus-test", "Original content", "desc", null,
+                SkillReader.SkillMode.OVERRIDE, projectDir.toString(), null, true);
+
+        SkillReader.writeSkill(
+                "quarkus-test", "Updated content", "desc", null,
+                SkillReader.SkillMode.OVERRIDE, projectDir.toString(), null, true);
+
+        Path skillFile = projectDir.resolve(".quarkus/skills/quarkus-test/SKILL.md");
+        String content = Files.readString(skillFile);
+        assertTrue(content.contains("Updated content"));
+        assertFalse(content.contains("Original content"));
     }
 }

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -1541,4 +1541,67 @@ class SkillReaderTest {
         assertNotNull(result);
         assertEquals(Path.of("/abs/path/settings.xml"), result);
     }
+
+    // --- Save skill (materialize composed skill locally) tests ---
+
+    @Test
+    void saveSkillWritesComposedContentWithOverrideMode() throws Exception {
+        Path m2Repo = tempDir.resolve("m2-repo");
+        createCoreExtension(m2Repo, "quarkus-arc", "3.21.2",
+                "### CDI patterns\nUse @Inject for DI.",
+                "name: \"ArC\"\ndescription: \"Build time CDI\"\nmetadata:\n  guide: \"https://quarkus.io/guides/cdi\"\n  categories:\n  - \"core\"\n");
+
+        // Read the composed skill (layer 1)
+        List<SkillReader.SkillInfo> skills = SkillReader.scanCoreExtensionSkills("3.21.2", m2Repo, false);
+        assertEquals(1, skills.size());
+        SkillReader.SkillInfo skill = skills.get(0);
+
+        // Write it locally with override mode
+        Path projectDir = tempDir.resolve("my-project");
+        Files.createDirectories(projectDir);
+        Path written = SkillReader.writeSkill(
+                skill.name(), skill.content(), skill.description(), skill.categories(),
+                SkillReader.SkillMode.OVERRIDE, projectDir.toString(), null, true);
+
+        assertTrue(Files.exists(written));
+        String savedContent = Files.readString(written);
+        assertTrue(savedContent.contains("name: quarkus-arc"));
+        assertTrue(savedContent.contains("mode: override"));
+        assertTrue(savedContent.contains("description: \"Build time CDI\""));
+        assertTrue(savedContent.contains("categories: \"core\""));
+        assertTrue(savedContent.contains("### CDI patterns"));
+        assertTrue(savedContent.contains("Use @Inject"));
+        assertEquals(projectDir.resolve(".quarkus/skills/quarkus-arc/SKILL.md"), written);
+    }
+
+    @Test
+    void savedSkillOverridesBaseOnNextRead() throws Exception {
+        Path m2Repo = tempDir.resolve("m2-repo");
+        createCoreExtension(m2Repo, "quarkus-arc", "3.21.2",
+                "### CDI patterns\nUse @Inject for DI.",
+                "name: \"ArC\"\ndescription: \"Build time CDI\"\n");
+
+        // Read the base skill
+        List<SkillReader.SkillInfo> baseSkills = SkillReader.scanCoreExtensionSkills("3.21.2", m2Repo, false);
+        SkillReader.SkillInfo base = baseSkills.get(0);
+
+        // Save it locally
+        Path projectDir = tempDir.resolve("my-project");
+        Files.createDirectories(projectDir);
+        SkillReader.writeSkill(
+                base.name(), base.content(), base.description(), base.categories(),
+                SkillReader.SkillMode.OVERRIDE, projectDir.toString(), null, true);
+
+        // Verify the saved skill is used as an override in the three-layer chain
+        Map<String, SkillReader.SkillInfo> skillMap = new LinkedHashMap<>();
+        skillMap.put(base.name(), base);
+
+        Path projectSkillsDir = projectDir.resolve(".quarkus/skills");
+        List<SkillReader.SkillInfo> projectSkills = SkillReader.readLocalSkills(projectSkillsDir);
+        SkillReader.overlaySkills(skillMap, projectSkills, projectSkillsDir.toString());
+
+        SkillReader.SkillInfo result = skillMap.get("quarkus-arc");
+        assertNotNull(result);
+        assertEquals(SkillReader.SkillMode.OVERRIDE, result.mode());
+    }
 }


### PR DESCRIPTION
Adds a new `quarkus_saveSkill` MCP tool that lets users save the full composed skill as a local file in `.quarkus/skills/<name>/SKILL.md`. This makes skills visible, version-controllable, and directly editable without going through the MCP tool.

The tool reads the composed skill (all three layers merged), writes it with override mode, and refuses to overwrite an existing local skill. The `quarkus_skills` tool description is also updated to instruct the agent to offer saving skills locally after presenting them.

Closes #67