### PR TITLE
Detect and surface container runtime issues to AI agents

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/AppLogTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/AppLogTools.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.jboss.logging.Logger;
 
 public class AppLogTools {
@@ -73,7 +74,12 @@ public class AppLogTools {
         try {
             int count = (lines != null && lines > 0) ? Math.min(lines, 10000) : 100;
             List<String> tail = readTail(logFile, count);
-            return ToolResponse.success(String.join("\n", tail));
+            String logs = String.join("\n", tail);
+            Optional<String> diagnostic = ContainerRuntimeChecker.detectContainerIssues(logs);
+            if (diagnostic.isPresent()) {
+                logs += "\n\n---\n" + diagnostic.get();
+            }
+            return ToolResponse.success(logs);
         } catch (IOException e) {
             LOG.error("Failed to read app log file", e);
             return ToolResponse.error("Failed to read app log file: " + e.getMessage());

--- a/src/main/java/io/quarkus/agent/mcp/ContainerRuntimeChecker.java
+++ b/src/main/java/io/quarkus/agent/mcp/ContainerRuntimeChecker.java
@@ -26,27 +26,29 @@ final class ContainerRuntimeChecker {
     private static final long CACHE_TTL_MS = 60_000;
 
     private static final Map<String, String> DEV_SERVICES_EXTENSIONS = Map.ofEntries(
-            Map.entry("jdbc-postgresql", "PostgreSQL"),
-            Map.entry("jdbc-mysql", "MySQL"),
-            Map.entry("jdbc-mariadb", "MariaDB"),
-            Map.entry("jdbc-mssql", "SQL Server"),
-            Map.entry("jdbc-oracle", "Oracle"),
-            Map.entry("jdbc-db2", "DB2"),
-            Map.entry("reactive-pg-client", "PostgreSQL Reactive"),
-            Map.entry("reactive-mysql-client", "MySQL Reactive"),
-            Map.entry("reactive-mssql-client", "SQL Server Reactive"),
-            Map.entry("reactive-oracle-client", "Oracle Reactive"),
-            Map.entry("mongodb", "MongoDB"),
-            Map.entry("elasticsearch", "Elasticsearch"),
-            Map.entry("opensearch", "OpenSearch"),
-            Map.entry("kafka", "Kafka"),
-            Map.entry("smallrye-reactive-messaging-amqp", "AMQP"),
-            Map.entry("smallrye-reactive-messaging-rabbitmq", "RabbitMQ"),
-            Map.entry("redis", "Redis"),
-            Map.entry("infinispan", "Infinispan"),
-            Map.entry("keycloak", "Keycloak"),
-            Map.entry("oidc", "OIDC/Keycloak"),
-            Map.entry("apicurio", "Apicurio Registry"));
+            Map.entry("quarkus-jdbc-postgresql", "PostgreSQL"),
+            Map.entry("quarkus-jdbc-mysql", "MySQL"),
+            Map.entry("quarkus-jdbc-mariadb", "MariaDB"),
+            Map.entry("quarkus-jdbc-mssql", "SQL Server"),
+            Map.entry("quarkus-jdbc-oracle", "Oracle"),
+            Map.entry("quarkus-jdbc-db2", "DB2"),
+            Map.entry("quarkus-reactive-pg-client", "PostgreSQL Reactive"),
+            Map.entry("quarkus-reactive-mysql-client", "MySQL Reactive"),
+            Map.entry("quarkus-reactive-mssql-client", "SQL Server Reactive"),
+            Map.entry("quarkus-reactive-oracle-client", "Oracle Reactive"),
+            Map.entry("quarkus-mongodb", "MongoDB"),
+            Map.entry("quarkus-elasticsearch", "Elasticsearch"),
+            Map.entry("quarkus-opensearch", "OpenSearch"),
+            Map.entry("quarkus-messaging-kafka", "Kafka"),
+            Map.entry("quarkus-kafka-client", "Kafka"),
+            Map.entry("quarkus-kafka-streams", "Kafka"),
+            Map.entry("quarkus-smallrye-reactive-messaging-amqp", "AMQP"),
+            Map.entry("quarkus-smallrye-reactive-messaging-rabbitmq", "RabbitMQ"),
+            Map.entry("quarkus-redis", "Redis"),
+            Map.entry("quarkus-infinispan", "Infinispan"),
+            Map.entry("quarkus-keycloak", "Keycloak"),
+            Map.entry("quarkus-oidc", "OIDC/Keycloak"),
+            Map.entry("quarkus-apicurio", "Apicurio Registry"));
 
     private static final List<String> CONTAINER_ERROR_PATTERNS = List.of(
             "Could not find a valid Docker environment",
@@ -54,9 +56,7 @@ final class ContainerRuntimeChecker {
             "Is the docker daemon running",
             "docker: not found",
             "podman: not found",
-            "ContainerLaunchException",
-            "Error response from daemon",
-            "DockerClientProviderStrategy: Could not find a valid Docker environment");
+            "ContainerLaunchException");
 
     private ContainerRuntimeChecker() {
     }
@@ -92,7 +92,7 @@ final class ContainerRuntimeChecker {
         }
         List<String> found = new ArrayList<>();
         for (var entry : DEV_SERVICES_EXTENSIONS.entrySet()) {
-            if (content.contains(entry.getKey())) {
+            if (content.contains(entry.getKey()) && !found.contains(entry.getValue())) {
                 found.add(entry.getValue());
             }
         }
@@ -111,8 +111,10 @@ final class ContainerRuntimeChecker {
             }
         }
         if (matchedPattern == null && logText.contains("org.testcontainers")) {
-            if (logText.contains("Exception") || logText.contains("Error")) {
-                matchedPattern = "Testcontainers error (org.testcontainers)";
+            if (logText.contains("Could not start container")
+                    || logText.contains("Timed out waiting for container")
+                    || logText.contains("Container startup failed")) {
+                matchedPattern = "Testcontainers container startup failure";
             }
         }
         if (matchedPattern == null) {
@@ -153,6 +155,25 @@ final class ContainerRuntimeChecker {
             LOG.debugf("Failed to read %s: %s", file, e.getMessage());
             return null;
         }
+    }
+
+    static String containerWarning(String projectDir) {
+        try {
+            if (!isContainerRuntimeAvailable()) {
+                List<String> extensions = detectDevServicesExtensions(projectDir);
+                if (!extensions.isEmpty()) {
+                    return "\n\nWARNING: Docker/Podman is not running. "
+                            + "This project uses extensions that require Dev Services containers: "
+                            + String.join(", ", extensions) + ". "
+                            + "The app will likely fail to start backing services. "
+                            + "Ask the user to start Docker/Podman, then restart the app with quarkus_stop + quarkus_start. "
+                            + "Do NOT attempt to fix this by changing code or configuration.";
+                }
+            }
+        } catch (Exception e) {
+            LOG.debugf("Container runtime check failed: %s", e.getMessage());
+        }
+        return "";
     }
 
     // Visible for testing

--- a/src/main/java/io/quarkus/agent/mcp/ContainerRuntimeChecker.java
+++ b/src/main/java/io/quarkus/agent/mcp/ContainerRuntimeChecker.java
@@ -1,0 +1,165 @@
+package io.quarkus.agent.mcp;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.DockerClientFactory;
+
+/**
+ * Checks container runtime availability and detects container-related errors
+ * in Quarkus application logs. Helps AI agents diagnose Dev Services failures
+ * when Docker/Podman is not running.
+ */
+final class ContainerRuntimeChecker {
+
+    private static final Logger LOG = Logger.getLogger(ContainerRuntimeChecker.class);
+
+    private static volatile Boolean cachedAvailable;
+    private static volatile long cachedAt;
+    private static final long CACHE_TTL_MS = 60_000;
+
+    private static final Map<String, String> DEV_SERVICES_EXTENSIONS = Map.ofEntries(
+            Map.entry("jdbc-postgresql", "PostgreSQL"),
+            Map.entry("jdbc-mysql", "MySQL"),
+            Map.entry("jdbc-mariadb", "MariaDB"),
+            Map.entry("jdbc-mssql", "SQL Server"),
+            Map.entry("jdbc-oracle", "Oracle"),
+            Map.entry("jdbc-db2", "DB2"),
+            Map.entry("reactive-pg-client", "PostgreSQL Reactive"),
+            Map.entry("reactive-mysql-client", "MySQL Reactive"),
+            Map.entry("reactive-mssql-client", "SQL Server Reactive"),
+            Map.entry("reactive-oracle-client", "Oracle Reactive"),
+            Map.entry("mongodb", "MongoDB"),
+            Map.entry("elasticsearch", "Elasticsearch"),
+            Map.entry("opensearch", "OpenSearch"),
+            Map.entry("kafka", "Kafka"),
+            Map.entry("smallrye-reactive-messaging-amqp", "AMQP"),
+            Map.entry("smallrye-reactive-messaging-rabbitmq", "RabbitMQ"),
+            Map.entry("redis", "Redis"),
+            Map.entry("infinispan", "Infinispan"),
+            Map.entry("keycloak", "Keycloak"),
+            Map.entry("oidc", "OIDC/Keycloak"),
+            Map.entry("apicurio", "Apicurio Registry"));
+
+    private static final List<String> CONTAINER_ERROR_PATTERNS = List.of(
+            "Could not find a valid Docker environment",
+            "Cannot connect to the Docker daemon",
+            "Is the docker daemon running",
+            "docker: not found",
+            "podman: not found",
+            "ContainerLaunchException",
+            "Error response from daemon",
+            "DockerClientProviderStrategy: Could not find a valid Docker environment");
+
+    private ContainerRuntimeChecker() {
+    }
+
+    static boolean isContainerRuntimeAvailable() {
+        long now = System.currentTimeMillis();
+        Boolean cached = cachedAvailable;
+        if (cached != null && (now - cachedAt) < CACHE_TTL_MS) {
+            return cached;
+        }
+        synchronized (ContainerRuntimeChecker.class) {
+            if (cachedAvailable != null && (System.currentTimeMillis() - cachedAt) < CACHE_TTL_MS) {
+                return cachedAvailable;
+            }
+            try {
+                cachedAvailable = DockerClientFactory.instance().isDockerAvailable();
+            } catch (Exception e) {
+                LOG.debugf("Container runtime availability check failed: %s", e.getMessage());
+                cachedAvailable = false;
+            }
+            cachedAt = System.currentTimeMillis();
+            return cachedAvailable;
+        }
+    }
+
+    static List<String> detectDevServicesExtensions(String projectDir) {
+        if (projectDir == null || projectDir.isBlank()) {
+            return List.of();
+        }
+        String content = readBuildFileContent(Path.of(projectDir));
+        if (content == null) {
+            return List.of();
+        }
+        List<String> found = new ArrayList<>();
+        for (var entry : DEV_SERVICES_EXTENSIONS.entrySet()) {
+            if (content.contains(entry.getKey())) {
+                found.add(entry.getValue());
+            }
+        }
+        return found;
+    }
+
+    static Optional<String> detectContainerIssues(String logText) {
+        if (logText == null || logText.isEmpty()) {
+            return Optional.empty();
+        }
+        String matchedPattern = null;
+        for (String pattern : CONTAINER_ERROR_PATTERNS) {
+            if (logText.contains(pattern)) {
+                matchedPattern = pattern;
+                break;
+            }
+        }
+        if (matchedPattern == null && logText.contains("org.testcontainers")) {
+            if (logText.contains("Exception") || logText.contains("Error")) {
+                matchedPattern = "Testcontainers error (org.testcontainers)";
+            }
+        }
+        if (matchedPattern == null) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                "CONTAINER RUNTIME ISSUE DETECTED\n\n"
+                        + "The application logs indicate that Docker/Podman is not running or not accessible.\n"
+                        + "This project uses Quarkus Dev Services, which require a container runtime to start "
+                        + "backing services (databases, message brokers, etc.) automatically.\n\n"
+                        + "Detected error: " + matchedPattern + "\n\n"
+                        + "ACTION REQUIRED: Ask the user to start Docker or Podman, then restart the app "
+                        + "with quarkus_restart or quarkus_stop + quarkus_start.\n\n"
+                        + "Do NOT attempt to fix this by modifying code, configuration, or dependencies. "
+                        + "This is an infrastructure issue, not a code issue.");
+    }
+
+    private static String readBuildFileContent(Path projectDir) {
+        Path pomXml = projectDir.resolve("pom.xml");
+        if (Files.exists(pomXml)) {
+            return readFileQuietly(pomXml);
+        }
+        Path buildGradleKts = projectDir.resolve("build.gradle.kts");
+        if (Files.exists(buildGradleKts)) {
+            return readFileQuietly(buildGradleKts);
+        }
+        Path buildGradle = projectDir.resolve("build.gradle");
+        if (Files.exists(buildGradle)) {
+            return readFileQuietly(buildGradle);
+        }
+        return null;
+    }
+
+    private static String readFileQuietly(Path file) {
+        try {
+            return Files.readString(file, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOG.debugf("Failed to read %s: %s", file, e.getMessage());
+            return null;
+        }
+    }
+
+    // Visible for testing
+    static void clearCache() {
+        synchronized (ContainerRuntimeChecker.class) {
+            cachedAvailable = null;
+            cachedAt = 0;
+        }
+    }
+}

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -182,6 +182,7 @@ public class CreateTools {
                 processManager.start(projectDir, buildTool);
                 LOG.infof("Auto-started Quarkus app at: %s", projectDir);
                 return ToolResponse.success("Quarkus project created and starting in dev mode at: " + projectDir
+                        + LifecycleTools.containerWarning(projectDir)
                         + "\n\nNEXT STEPS (follow this order strictly):"
                         + "\n1. STOP -- do NOT write any code yet. For each capability the user requested, "
                         + "search for Quarkus extensions that provide it using quarkus_searchDocs and quarkus_searchTools query='extension'. "

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -182,7 +182,7 @@ public class CreateTools {
                 processManager.start(projectDir, buildTool);
                 LOG.infof("Auto-started Quarkus app at: %s", projectDir);
                 return ToolResponse.success("Quarkus project created and starting in dev mode at: " + projectDir
-                        + LifecycleTools.containerWarning(projectDir)
+                        + ContainerRuntimeChecker.containerWarning(projectDir)
                         + "\n\nNEXT STEPS (follow this order strictly):"
                         + "\n1. STOP -- do NOT write any code yet. For each capability the user requested, "
                         + "search for Quarkus extensions that provide it using quarkus_searchDocs and quarkus_searchTools query='extension'. "

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -6,7 +6,9 @@ import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.ToolResponse;
 import jakarta.inject.Inject;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.jboss.logging.Logger;
 
 /**
@@ -32,7 +34,9 @@ public class LifecycleTools {
             @ToolArg(description = "Build tool to use: 'maven' or 'gradle' (auto-detected if omitted)", required = false) String buildTool) {
         try {
             processManager.start(projectDir, buildTool);
-            return ToolResponse.success("Quarkus application starting in dev mode at: " + projectDir);
+            String message = "Quarkus application starting in dev mode at: " + projectDir;
+            message += containerWarning(projectDir);
+            return ToolResponse.success(message);
         } catch (Exception e) {
             LOG.error("Failed to start Quarkus application at " + projectDir, e);
             return ToolResponse.error(e.getMessage());
@@ -78,9 +82,17 @@ public class LifecycleTools {
             if (instance == null) {
                 return ToolResponse.success("not_started");
             }
-            String status = instance.getStatus().name().toLowerCase();
-            if (instance.getStatus() == QuarkusInstance.Status.RUNNING && instance.getHttpPort() > 0) {
+            QuarkusInstance.Status currentStatus = instance.getStatus();
+            String status = currentStatus.name().toLowerCase();
+            if (currentStatus == QuarkusInstance.Status.RUNNING && instance.getHttpPort() > 0) {
                 return ToolResponse.success(status + " (port: " + instance.getHttpPort() + ")");
+            }
+            if (currentStatus == QuarkusInstance.Status.CRASHED) {
+                String recentLogs = instance.getRecentLogs(100);
+                Optional<String> diagnostic = ContainerRuntimeChecker.detectContainerIssues(recentLogs);
+                if (diagnostic.isPresent()) {
+                    return ToolResponse.success(status + "\n\n" + diagnostic.get());
+                }
             }
             return ToolResponse.success(status);
         } catch (Exception e) {
@@ -104,7 +116,12 @@ public class LifecycleTools {
                 return ToolResponse.error("No instance found for: " + projectDir);
             }
             int count = (lines != null && lines > 0) ? Math.min(lines, 10000) : 50;
-            return ToolResponse.success(instance.getRecentLogs(count));
+            String logs = instance.getRecentLogs(count);
+            Optional<String> diagnostic = ContainerRuntimeChecker.detectContainerIssues(logs);
+            if (diagnostic.isPresent()) {
+                logs += "\n\n---\n" + diagnostic.get();
+            }
+            return ToolResponse.success(logs);
         } catch (Exception e) {
             LOG.error("Failed to get logs for " + projectDir, e);
             return ToolResponse.error(e.getMessage());
@@ -126,5 +143,24 @@ public class LifecycleTools {
         } catch (JsonProcessingException e) {
             return ToolResponse.error("Failed to serialize instance list: " + e.getMessage());
         }
+    }
+
+    static String containerWarning(String projectDir) {
+        try {
+            if (!ContainerRuntimeChecker.isContainerRuntimeAvailable()) {
+                List<String> extensions = ContainerRuntimeChecker.detectDevServicesExtensions(projectDir);
+                if (!extensions.isEmpty()) {
+                    return "\n\nWARNING: Docker/Podman is not running. "
+                            + "This project uses extensions that require Dev Services containers: "
+                            + String.join(", ", extensions) + ". "
+                            + "The app will likely fail to start backing services. "
+                            + "Ask the user to start Docker/Podman, then restart the app with quarkus_stop + quarkus_start. "
+                            + "Do NOT attempt to fix this by changing code or configuration.";
+                }
+            }
+        } catch (Exception e) {
+            LOG.debugf("Container runtime check failed: %s", e.getMessage());
+        }
+        return "";
     }
 }

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -6,7 +6,6 @@ import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.ToolResponse;
 import jakarta.inject.Inject;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.jboss.logging.Logger;
@@ -35,7 +34,7 @@ public class LifecycleTools {
         try {
             processManager.start(projectDir, buildTool);
             String message = "Quarkus application starting in dev mode at: " + projectDir;
-            message += containerWarning(projectDir);
+            message += ContainerRuntimeChecker.containerWarning(projectDir);
             return ToolResponse.success(message);
         } catch (Exception e) {
             LOG.error("Failed to start Quarkus application at " + projectDir, e);
@@ -143,24 +142,5 @@ public class LifecycleTools {
         } catch (JsonProcessingException e) {
             return ToolResponse.error("Failed to serialize instance list: " + e.getMessage());
         }
-    }
-
-    static String containerWarning(String projectDir) {
-        try {
-            if (!ContainerRuntimeChecker.isContainerRuntimeAvailable()) {
-                List<String> extensions = ContainerRuntimeChecker.detectDevServicesExtensions(projectDir);
-                if (!extensions.isEmpty()) {
-                    return "\n\nWARNING: Docker/Podman is not running. "
-                            + "This project uses extensions that require Dev Services containers: "
-                            + String.join(", ", extensions) + ". "
-                            + "The app will likely fail to start backing services. "
-                            + "Ask the user to start Docker/Podman, then restart the app with quarkus_stop + quarkus_start. "
-                            + "Do NOT attempt to fix this by changing code or configuration.";
-                }
-            }
-        } catch (Exception e) {
-            LOG.debugf("Container runtime check failed: %s", e.getMessage());
-        }
-        return "";
     }
 }

--- a/src/test/java/io/quarkus/agent/mcp/ContainerRuntimeCheckerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/ContainerRuntimeCheckerTest.java
@@ -124,6 +124,43 @@ class ContainerRuntimeCheckerTest {
         assertTrue(result.contains("Elasticsearch"));
     }
 
+    @Test
+    void ignoresExtensionNamesInComments() throws IOException {
+        Files.writeString(tempDir.resolve("pom.xml"), """
+                <project>
+                    <!-- TODO: add kafka and redis support later -->
+                    <dependencies>
+                        <dependency>
+                            <artifactId>quarkus-rest-jackson</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+
+        List<String> result = ContainerRuntimeChecker.detectDevServicesExtensions(tempDir.toString());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void deduplicatesMultipleKafkaExtensions() throws IOException {
+        Files.writeString(tempDir.resolve("pom.xml"), """
+                <project>
+                    <dependencies>
+                        <dependency>
+                            <artifactId>quarkus-messaging-kafka</artifactId>
+                        </dependency>
+                        <dependency>
+                            <artifactId>quarkus-kafka-client</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+
+        List<String> result = ContainerRuntimeChecker.detectDevServicesExtensions(tempDir.toString());
+        assertEquals(1, result.size());
+        assertEquals("Kafka", result.get(0));
+    }
+
     // --- detectContainerIssues ---
 
     @Test
@@ -159,13 +196,6 @@ class ContainerRuntimeCheckerTest {
     }
 
     @Test
-    void detectsErrorResponseFromDaemon() {
-        String logs = "Error response from daemon: conflict";
-        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
-        assertTrue(result.isPresent());
-    }
-
-    @Test
     void detectsDockerNotFound() {
         String logs = "docker: not found";
         Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
@@ -180,15 +210,24 @@ class ContainerRuntimeCheckerTest {
     }
 
     @Test
-    void detectsTestcontainersException() {
+    void detectsTestcontainersStartupFailure() {
         String logs = """
                 2024-01-01 INFO Starting
-                org.testcontainers.containers.GenericContainer - something
-                java.lang.Exception: connection refused
+                org.testcontainers.containers.GenericContainer - Could not start container
                 """;
         Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
         assertTrue(result.isPresent());
-        assertTrue(result.get().contains("Testcontainers error"));
+        assertTrue(result.get().contains("Testcontainers container startup failure"));
+    }
+
+    @Test
+    void ignoresNormalTestcontainersLogs() {
+        String logs = """
+                2024-01-01 INFO org.testcontainers.DockerClientFactory - Docker client strategy found
+                2024-01-01 INFO org.testcontainers.utility.ImageNameSubstitutor - Image name substitution
+                """;
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isEmpty());
     }
 
     @Test

--- a/src/test/java/io/quarkus/agent/mcp/ContainerRuntimeCheckerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/ContainerRuntimeCheckerTest.java
@@ -1,0 +1,225 @@
+package io.quarkus.agent.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ContainerRuntimeCheckerTest {
+
+    @TempDir
+    Path tempDir;
+
+    // --- detectDevServicesExtensions ---
+
+    @Test
+    void detectsPostgresqlAndKafkaInMaven() throws IOException {
+        Files.writeString(tempDir.resolve("pom.xml"), """
+                <project>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-jdbc-postgresql</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-messaging-kafka</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+
+        List<String> result = ContainerRuntimeChecker.detectDevServicesExtensions(tempDir.toString());
+        assertTrue(result.contains("PostgreSQL"));
+        assertTrue(result.contains("Kafka"));
+    }
+
+    @Test
+    void detectsRedisInGradleKts() throws IOException {
+        Files.writeString(tempDir.resolve("build.gradle.kts"), """
+                dependencies {
+                    implementation("io.quarkus:quarkus-redis")
+                }
+                """);
+
+        List<String> result = ContainerRuntimeChecker.detectDevServicesExtensions(tempDir.toString());
+        assertTrue(result.contains("Redis"));
+    }
+
+    @Test
+    void detectsMongodbInGradle() throws IOException {
+        Files.writeString(tempDir.resolve("build.gradle"), """
+                dependencies {
+                    implementation 'io.quarkus:quarkus-mongodb-client'
+                }
+                """);
+
+        List<String> result = ContainerRuntimeChecker.detectDevServicesExtensions(tempDir.toString());
+        assertTrue(result.contains("MongoDB"));
+    }
+
+    @Test
+    void returnsEmptyForRestOnlyProject() throws IOException {
+        Files.writeString(tempDir.resolve("pom.xml"), """
+                <project>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-rest-jackson</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+
+        List<String> result = ContainerRuntimeChecker.detectDevServicesExtensions(tempDir.toString());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyWhenNoBuildFile() {
+        List<String> result = ContainerRuntimeChecker.detectDevServicesExtensions(tempDir.toString());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForNullProjectDir() {
+        List<String> result = ContainerRuntimeChecker.detectDevServicesExtensions(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForBlankProjectDir() {
+        List<String> result = ContainerRuntimeChecker.detectDevServicesExtensions("   ");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void detectsMultipleExtensions() throws IOException {
+        Files.writeString(tempDir.resolve("pom.xml"), """
+                <project>
+                    <dependencies>
+                        <dependency>
+                            <artifactId>quarkus-jdbc-postgresql</artifactId>
+                        </dependency>
+                        <dependency>
+                            <artifactId>quarkus-redis</artifactId>
+                        </dependency>
+                        <dependency>
+                            <artifactId>quarkus-elasticsearch</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """);
+
+        List<String> result = ContainerRuntimeChecker.detectDevServicesExtensions(tempDir.toString());
+        assertEquals(3, result.size());
+        assertTrue(result.contains("PostgreSQL"));
+        assertTrue(result.contains("Redis"));
+        assertTrue(result.contains("Elasticsearch"));
+    }
+
+    // --- detectContainerIssues ---
+
+    @Test
+    void detectsDockerEnvironmentError() {
+        String logs = "2024-01-01 ERROR Could not find a valid Docker environment";
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isPresent());
+        assertTrue(result.get().contains("CONTAINER RUNTIME ISSUE DETECTED"));
+        assertTrue(result.get().contains("Could not find a valid Docker environment"));
+    }
+
+    @Test
+    void detectsDockerDaemonNotRunning() {
+        String logs = "Cannot connect to the Docker daemon at unix:///var/run/docker.sock";
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isPresent());
+        assertTrue(result.get().contains("Cannot connect to the Docker daemon"));
+    }
+
+    @Test
+    void detectsIsDockerDaemonRunning() {
+        String logs = "Is the docker daemon running?";
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    void detectsContainerLaunchException() {
+        String logs = "org.testcontainers.containers.ContainerLaunchException: failed to start";
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isPresent());
+        assertTrue(result.get().contains("ContainerLaunchException"));
+    }
+
+    @Test
+    void detectsErrorResponseFromDaemon() {
+        String logs = "Error response from daemon: conflict";
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    void detectsDockerNotFound() {
+        String logs = "docker: not found";
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    void detectsPodmanNotFound() {
+        String logs = "podman: not found";
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    void detectsTestcontainersException() {
+        String logs = """
+                2024-01-01 INFO Starting
+                org.testcontainers.containers.GenericContainer - something
+                java.lang.Exception: connection refused
+                """;
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isPresent());
+        assertTrue(result.get().contains("Testcontainers error"));
+    }
+
+    @Test
+    void returnsEmptyForCleanLogs() {
+        String logs = """
+                2024-01-01 INFO Quarkus started
+                2024-01-01 INFO Listening on: http://0.0.0.0:8080
+                2024-01-01 INFO installed features: [cdi, rest]
+                """;
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForNullLogs() {
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(null);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForEmptyLogs() {
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues("");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void diagnosticIncludesActionGuidance() {
+        String logs = "Could not find a valid Docker environment";
+        Optional<String> result = ContainerRuntimeChecker.detectContainerIssues(logs);
+        assertTrue(result.isPresent());
+        assertTrue(result.get().contains("Ask the user to start Docker or Podman"));
+        assertTrue(result.get().contains("Do NOT attempt to fix this by modifying code"));
+    }
+}


### PR DESCRIPTION
When Docker/Podman isn't running, Quarkus Dev Services fail with cryptic Testcontainers errors. AI agents (like Bob) reading these logs can't interpret the root cause and spiral trying code/config fixes instead of simply asking the user to start their container runtime.

This adds two layers of detection:

**Proactive warning** — When `quarkus_start` or `quarkus_create` launches an app, the response now checks if Docker/Podman is available. If not, and the project uses extensions that need Dev Services containers (detected by scanning `pom.xml`/`build.gradle` for 21 known extension patterns like `jdbc-postgresql`, `kafka`, `redis`, etc.), a clear warning is appended telling the agent to ask the user to start Docker/Podman — not to attempt code fixes.

**Reactive diagnosis** — When `quarkus_logs`, `quarkus_status` (on crash), or `quarkus_app_log` returns output, the logs are scanned for known container-failure patterns (`"Could not find a valid Docker environment"`, `"ContainerLaunchException"`, `"Cannot connect to the Docker daemon"`, etc.). If matched, a diagnostic block is appended with the detected error and explicit agent-directed guidance: "Do NOT attempt to fix this by modifying code, configuration, or dependencies. This is an infrastructure issue."

The Docker availability check uses a 60-second TTL cache so it refreshes after the user starts Docker, unlike the permanent cache used for doc-search containers.

Closes #109