### PR TITLE
Allow enabling agent file logging via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,36 @@ For existing projects, `quarkus_update` checks if the Quarkus version is current
 
 ### Agent Logging
 
-In stdio mode, server logs are invisible because stdout/stderr are consumed by the MCP protocol. These tools let the agent toggle file logging at runtime without any upfront configuration.
+In stdio mode, server logs are invisible because stdout/stderr are consumed by the MCP protocol.
+
+File logging can be enabled permanently by setting `agent-mcp.log.enabled=true`. The easiest way is via an environment variable in your MCP server configuration:
+
+**Claude Code:**
+
+```bash
+claude mcp add quarkus-agent -e AGENT_MCP_LOG_ENABLED=true -- jbang quarkus-agent-mcp@quarkusio
+```
+
+**VS Code / Cursor / Windsurf / JetBrains (JSON config):**
+
+```json
+{
+  "servers": {
+    "quarkus-agent": {
+      "type": "stdio",
+      "command": "jbang",
+      "args": ["quarkus-agent-mcp@quarkusio"],
+      "env": {
+        "AGENT_MCP_LOG_ENABLED": "true"
+      }
+    }
+  }
+}
+```
+
+Logs are written to `~/.quarkus/agent-mcp/agent-mcp.log`.
+
+The agent can also toggle file logging on-the-fly using these tools:
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
@@ -364,6 +393,7 @@ Configuration via `application.properties`, system properties (`-D`), or environ
 | `agent-mcp.local-skills-dir` | `~/.quarkus/skills` | Directory for user-level skill customizations |
 | `agent-mcp.process.mvn-cmd` | _(auto-detect)_ | Override the Maven command used to start dev mode (e.g. `mvn` to skip wrapper detection) |
 | `agent-mcp.process.gradle-cmd` | _(auto-detect)_ | Override the Gradle command used to start dev mode (e.g. `gradle` to skip wrapper detection) |
+| `agent-mcp.log.enabled` | `false` | Enable file logging on startup — logs are written to `~/.quarkus/agent-mcp/agent-mcp.log` |
 
 ## Building a Native Image
 

--- a/src/main/java/io/quarkus/agent/mcp/AgentLogTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/AgentLogTools.java
@@ -3,6 +3,9 @@ package io.quarkus.agent.mcp;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
@@ -11,10 +14,13 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Logger;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logmanager.formatters.PatternFormatter;
 import org.jboss.logmanager.handlers.FileHandler;
 
+@ApplicationScoped
 public class AgentLogTools {
 
     private static final org.jboss.logging.Logger LOG = org.jboss.logging.Logger.getLogger(AgentLogTools.class);
@@ -22,6 +28,15 @@ public class AgentLogTools {
     private static final Path LOG_DIR = Path.of(System.getProperty("user.home"), ".quarkus", "agent-mcp");
     private static final Path LOG_FILE = LOG_DIR.resolve("agent-mcp.log");
     private static volatile FileHandler activeHandler;
+
+    @ConfigProperty(name = "agent-mcp.log.enabled")
+    Optional<Boolean> logEnabled;
+
+    void onStart(@Observes StartupEvent event) {
+        if (logEnabled.orElse(false)) {
+            enableLogging();
+        }
+    }
 
     @Tool(name = "quarkus_agent_log_enable", description = "Enable file logging for the Quarkus Agent MCP server. "
             + "Use this when running in stdio mode to capture log output that would otherwise be invisible. "
@@ -65,7 +80,7 @@ public class AgentLogTools {
 
     @Tool(name = "quarkus_agent_log", description = "Read the Quarkus Agent MCP server's own log file. "
             + "Returns the most recent lines from ~/.quarkus/agent-mcp/agent-mcp.log. "
-            + "The log file exists if quarkus_agent_log_enable was called previously.",
+            + "The log file exists if file logging was enabled via agent-mcp.log.enabled=true or by calling quarkus_agent_log_enable.",
             annotations = @Tool.Annotations(title = "quarkus_agent_log", readOnlyHint = true, destructiveHint = false,
                     idempotentHint = true, openWorldHint = false))
     ToolResponse readLog(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,7 +31,8 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   - Use quarkus_logs only when you need broader log context beyond the exception itself\n\n\
   AGENT SERVER LOGGING (stdio mode):\n\
   - In stdio mode, MCP server logs are not visible because stdout/stderr are used by the protocol\n\
-  - Call quarkus_agent_log_enable to start writing server logs to ~/.quarkus/agent-mcp/agent-mcp.log\n\
+  - File logging can be enabled permanently by setting agent-mcp.log.enabled=true (e.g. via the AGENT_MCP_LOG_ENABLED=true environment variable)\n\
+  - Call quarkus_agent_log_enable to start writing server logs on-the-fly to ~/.quarkus/agent-mcp/agent-mcp.log\n\
   - Call quarkus_agent_log to read recent log output from the server\n\
   - Call quarkus_agent_log_disable to stop file logging (the log file is preserved)\n\n\
   KEY RULES:\n\


### PR DESCRIPTION
Users running in stdio mode currently have to ask the agent to call `quarkus_agent_log_enable` at the start of every session to get server logs. This adds an `agent-mcp.log.enabled` config property so file logging can be turned on permanently — for example by setting `AGENT_MCP_LOG_ENABLED=true` in the MCP server's `env` block.

When the property is set, file logging is activated automatically on startup. The existing `quarkus_agent_log_enable` / `quarkus_agent_log_disable` tools remain available for on-the-fly control.

Closes #100