### PR TITLE
Fix legacy/modern guide matching to use repoPath fallback

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -283,13 +283,13 @@ public class DocSearchTools {
                 }
             }
 
-            if (LEGACY_GUIDES.contains(title) || topics.contains("resteasy-classic")) {
+            if (matchesGuide(LEGACY_GUIDES, title, repoPath) || topics.contains("resteasy-classic")) {
                 score += LEGACY_PENALTY;
             }
             if (topics.contains("internals") || topics.contains("documentation")) {
                 score += INTERNAL_DOCS_PENALTY;
             }
-            if (MODERN_GUIDES.contains(title) || topics.contains("resteasy-reactive")) {
+            if (matchesGuide(MODERN_GUIDES, title, repoPath) || topics.contains("resteasy-reactive")) {
                 score += MODERN_GUIDE_BOOST;
             }
 
@@ -298,6 +298,18 @@ public class DocSearchTools {
 
         scored.sort((a, b) -> Double.compare(b.score, a.score));
         return scored;
+    }
+
+    private static boolean matchesGuide(Set<String> guides, String title, String repoPath) {
+        if (guides.contains(title)) {
+            return true;
+        }
+        for (String guide : guides) {
+            if (repoPath.contains("/" + guide + ".") || repoPath.contains("/" + guide + "/")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String metadataOrEmpty(TextSegment segment, String key) {


### PR DESCRIPTION
The `Set.contains(title)` checks from #110 only matched when the entire lowercased title was exactly a guide slug like `"resteasy"` or `"rest"`. If the `title` metadata contains a full guide name rather than a slug, the era-aware penalties and boosts silently don't apply.

This adds a `matchesGuide` helper that first tries the exact title match (fast path for slug titles), then falls back to checking whether any guide identifier appears as a path segment in `repoPath` — using boundary checks (`"/" + guide + "."` and `"/" + guide + "/"`) so that `"rest"` won't incorrectly match `"resteasy"` paths.