### PR TITLE
Restore POM to 1.0.5-SNAPSHOT after failed releases

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quarkus-agent",
   "description": "MCP server for AI coding agents to create, manage, and interact with Quarkus applications. Provides tools for project scaffolding, dev mode lifecycle, extension skills, Dev MCP proxy, and documentation search.",
-  "version": "1.0.2",
+  "version": "1.0.5-SNAPSHOT",
   "author": {
     "name": "Quarkus",
     "url": "https://quarkus.io"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-agent-mcp</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5-SNAPSHOT</version>
     <name>Quarkus Agent MCP</name>
     <description>Standalone MCP server for AI coding agents to manage Quarkus applications</description>
     <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
@@ -28,7 +28,7 @@
         <connection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</connection>
         <developerConnection>scm:git:https://github.com/quarkusio/quarkus-agent-mcp.git</developerConnection>
         <url>https://github.com/quarkusio/quarkus-agent-mcp</url>
-      <tag>1.0.4</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Multiple failed release attempts (1.0.3, 1.0.4) left main with a non-SNAPSHOT POM version. The stale tags cannot be deleted due to an org-level immutable tags ruleset.

This PR fixes the POM and plugin.json only (not project.yml) to avoid triggering the prepare-release workflow. A follow-up release PR will bump project.yml to release 1.0.5.