### PR TITLE
Restore SNAPSHOT version after failed 1.0.3 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agent",
   "description": "MCP server for AI coding agents to create, manage, and interact with Quarkus applications. Provides tools for project scaffolding, dev mode lifecycle, extension skills, Dev MCP proxy, and documentation search.",
-  "version": "1.0.3",
+  "version": "1.0.4-SNAPSHOT",
   "author": {
     "name": "Quarkus",
     "url": "https://quarkus.io"

--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "1.0.4"
-  next-version: "1.0.5-SNAPSHOT"
+  current-version: "1.0.3"
+  next-version: "1.0.4-SNAPSHOT"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-agent-mcp</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
     <name>Quarkus Agent MCP</name>
     <description>Standalone MCP server for AI coding agents to manage Quarkus applications</description>
     <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
@@ -28,7 +28,7 @@
         <connection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</connection>
         <developerConnection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</developerConnection>
         <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
-      <tag>1.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <distributionManagement>


### PR DESCRIPTION
The 1.0.3 prepare-release partially ran — it committed the non-SNAPSHOT version to main but failed to push the tag (stale tag from the first attempt). This left main in a broken state where the POM has version 1.0.3 (non-SNAPSHOT) and project.yml was already bumped to 1.0.4.

This PR resets everything so a clean 1.0.4 release can be done:
- POM version → 1.0.4-SNAPSHOT
- SCM tag → HEAD
- plugin.json version → 1.0.4-SNAPSHOT
- project.yml → current-version 1.0.3, next-version 1.0.4-SNAPSHOT