### PR TITLE
Restore POM to 1.0.4-SNAPSHOT after failed 1.0.3 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agent",
   "description": "MCP server for AI coding agents to create, manage, and interact with Quarkus applications. Provides tools for project scaffolding, dev mode lifecycle, extension skills, Dev MCP proxy, and documentation search.",
-  "version": "1.0.3",
+  "version": "1.0.4-SNAPSHOT",
   "author": {
     "name": "Quarkus",
     "url": "https://quarkus.io"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-agent-mcp</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
     <name>Quarkus Agent MCP</name>
     <description>Standalone MCP server for AI coding agents to manage Quarkus applications</description>
     <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
@@ -28,7 +28,7 @@
         <connection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</connection>
         <developerConnection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</developerConnection>
         <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
-      <tag>1.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <distributionManagement>


### PR DESCRIPTION
The previous fix PR (#93) touched project.yml which re-triggered prepare-release, undoing the fix. This PR only touches pom.xml and plugin.json — no project.yml change — so the prepare-release workflow will not trigger.

After merging this, a separate release PR bumping project.yml will trigger a clean 1.0.4 release.