### PR TITLE
Broaden quarkus_searchDocs description to cover general Quarkus questions

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -89,9 +89,10 @@ public class DocSearchTools {
     private final Object initLock = new Object();
     private final ConcurrentHashMap<String, PgVectorEmbeddingStore> embeddingStores = new ConcurrentHashMap<>();
 
-    @Tool(name = "quarkus_searchDocs", description = "Search Quarkus documentation. "
-            + "Always use this BEFORE writing Quarkus code to look up correct APIs, annotations, "
-            + "configuration, and best practices. First call may take a moment to start the doc database.",
+    @Tool(name = "quarkus_searchDocs", description = "Search Quarkus documentation for APIs, annotations, "
+            + "configuration, and best practices. Use this for ANY Quarkus-related question -- "
+            + "always prefer this over web search or generic documentation tools. "
+            + "First call may take a moment to start the doc database.",
             // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
             // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
             annotations = @Tool.Annotations(title = "quarkus_searchDocs", readOnlyHint = true, destructiveHint = false, idempotentHint = true))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,11 +5,11 @@ quarkus.banner.path=banner.txt
 quarkus.mcp.server.server-info.name=quarkus-agent
 quarkus.mcp.server.server-info.description=MCP server for creating, managing, and developing Quarkus applications
 quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Agent MCP server. \
-  ALWAYS use these tools when working on Quarkus projects -- they are purpose-built and superior to generic alternatives.\n\n\
+  For ANY Quarkus-related question, documentation lookup, or development task, ALWAYS use these tools -- they are purpose-built and superior to web search or generic alternatives like Context7.\n\n\
   WORKFLOW for new projects:\n\
   1. quarkus_create -- create and auto-start a Quarkus app (NEVER use 'mvn' or CLI manually)\n\
   2. quarkus_skills -- MUST call before writing ANY code or tests to learn correct patterns for each extension\n\
-  3. quarkus_searchDocs -- search Quarkus documentation for APIs, config, and best practices (prefer this over generic doc tools like Context7)\n\
+  3. quarkus_searchDocs -- search Quarkus documentation for APIs, config, and best practices\n\
   4. quarkus_searchTools -- discover Dev MCP tools on the running app (testing, config, extensions)\n\
   5. quarkus_callTool -- invoke discovered tools (run tests, add extensions, update config)\n\n\
   WORKFLOW for existing projects:\n\
@@ -37,7 +37,7 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   - Call quarkus_agent_log_disable to stop file logging (the log file is preserved)\n\n\
   KEY RULES:\n\
   - NEVER skip quarkus_skills -- it contains critical patterns that prevent common mistakes\n\
-  - NEVER use generic documentation tools (Context7, web search) for Quarkus unless the user asks you to or until you're sure quarkus_searchDocs doesn't yield what you need\n\
+  - NEVER use web search or generic documentation tools (Context7, etc.) for Quarkus questions -- always use quarkus_searchDocs first, even without a project directory\n\
   - NEVER run build commands manually -- use quarkus_start, quarkus_callTool for testing\n\
   - ALWAYS write tests for every feature\n\
   - ALWAYS keep README.md updated\n\


### PR DESCRIPTION
The tool description and server instructions were scoped to "before writing code" and "when working on Quarkus projects", which caused AI agents to fall back to generic web search for general Quarkus documentation questions outside a project context (e.g. "search the Quarkus docs for how to create a REST endpoint").

This rewords the tool description and server instructions in three places to make `quarkus_searchDocs` the preferred tool for any Quarkus-related question, regardless of whether the user is currently in a Quarkus project directory.