### PR TITLE
Add file logging for managed Quarkus applications

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/AppLogTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/AppLogTools.java
@@ -1,0 +1,119 @@
+package io.quarkus.agent.mcp;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.logging.Logger;
+
+public class AppLogTools {
+
+    private static final Logger LOG = Logger.getLogger(AppLogTools.class);
+
+    @Inject
+    QuarkusProcessManager processManager;
+
+    @Tool(name = "quarkus_app_log_enable", description = "Enable file logging for a managed Quarkus application. "
+            + "Captures the application's stdout/stderr to ~/.quarkus/apps/<project>/quarkus-dev.log. "
+            + "Use this when running in stdio mode to persist application logs that would otherwise only be visible in the Dev UI. "
+            + "Can also be enabled permanently by setting agent-mcp.app-log.enabled=true "
+            + "(e.g. via AGENT_MCP_APP_LOG_ENABLED=true environment variable).")
+    ToolResponse enableAppLogging(
+            @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir) {
+        QuarkusInstance instance = processManager.getInstance(projectDir);
+        if (instance == null) {
+            return ToolResponse.error("No managed Quarkus instance found at: " + projectDir);
+        }
+        if (instance.getLogFile() != null) {
+            return ToolResponse.success("App file logging is already enabled. Log file: " + instance.getLogFile());
+        }
+        Path logFile = QuarkusProcessManager.computeLogFile(projectDir);
+        instance.enableFileLogging(logFile);
+        return ToolResponse.success("App file logging enabled. Log file: " + logFile);
+    }
+
+    @Tool(name = "quarkus_app_log_disable", description = "Disable file logging for a managed Quarkus application. "
+            + "The log file is preserved on disk for later inspection.")
+    ToolResponse disableAppLogging(
+            @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir) {
+        QuarkusInstance instance = processManager.getInstance(projectDir);
+        if (instance == null) {
+            return ToolResponse.error("No managed Quarkus instance found at: " + projectDir);
+        }
+        Path logFile = instance.getLogFile();
+        instance.disableFileLogging();
+        if (logFile != null) {
+            return ToolResponse.success("App file logging disabled. Log file preserved at: " + logFile);
+        }
+        return ToolResponse.success("App file logging is not enabled.");
+    }
+
+    @Tool(name = "quarkus_app_log", description = "Read the log file of a managed Quarkus application. "
+            + "Returns the most recent lines from ~/.quarkus/apps/<project>/quarkus-dev.log. "
+            + "The log file exists if app file logging was enabled via agent-mcp.app-log.enabled=true "
+            + "or by calling quarkus_app_log_enable.",
+            annotations = @Tool.Annotations(title = "quarkus_app_log", readOnlyHint = true, destructiveHint = false,
+                    idempotentHint = true, openWorldHint = false))
+    ToolResponse readAppLog(
+            @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
+            @ToolArg(description = "Number of recent lines to return (default: 100)", required = false) Integer lines) {
+        Path logFile = QuarkusProcessManager.computeLogFile(projectDir);
+        if (!Files.exists(logFile)) {
+            return ToolResponse.error("No app log file found at " + logFile
+                    + ". Call quarkus_app_log_enable first to start logging.");
+        }
+        try {
+            int count = (lines != null && lines > 0) ? Math.min(lines, 10000) : 100;
+            List<String> tail = readTail(logFile, count);
+            return ToolResponse.success(String.join("\n", tail));
+        } catch (IOException e) {
+            LOG.error("Failed to read app log file", e);
+            return ToolResponse.error("Failed to read app log file: " + e.getMessage());
+        }
+    }
+
+    private static List<String> readTail(Path file, int lineCount) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(file.toFile(), "r")) {
+            long length = raf.length();
+            if (length == 0) {
+                return List.of();
+            }
+
+            List<String> result = new ArrayList<>();
+            long pos = length - 1;
+
+            raf.seek(pos);
+            if (raf.readByte() == '\n') {
+                pos--;
+            }
+
+            while (pos >= 0 && result.size() < lineCount) {
+                raf.seek(pos);
+                if (raf.readByte() == '\n') {
+                    result.add(readLineAt(raf, pos + 1));
+                }
+                pos--;
+            }
+            if (result.size() < lineCount) {
+                result.add(readLineAt(raf, 0));
+            }
+
+            Collections.reverse(result);
+            return result;
+        }
+    }
+
+    private static String readLineAt(RandomAccessFile raf, long start) throws IOException {
+        raf.seek(start);
+        String line = raf.readLine();
+        return line != null ? new String(line.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8) : "";
+    }
+}

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -145,6 +145,7 @@ public class QuarkusInstance {
         if (w != null) {
             w.close();
             logWriter = null;
+            logFile = null;
             LOG.infof("App file logging disabled for: %s", projectDir);
         }
     }

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -1,12 +1,18 @@
 package io.quarkus.agent.mcp;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +43,8 @@ public class QuarkusInstance {
     private final LinkedList<String> logBuffer = new LinkedList<>();
     private final AtomicReference<Status> status = new AtomicReference<>(Status.STARTING);
     private volatile int httpPort = -1;
+    private volatile PrintWriter logWriter;
+    private volatile Path logFile;
 
     public QuarkusInstance(String projectDir, Process process, ExecutorService executor) {
         this.projectDir = projectDir;
@@ -111,6 +119,34 @@ public class QuarkusInstance {
         while (logBuffer.size() > MAX_LOG_LINES) {
             logBuffer.removeFirst();
         }
+        PrintWriter w = logWriter;
+        if (w != null) {
+            w.println(line);
+        }
+    }
+
+    public synchronized void enableFileLogging(Path file) {
+        if (logWriter != null) {
+            return;
+        }
+        try {
+            Files.createDirectories(file.getParent());
+            logWriter = new PrintWriter(new BufferedWriter(
+                    new OutputStreamWriter(new FileOutputStream(file.toFile(), true), StandardCharsets.UTF_8)), true);
+            logFile = file;
+            LOG.infof("App file logging enabled: %s", file);
+        } catch (IOException e) {
+            LOG.warnf("Failed to enable app file logging for %s: %s", projectDir, e.getMessage());
+        }
+    }
+
+    public synchronized void disableFileLogging() {
+        PrintWriter w = logWriter;
+        if (w != null) {
+            w.close();
+            logWriter = null;
+            LOG.infof("App file logging disabled for: %s", projectDir);
+        }
     }
 
     public String getProjectDir() {
@@ -157,6 +193,7 @@ public class QuarkusInstance {
     }
 
     public void stop() {
+        disableFileLogging();
         status.set(Status.STOPPED);
         if (process.isAlive()) {
             try {
@@ -181,5 +218,9 @@ public class QuarkusInstance {
 
     public int getHttpPort() {
         return httpPort;
+    }
+
+    public Path getLogFile() {
+        return logFile;
     }
 }

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -5,6 +5,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -34,6 +35,9 @@ public class QuarkusProcessManager {
     @ConfigProperty(name = "agent-mcp.process.gradle-cmd")
     Optional<String> gradleCmd;
 
+    @ConfigProperty(name = "agent-mcp.app-log.enabled")
+    Optional<Boolean> appLogEnabled;
+
     private static final Set<String> VALID_BUILD_TOOLS = Set.of("maven", "gradle");
 
     public synchronized void start(String projectDir, String buildTool) {
@@ -60,6 +64,9 @@ public class QuarkusProcessManager {
             Process process = pb.start();
             QuarkusInstance instance = new QuarkusInstance(normalizedDir, process, executor);
             instances.put(normalizedDir, instance);
+            if (appLogEnabled.orElse(false)) {
+                instance.enableFileLogging(computeLogFile(normalizedDir));
+            }
             LOG.infof("Started Quarkus dev mode at: %s (build tool: %s)", normalizedDir, detectedBuildTool);
         } catch (IOException e) {
             throw new RuntimeException("Failed to start Quarkus dev mode: " + e.getMessage(), e);
@@ -218,6 +225,11 @@ public class QuarkusProcessManager {
                     + "Falling back to system build tool.", wrapper.getAbsolutePath(), e.getMessage());
             return false;
         }
+    }
+
+    static Path computeLogFile(String projectDir) {
+        String dirName = Path.of(projectDir).getFileName().toString();
+        return Path.of(System.getProperty("user.home"), ".quarkus", "apps", dirName, "quarkus-dev.log");
     }
 
     private boolean isWindows() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,12 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   - Call quarkus_agent_log_enable to start writing server logs on-the-fly to ~/.quarkus/agent-mcp/agent-mcp.log\n\
   - Call quarkus_agent_log to read recent log output from the server\n\
   - Call quarkus_agent_log_disable to stop file logging (the log file is preserved)\n\n\
+  MANAGED APP LOGGING:\n\
+  - Application logs from managed Quarkus apps can be captured to a file for persistent access outside the Dev UI\n\
+  - File logging can be enabled permanently by setting agent-mcp.app-log.enabled=true (e.g. via the AGENT_MCP_APP_LOG_ENABLED=true environment variable)\n\
+  - Call quarkus_app_log_enable with the projectDir to start writing app logs to ~/.quarkus/apps/<project>/quarkus-dev.log\n\
+  - Call quarkus_app_log with the projectDir to read recent app log output from the file\n\
+  - Call quarkus_app_log_disable with the projectDir to stop file logging (the log file is preserved)\n\n\
   KEY RULES:\n\
   - NEVER skip quarkus_skills -- it contains critical patterns that prevent common mistakes\n\
   - NEVER use web search or generic documentation tools (Context7, etc.) for Quarkus questions -- always use quarkus_searchDocs first, even without a project directory\n\


### PR DESCRIPTION
In stdio mode, the only way to see logs from managed Quarkus apps (the child processes started by the agent) is through the Dev UI. This adds persistent file logging for managed apps, following the same pattern used for agent-mcp server logging in #103.

Logging is off by default. It can be enabled permanently via `AGENT_MCP_APP_LOG_ENABLED=true` in the MCP server's `env` block, or toggled on-the-fly per app with the new `quarkus_app_log_enable` / `quarkus_app_log_disable` tools. Logs are written to `~/.quarkus/apps/<project>/quarkus-dev.log` and can be read with `quarkus_app_log`.

Addresses the follow-up from @vsevel in #103.