### PR TITLE
Use .agent/skills/ instead of .quarkus/skills/ for project-level skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Skills are loaded using a three-layer chain (most specific wins):
 
 1. **Extension skills** — discovered from individual extension deployment JARs (`META-INF/quarkus-skill.md`) in the local Maven repository, composed with extension metadata and available Dev MCP tools. This supports skills from Quarkus core, Quarkiverse, and custom extensions. For older Quarkus versions that don't ship skill files in deployment JARs, the aggregated `quarkus-extension-skills` JAR is used as a fallback.
 2. **User-level skills** — from `~/.quarkus/skills/<extension-name>/SKILL.md` (or a directory configured via `agent-mcp.local-skills-dir`). Useful for extension developers testing new or modified skills without rebuilding the aggregated JAR.
-3. **Project-level skills** — from `.quarkus/skills/<extension-name>/SKILL.md` in the project directory. Allows teams to customize extension patterns for their specific project conventions.
+3. **Project-level skills** — from `.agent/skills/<extension-name>/SKILL.md` in the project directory. Allows teams to customize extension patterns for their specific project conventions.
 
 Each layer can either **enhance** (default) or **override** the previous layer, controlled by the `mode` field in the SKILL.md frontmatter:
 
@@ -246,9 +246,9 @@ Each layer can either **enhance** (default) or **override** the previous layer, 
 
 The agent can also create or update skill customizations using `quarkus_updateSkill`. When the user asks to customize a skill, the agent will ask:
 1. **Enhance or override?** — append to the base skill or fully replace it.
-2. **Project or global scope?** — save under `.quarkus/skills/` (this project only) or `~/.quarkus/skills/` (all projects).
+2. **Project or global scope?** — save under `.agent/skills/` (this project only) or `~/.quarkus/skills/` (all projects).
 
-To inspect or version-control a skill, the agent can use `quarkus_saveSkill` to materialize the full composed skill (all layers merged) as a local file in `.quarkus/skills/`.
+To inspect or version-control a skill, the agent can use `quarkus_saveSkill` to materialize the full composed skill (all layers merged) as a local file in `.agent/skills/`.
 
 ### Documentation search
 
@@ -285,7 +285,7 @@ For existing projects, `quarkus_update` checks if the Quarkus version is current
 |------|-------------|------------|
 | `quarkus_skills` | Get coding patterns, testing guidelines, and pitfalls for project extensions | `projectDir` (required), `query` |
 | `quarkus_updateSkill` | Create or update a skill customization (enhance or override) | `projectDir` (required), `skillName` (required), `content` (required), `description`, `categories`, `mode`, `scope` |
-| `quarkus_saveSkill` | Save a composed skill as a local file in `.quarkus/skills/` for inspection and version control | `projectDir` (required), `skillName` (required) |
+| `quarkus_saveSkill` | Save a composed skill as a local file in `.agent/skills/` for inspection and version control | `projectDir` (required), `skillName` (required) |
 
 ### Lifecycle Management
 

--- a/README.md
+++ b/README.md
@@ -237,18 +237,16 @@ Skills are loaded using a three-layer chain (most specific wins):
 
 1. **Extension skills** — discovered from individual extension deployment JARs (`META-INF/quarkus-skill.md`) in the local Maven repository, composed with extension metadata and available Dev MCP tools. This supports skills from Quarkus core, Quarkiverse, and custom extensions. For older Quarkus versions that don't ship skill files in deployment JARs, the aggregated `quarkus-extension-skills` JAR is used as a fallback.
 2. **User-level skills** — from `~/.quarkus/skills/<extension-name>/SKILL.md` (or a directory configured via `agent-mcp.local-skills-dir`). Useful for extension developers testing new or modified skills without rebuilding the aggregated JAR.
-3. **Project-level skills** — from `.agent/skills/<extension-name>/SKILL.md` in the project directory. Allows teams to customize extension patterns for their specific project conventions.
+3. **Project-level skills** — from `.agent/skills/<extension-name>/SKILL.md` in the project directory. These are **standalone files** read as-is (no composition with base layers), so any agent can read them directly from the filesystem. Use `quarkus_saveSkill` to materialize a fully composed skill into this directory, then edit the file directly.
 
-Each layer can either **enhance** (default) or **override** the previous layer, controlled by the `mode` field in the SKILL.md frontmatter:
+Layers 1 and 2 support **enhance** and **override** composition, controlled by the `mode` field in the SKILL.md frontmatter:
 
-- **`mode: enhance`** (default) — appends content to the base skill. The base content is preserved and the customization is added after a separator. This is ideal for adding project conventions or team standards without losing the built-in guidance.
+- **`mode: enhance`** (default) — appends content to the base skill. The base content is preserved and the customization is added after a separator. This is ideal for adding personal conventions or standards without losing the built-in guidance.
 - **`mode: override`** — fully replaces the base skill. Use this when you need complete control over a skill's content.
 
-The agent can also create or update skill customizations using `quarkus_updateSkill`. When the user asks to customize a skill, the agent will ask:
-1. **Enhance or override?** — append to the base skill or fully replace it.
-2. **Project or global scope?** — save under `.agent/skills/` (this project only) or `~/.quarkus/skills/` (all projects).
+Layer 3 (project) always replaces — the file content is used directly with no composition.
 
-To inspect or version-control a skill, the agent can use `quarkus_saveSkill` to materialize the full composed skill (all layers merged) as a local file in `.agent/skills/`.
+The agent can create or update **global** skill customizations using `quarkus_updateSkill` (writes to `~/.quarkus/skills/`). For **project-level** customization, use `quarkus_saveSkill` to materialize the full composed skill into `.agent/skills/`, then edit the file directly.
 
 ### Documentation search
 
@@ -284,8 +282,8 @@ For existing projects, `quarkus_update` checks if the Quarkus version is current
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | `quarkus_skills` | Get coding patterns, testing guidelines, and pitfalls for project extensions | `projectDir` (required), `query` |
-| `quarkus_updateSkill` | Create or update a skill customization (enhance or override) | `projectDir` (required), `skillName` (required), `content` (required), `description`, `categories`, `mode`, `scope` |
-| `quarkus_saveSkill` | Save a composed skill as a local file in `.agent/skills/` for inspection and version control | `projectDir` (required), `skillName` (required) |
+| `quarkus_updateSkill` | Create or update a global skill customization (enhance or override) in `~/.quarkus/skills/` | `projectDir` (required), `skillName` (required), `content` (required), `description`, `categories`, `mode` |
+| `quarkus_saveSkill` | Materialize a composed skill as a standalone file in `.agent/skills/` for any agent to read | `projectDir` (required), `skillName` (required) |
 
 ### Lifecycle Management
 

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -522,18 +522,13 @@ public class CreateTools {
 
                     ## Customizing Skills
 
-                    Extension skills can be customized per-project or globally using `quarkus_updateSkill`.
-                    When the user asks to update or customize a skill, ask them:
-                    1. **Enhance or override?** -- Enhance (default) appends content to the base skill.
-                       Override fully replaces the base skill.
-                    2. **Project or global scope?** -- Project scope (`.agent/skills/`) affects only this project.
-                       Global scope (`~/.quarkus/skills/`) affects all projects.
+                    **Global customizations** (`~/.quarkus/skills/`) apply to all projects. Use `quarkus_updateSkill`
+                    to create or update global customizations. Ask the user whether to ENHANCE (append to the base)
+                    or OVERRIDE (fully replace the base).
 
-                    Skills use a three-layer chain: JAR defaults -> global customizations -> project customizations.
-                    Each layer can either enhance (append to) or override (replace) the previous layer.
-
-                    You can also manually place SKILL.md files under `.agent/skills/<extension-name>/SKILL.md`.
-                    Use `mode: enhance` (default) or `mode: override` in the YAML frontmatter to control behavior.
+                    **Project-level skills** (`.agent/skills/`) are standalone files readable by any agent.
+                    Use `quarkus_saveSkill` to materialize the full composed skill into `.agent/skills/`,
+                    then edit the file directly to customize it for the project.
                     """;
             Files.writeString(Path.of(projectDir, "AGENTS.md"), agentsMdContent, StandardCharsets.UTF_8);
             LOG.debugf("Generated AGENTS.md in %s", projectDir);

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -526,13 +526,13 @@ public class CreateTools {
                     When the user asks to update or customize a skill, ask them:
                     1. **Enhance or override?** -- Enhance (default) appends content to the base skill.
                        Override fully replaces the base skill.
-                    2. **Project or global scope?** -- Project scope (`.quarkus/skills/`) affects only this project.
+                    2. **Project or global scope?** -- Project scope (`.agent/skills/`) affects only this project.
                        Global scope (`~/.quarkus/skills/`) affects all projects.
 
                     Skills use a three-layer chain: JAR defaults -> global customizations -> project customizations.
                     Each layer can either enhance (append to) or override (replace) the previous layer.
 
-                    You can also manually place SKILL.md files under `.quarkus/skills/<extension-name>/SKILL.md`.
+                    You can also manually place SKILL.md files under `.agent/skills/<extension-name>/SKILL.md`.
                     Use `mode: enhance` (default) or `mode: override` in the YAML frontmatter to control behavior.
                     """;
             Files.writeString(Path.of(projectDir, "AGENTS.md"), agentsMdContent, StandardCharsets.UTF_8);

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -114,7 +114,7 @@ public class DevMcpProxyTools {
             + "Skills may include an 'Available Dev MCP Tools' section listing extension-specific Dev MCP tools "
             + "that can be invoked via quarkus_callTool (e.g. OpenAPI schema retrieval, scheduler job management). "
             + "Skills can be customized using quarkus_updateSkill. Customizations use a three-layer chain: "
-            + "JAR defaults -> global (~/.quarkus/skills/) -> project (.quarkus/skills/). "
+            + "JAR defaults -> global (~/.quarkus/skills/) -> project (.agent/skills/). "
             + "By default, customizations ENHANCE (append to) the base skill. "
             + "Use mode 'override' to fully replace a base skill.",
             // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
@@ -271,7 +271,7 @@ public class DevMcpProxyTools {
             + "IMPORTANT: Before writing, ask the user two questions: "
             + "(1) Should this ENHANCE the existing skill (append your content to the base) or OVERRIDE it (fully replace the base)? "
             + "Enhance is the default and recommended for most cases. "
-            + "(2) Should this be saved at PROJECT scope (.quarkus/skills/ in the project, affects only this project) "
+            + "(2) Should this be saved at PROJECT scope (.agent/skills/ in the project, affects only this project) "
             + "or GLOBAL scope (~/.quarkus/skills/, affects all projects)?",
             // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
             // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
@@ -283,7 +283,7 @@ public class DevMcpProxyTools {
             @ToolArg(description = "Optional description for the skill", required = false) String description,
             @ToolArg(description = "Optional comma-separated categories for the skill index (e.g. 'web', 'data', 'security', 'core')", required = false) String categories,
             @ToolArg(description = "Mode: 'enhance' (default) appends to the base skill, 'override' fully replaces it", required = false) String mode,
-            @ToolArg(description = "Scope: 'project' (default) saves under .quarkus/skills/ in the project, "
+            @ToolArg(description = "Scope: 'project' (default) saves under .agent/skills/ in the project, "
                     + "'global' saves under ~/.quarkus/skills/", required = false) String scope) {
         try {
             SkillReader.SkillMode skillMode = SkillReader.SkillMode.fromString(mode);
@@ -308,7 +308,7 @@ public class DevMcpProxyTools {
     }
 
     @Tool(name = "quarkus_saveSkill", description = "Save/materialize a composed extension skill as a local file "
-            + "in the project's .quarkus/skills/ directory. This creates a local copy of the full skill "
+            + "in the project's .agent/skills/ directory. This creates a local copy of the full skill "
             + "(including any existing user/project customizations) that the user can then see, "
             + "version-control, and edit directly. The saved file uses OVERRIDE mode. "
             + "Use this when the user wants to inspect, customize, or version-control an extension skill. "

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -289,7 +289,7 @@ public class DevMcpProxyTools {
             List<String> parsedCategories = categories != null ? SkillReader.parseCategories(categories) : null;
             Path written = SkillReader.writeSkill(
                     skillName, content, description, parsedCategories, skillMode,
-                    projectDir, localSkillsDir.map(Path::of).orElse(null), false);
+                    null, localSkillsDir.map(Path::of).orElse(null), false);
 
             String modeLabel = skillMode == SkillReader.SkillMode.ENHANCE ? "enhance" : "override";
             return ToolResponse.success(

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -113,10 +113,9 @@ public class DevMcpProxyTools {
             + "If the app is still building (just created), this will wait for the build to complete. "
             + "Skills may include an 'Available Dev MCP Tools' section listing extension-specific Dev MCP tools "
             + "that can be invoked via quarkus_callTool (e.g. OpenAPI schema retrieval, scheduler job management). "
-            + "Skills can be customized using quarkus_updateSkill. Customizations use a three-layer chain: "
-            + "JAR defaults -> global (~/.quarkus/skills/) -> project (.agent/skills/). "
-            + "By default, customizations ENHANCE (append to) the base skill. "
-            + "Use mode 'override' to fully replace a base skill.",
+            + "Skills can be customized globally using quarkus_updateSkill (writes to ~/.quarkus/skills/). "
+            + "Project-level skills in .agent/skills/ are standalone files readable by any agent -- "
+            + "use quarkus_saveSkill to materialize a fully composed skill there, then edit directly.",
             // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
             // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
             annotations = @Tool.Annotations(title = "quarkus_skills", readOnlyHint = true, destructiveHint = false, idempotentHint = true, openWorldHint = false))
@@ -266,13 +265,14 @@ public class DevMcpProxyTools {
         return sb.toString();
     }
 
-    @Tool(name = "quarkus_updateSkill", description = "Create or update a skill customization for a Quarkus extension. "
-            + "Use this when the user wants to add project conventions, team standards, or guardrails to an extension skill. "
-            + "IMPORTANT: Before writing, ask the user two questions: "
-            + "(1) Should this ENHANCE the existing skill (append your content to the base) or OVERRIDE it (fully replace the base)? "
+    @Tool(name = "quarkus_updateSkill", description = "Create or update a global skill customization for a Quarkus extension. "
+            + "Writes to ~/.quarkus/skills/ (affects all projects). "
+            + "Use this when the user wants to add personal conventions or guardrails to an extension skill. "
+            + "IMPORTANT: Before writing, ask the user: "
+            + "Should this ENHANCE the existing skill (append your content to the base) or OVERRIDE it (fully replace the base)? "
             + "Enhance is the default and recommended for most cases. "
-            + "(2) Should this be saved at PROJECT scope (.agent/skills/ in the project, affects only this project) "
-            + "or GLOBAL scope (~/.quarkus/skills/, affects all projects)?",
+            + "For project-level customization, use quarkus_saveSkill to materialize a skill into .agent/skills/, "
+            + "then edit the file directly.",
             // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
             // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
             annotations = @Tool.Annotations(title = "quarkus_updateSkill", readOnlyHint = false, destructiveHint = false, idempotentHint = true))
@@ -282,24 +282,20 @@ public class DevMcpProxyTools {
             @ToolArg(description = "The skill content in markdown (without frontmatter -- it will be generated)") String content,
             @ToolArg(description = "Optional description for the skill", required = false) String description,
             @ToolArg(description = "Optional comma-separated categories for the skill index (e.g. 'web', 'data', 'security', 'core')", required = false) String categories,
-            @ToolArg(description = "Mode: 'enhance' (default) appends to the base skill, 'override' fully replaces it", required = false) String mode,
-            @ToolArg(description = "Scope: 'project' (default) saves under .agent/skills/ in the project, "
-                    + "'global' saves under ~/.quarkus/skills/", required = false) String scope) {
+            @ToolArg(description = "Mode: 'enhance' (default) appends to the base skill, 'override' fully replaces it", required = false) String mode) {
         try {
             SkillReader.SkillMode skillMode = SkillReader.SkillMode.fromString(mode);
-            boolean projectScope = !"global".equalsIgnoreCase(scope);
 
             List<String> parsedCategories = categories != null ? SkillReader.parseCategories(categories) : null;
             Path written = SkillReader.writeSkill(
                     skillName, content, description, parsedCategories, skillMode,
-                    projectDir, localSkillsDir.map(Path::of).orElse(null), projectScope);
+                    projectDir, localSkillsDir.map(Path::of).orElse(null), false);
 
             String modeLabel = skillMode == SkillReader.SkillMode.ENHANCE ? "enhance" : "override";
-            String scopeLabel = projectScope ? "project" : "global";
             return ToolResponse.success(
                     "Skill '" + skillName + "' saved successfully.\n"
                             + "- **Mode**: " + modeLabel + "\n"
-                            + "- **Scope**: " + scopeLabel + "\n"
+                            + "- **Scope**: global\n"
                             + "- **Path**: " + written + "\n\n"
                             + "The skill will take effect on the next call to `quarkus_skills`.");
         } catch (Exception e) {
@@ -307,10 +303,10 @@ public class DevMcpProxyTools {
         }
     }
 
-    @Tool(name = "quarkus_saveSkill", description = "Save/materialize a composed extension skill as a local file "
-            + "in the project's .agent/skills/ directory. This creates a local copy of the full skill "
-            + "(including any existing user/project customizations) that the user can then see, "
-            + "version-control, and edit directly. The saved file uses OVERRIDE mode. "
+    @Tool(name = "quarkus_saveSkill", description = "Save/materialize a composed extension skill as a standalone file "
+            + "in the project's .agent/skills/ directory. This creates a self-contained copy of the full skill "
+            + "(including extension metadata and any global customizations) that any agent can read directly "
+            + "from the filesystem. The user can then edit the file to customize it for the project. "
             + "Use this when the user wants to inspect, customize, or version-control an extension skill. "
             + "NOTE: If a local project skill already exists for this name, the tool will NOT overwrite it.",
             annotations = @Tool.Annotations(title = "quarkus_saveSkill", readOnlyHint = false, destructiveHint = false, idempotentHint = false))
@@ -345,7 +341,7 @@ public class DevMcpProxyTools {
         } catch (FileAlreadyExistsException e) {
             return ToolResponse.success(
                     "A local skill for '" + skillName + "' already exists at " + e.getFile() + ".\n"
-                            + "To modify it, edit the file directly or use quarkus_updateSkill.");
+                            + "To modify it, edit the file directly.");
         } catch (Exception e) {
             return ToolResponse.error("Failed to save skill: " + e.getMessage());
         }

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -998,7 +998,9 @@ public final class SkillReader {
         if (categories != null && !categories.isEmpty()) {
             sb.append("categories: \"").append(String.join(", ", categories)).append("\"\n");
         }
-        sb.append("mode: ").append(mode.name().toLowerCase()).append("\n");
+        if (!projectScope) {
+            sb.append("mode: ").append(mode.name().toLowerCase()).append("\n");
+        }
         sb.append("---\n\n");
         sb.append(content);
 

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -55,7 +55,7 @@ import org.w3c.dom.NodeList;
  *       {@code quarkus-extension-skills} JAR for older Quarkus versions.</li>
  *   <li><b>User-level skills</b> — from {@code ~/.quarkus/skills/} or a configured
  *       directory (for extension developers testing globally)</li>
- *   <li><b>Project-level skills</b> — from {@code .quarkus/skills/}
+ *   <li><b>Project-level skills</b> — from {@code .agent/skills/}
  *       in the project directory (for per-project customization)</li>
  * </ol>
  * Each layer can either <b>enhance</b> (append to) or <b>override</b> (replace)
@@ -199,9 +199,9 @@ public final class SkillReader {
         Path effectiveLocalDir = localSkillsDir != null ? localSkillsDir : DEFAULT_LOCAL_SKILLS_DIR;
         overlaySkills(skillsByName, readLocalSkills(effectiveLocalDir, metadataOnly), effectiveLocalDir.toString());
 
-        // Layer 3: Overlay project-level skills (.quarkus/skills/)
+        // Layer 3: Overlay project-level skills (.agent/skills/)
         if (projectDir != null) {
-            Path projectSkillsDir = Path.of(projectDir, ".quarkus", "skills");
+            Path projectSkillsDir = Path.of(projectDir, ".agent", "skills");
             overlaySkills(skillsByName, readLocalSkills(projectSkillsDir, metadataOnly), projectSkillsDir.toString());
         }
 
@@ -954,7 +954,7 @@ public final class SkillReader {
      * @param mode         ENHANCE or OVERRIDE
      * @param projectDir   the project directory (used for project-scope writes)
      * @param localSkillsDir user-level skills directory, or null for the default
-     * @param projectScope true to write under {@code <projectDir>/.quarkus/skills/},
+     * @param projectScope true to write under {@code <projectDir>/.agent/skills/},
      *                     false to write under the user-level directory
      * @return the path the file was written to
      */
@@ -974,7 +974,7 @@ public final class SkillReader {
 
         Path baseDir;
         if (projectScope) {
-            baseDir = Path.of(projectDir, ".quarkus", "skills");
+            baseDir = Path.of(projectDir, ".agent", "skills");
         } else {
             baseDir = localSkillsDir != null ? localSkillsDir : DEFAULT_LOCAL_SKILLS_DIR;
         }

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -56,11 +56,14 @@ import org.w3c.dom.NodeList;
  *   <li><b>User-level skills</b> — from {@code ~/.quarkus/skills/} or a configured
  *       directory (for extension developers testing globally)</li>
  *   <li><b>Project-level skills</b> — from {@code .agent/skills/}
- *       in the project directory (for per-project customization)</li>
+ *       in the project directory. These are standalone files read as-is
+ *       (no composition with base layers), so any agent can read them
+ *       directly from the filesystem. Use {@code quarkus_saveSkill} to
+ *       materialize a fully composed skill into this directory.</li>
  * </ol>
- * Each layer can either <b>enhance</b> (append to) or <b>override</b> (replace)
- * the previous layer, controlled by the {@code mode} field in the SKILL.md
- * frontmatter. The default mode is {@code enhance}.
+ * Layers 1 and 2 support <b>enhance</b> (append) and <b>override</b> (replace)
+ * composition via the {@code mode} field in the SKILL.md frontmatter.
+ * Layer 3 (project) always replaces — no composition is applied.
  */
 public final class SkillReader {
 
@@ -199,10 +202,13 @@ public final class SkillReader {
         Path effectiveLocalDir = localSkillsDir != null ? localSkillsDir : DEFAULT_LOCAL_SKILLS_DIR;
         overlaySkills(skillsByName, readLocalSkills(effectiveLocalDir, metadataOnly), effectiveLocalDir.toString());
 
-        // Layer 3: Overlay project-level skills (.agent/skills/)
+        // Layer 3: Project-level skills (.agent/skills/) — standalone, no composition
         if (projectDir != null) {
             Path projectSkillsDir = Path.of(projectDir, ".agent", "skills");
-            overlaySkills(skillsByName, readLocalSkills(projectSkillsDir, metadataOnly), projectSkillsDir.toString());
+            for (SkillInfo skill : readLocalSkills(projectSkillsDir, metadataOnly)) {
+                skillsByName.put(skill.name(), skill);
+                LOG.infof("Skill '%s' loaded from project %s", skill.name(), projectSkillsDir);
+            }
         }
 
         LOG.infof("Found %d skills for project %s (version %s)",
@@ -954,7 +960,8 @@ public final class SkillReader {
      * @param mode         ENHANCE or OVERRIDE
      * @param projectDir   the project directory (used for project-scope writes)
      * @param localSkillsDir user-level skills directory, or null for the default
-     * @param projectScope true to write under {@code <projectDir>/.agent/skills/},
+     * @param projectScope true to write under {@code <projectDir>/.agent/skills/}
+     *                     (used by {@code saveSkill} to materialize composed skills),
      *                     false to write under the user-level directory
      * @return the path the file was written to
      */

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -595,7 +595,7 @@ class SkillReaderTest {
         String content = Files.readString(written);
         assertTrue(content.contains("name: quarkus-rest"));
         assertTrue(content.contains("description: \"Custom REST skill\""));
-        assertTrue(content.contains("mode: enhance"));
+        assertFalse(content.contains("mode:"), "Project-scoped skills should not include mode");
         assertTrue(content.contains("### My custom patterns"));
         assertEquals(projectDir.resolve(".agent/skills/quarkus-rest/SKILL.md"), written);
     }
@@ -622,7 +622,23 @@ class SkillReaderTest {
     }
 
     @Test
-    void writeSkillWithOverrideMode() throws Exception {
+    void writeSkillWithOverrideModeGlobal() throws Exception {
+        Path globalDir = tempDir.resolve("global-skills");
+
+        Path written = SkillReader.writeSkill(
+                "quarkus-rest",
+                "### Full replacement",
+                "Override skill",
+                null,
+                SkillReader.SkillMode.OVERRIDE,
+                null, globalDir, false);
+
+        String content = Files.readString(written);
+        assertTrue(content.contains("mode: override"));
+    }
+
+    @Test
+    void writeSkillProjectScopeOmitsMode() throws Exception {
         Path projectDir = tempDir.resolve("my-project");
         Files.createDirectories(projectDir);
 
@@ -635,7 +651,7 @@ class SkillReaderTest {
                 projectDir.toString(), null, true);
 
         String content = Files.readString(written);
-        assertTrue(content.contains("mode: override"));
+        assertFalse(content.contains("mode:"), "Project-scoped skills should not include mode");
     }
 
     @Test
@@ -1605,7 +1621,7 @@ class SkillReaderTest {
         assertTrue(Files.exists(written));
         String savedContent = Files.readString(written);
         assertTrue(savedContent.contains("name: quarkus-arc"));
-        assertTrue(savedContent.contains("mode: override"));
+        assertFalse(savedContent.contains("mode:"), "Project-scoped skills should not include mode");
         assertTrue(savedContent.contains("description: \"Build time CDI\""));
         assertTrue(savedContent.contains("categories: \"core\""));
         assertTrue(savedContent.contains("### CDI patterns"));
@@ -1642,7 +1658,8 @@ class SkillReaderTest {
 
         SkillReader.SkillInfo result = skillMap.get("quarkus-arc");
         assertNotNull(result);
-        assertEquals(SkillReader.SkillMode.OVERRIDE, result.mode());
+        // Project skills don't write mode to frontmatter, so parsed mode defaults to ENHANCE
+        assertEquals(SkillReader.SkillMode.ENHANCE, result.mode());
     }
 
     @Test

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -279,6 +279,44 @@ class SkillReaderTest {
     }
 
     @Test
+    void projectSkillReplacesBaseWithoutComposition() throws Exception {
+        // Base skill simulating JAR layer
+        SkillReader.SkillInfo base = new SkillReader.SkillInfo(
+                "quarkus-rest", "Base REST skill", "### Base REST patterns\nUse @GET for endpoints.",
+                SkillReader.SkillMode.ENHANCE, List.of("web"));
+
+        // Project-level skill in .agent/skills/ with ENHANCE mode
+        Path projectSkillsDir = tempDir.resolve(".agent/skills/quarkus-rest");
+        Files.createDirectories(projectSkillsDir);
+        Files.writeString(projectSkillsDir.resolve("SKILL.md"), """
+                ---
+                name: quarkus-rest
+                description: "Project REST conventions"
+                mode: enhance
+                ---
+
+                ### Project-specific patterns
+                Always use record DTOs.
+                """);
+
+        Map<String, SkillReader.SkillInfo> skillMap = new LinkedHashMap<>();
+        skillMap.put(base.name(), base);
+
+        // Project skills should replace directly — no enhance composition even though mode says enhance
+        Path skillsDir = tempDir.resolve(".agent/skills");
+        for (SkillReader.SkillInfo skill : SkillReader.readLocalSkills(skillsDir)) {
+            skillMap.put(skill.name(), skill);
+        }
+
+        SkillReader.SkillInfo result = skillMap.get("quarkus-rest");
+        assertNotNull(result);
+        assertEquals("Project REST conventions", result.description());
+        assertTrue(result.content().contains("Project-specific patterns"));
+        // Base content should NOT be present — project skills are standalone
+        assertFalse(result.content().contains("Base REST patterns"));
+    }
+
+    @Test
     void parseMirrorUrlFromSettingsXml() throws Exception {
         Path settingsFile = tempDir.resolve("settings.xml");
         Files.writeString(settingsFile, """
@@ -1593,13 +1631,14 @@ class SkillReaderTest {
                 base.name(), base.content(), base.description(), base.categories(),
                 SkillReader.SkillMode.OVERRIDE, projectDir.toString(), null, true);
 
-        // Verify the saved skill is used as an override in the three-layer chain
+        // Verify the saved skill replaces the base (project skills are standalone, no composition)
         Map<String, SkillReader.SkillInfo> skillMap = new LinkedHashMap<>();
         skillMap.put(base.name(), base);
 
         Path projectSkillsDir = projectDir.resolve(".agent/skills");
-        List<SkillReader.SkillInfo> projectSkills = SkillReader.readLocalSkills(projectSkillsDir);
-        SkillReader.overlaySkills(skillMap, projectSkills, projectSkillsDir.toString());
+        for (SkillReader.SkillInfo skill : SkillReader.readLocalSkills(projectSkillsDir)) {
+            skillMap.put(skill.name(), skill);
+        }
 
         SkillReader.SkillInfo result = skillMap.get("quarkus-arc");
         assertNotNull(result);

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -257,8 +257,8 @@ class SkillReaderTest {
 
     @Test
     void readLocalSkillsFromProjectDir() throws Exception {
-        // Simulate a project with skills under .quarkus/skills/
-        Path projectSkillsDir = tempDir.resolve(".quarkus/skills/quarkus-rest");
+        // Simulate a project with skills under .agent/skills/
+        Path projectSkillsDir = tempDir.resolve(".agent/skills/quarkus-rest");
         Files.createDirectories(projectSkillsDir);
         Files.writeString(projectSkillsDir.resolve("SKILL.md"), """
                 ---
@@ -269,7 +269,7 @@ class SkillReaderTest {
                 ### Custom REST patterns for this project
                 """);
 
-        Path skillsDir = tempDir.resolve(".quarkus/skills");
+        Path skillsDir = tempDir.resolve(".agent/skills");
         List<SkillReader.SkillInfo> skills = SkillReader.readLocalSkills(skillsDir);
 
         assertEquals(1, skills.size());
@@ -559,7 +559,7 @@ class SkillReaderTest {
         assertTrue(content.contains("description: \"Custom REST skill\""));
         assertTrue(content.contains("mode: enhance"));
         assertTrue(content.contains("### My custom patterns"));
-        assertEquals(projectDir.resolve(".quarkus/skills/quarkus-rest/SKILL.md"), written);
+        assertEquals(projectDir.resolve(".agent/skills/quarkus-rest/SKILL.md"), written);
     }
 
     @Test
@@ -1572,7 +1572,7 @@ class SkillReaderTest {
         assertTrue(savedContent.contains("categories: \"core\""));
         assertTrue(savedContent.contains("### CDI patterns"));
         assertTrue(savedContent.contains("Use @Inject"));
-        assertEquals(projectDir.resolve(".quarkus/skills/quarkus-arc/SKILL.md"), written);
+        assertEquals(projectDir.resolve(".agent/skills/quarkus-arc/SKILL.md"), written);
     }
 
     @Test
@@ -1597,7 +1597,7 @@ class SkillReaderTest {
         Map<String, SkillReader.SkillInfo> skillMap = new LinkedHashMap<>();
         skillMap.put(base.name(), base);
 
-        Path projectSkillsDir = projectDir.resolve(".quarkus/skills");
+        Path projectSkillsDir = projectDir.resolve(".agent/skills");
         List<SkillReader.SkillInfo> projectSkills = SkillReader.readLocalSkills(projectSkillsDir);
         SkillReader.overlaySkills(skillMap, projectSkills, projectSkillsDir.toString());
 
@@ -1641,7 +1641,7 @@ class SkillReaderTest {
                 "quarkus-test", "Updated content", "desc", null,
                 SkillReader.SkillMode.OVERRIDE, projectDir.toString(), null, true);
 
-        Path skillFile = projectDir.resolve(".quarkus/skills/quarkus-test/SKILL.md");
+        Path skillFile = projectDir.resolve(".agent/skills/quarkus-test/SKILL.md");
         String content = Files.readString(skillFile);
         assertTrue(content.contains("Updated content"));
         assertFalse(content.contains("Original content"));


### PR DESCRIPTION
Moves the project-level skills directory from `.quarkus/skills/` to `.agent/skills/` and makes project-level skills standalone — they are read as-is without enhance/override composition, so any agent can read them directly from the filesystem.

The `updateSkill` tool is now global-only (`~/.quarkus/skills/`). For project customization, use `saveSkill` to materialize the full composed skill into `.agent/skills/`, then edit the file directly. The global/user-level path (`~/.quarkus/skills/`) remains unchanged and still supports composition.

Addresses feedback from @maxandersen in #88.