### PR TITLE
Release 1.0.4

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "1.0.3"
-  next-version: "1.0.4-SNAPSHOT"
+  current-version: "1.0.4"
+  next-version: "1.0.5-SNAPSHOT"


### PR DESCRIPTION
Skipping 1.0.3 due to a stale tag that cannot be deleted (tag protection rule). This release includes all changes since 1.0.2.