### PR TITLE
Release 1.0.3

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "1.0.2"
-  next-version: "1.0.3-SNAPSHOT"
+  current-version: "1.0.3"
+  next-version: "1.0.4-SNAPSHOT"


### PR DESCRIPTION
The previous 1.0.3 release attempt failed because the tag was created against a commit that still had the SNAPSHOT version in the POM. This updates project.yml to trigger the prepare-release workflow properly.