### PR TITLE
Add configurable HTTP port for dev mode with auto-assignment

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -76,7 +76,10 @@ public class CreateTools {
                     + "Some extensions provide useful starter code tailored to the extension; "
                     + "others only generate a basic hello world.") boolean noCode,
             @ToolArg(description = "Whether to skip generating the Maven/Gradle wrapper scripts. "
-                    + "If not specified, ask the user before creating the project.") boolean noWrapper) {
+                    + "If not specified, ask the user before creating the project.") boolean noWrapper,
+            @ToolArg(description = "HTTP port for the Quarkus application when it auto-starts in dev mode (e.g. 8081). "
+                    + "If omitted, defaults to 8080. When 8080 is already in use, "
+                    + "an available port is assigned automatically.", required = false) Integer httpPort) {
         try {
             String resolvedGroupId = (groupId != null && !groupId.isBlank()) ? groupId : "org.acme";
             String resolvedArtifactId = (artifactId != null && !artifactId.isBlank()) ? artifactId : "quarkus-app";
@@ -179,7 +182,7 @@ public class CreateTools {
 
             // Auto-start the app in dev mode
             try {
-                processManager.start(projectDir, buildTool);
+                processManager.start(projectDir, buildTool, httpPort);
                 LOG.infof("Auto-started Quarkus app at: %s", projectDir);
                 return ToolResponse.success("Quarkus project created and starting in dev mode at: " + projectDir
                         + ContainerRuntimeChecker.containerWarning(projectDir)

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -182,9 +182,10 @@ public class CreateTools {
 
             // Auto-start the app in dev mode
             try {
-                processManager.start(projectDir, buildTool, httpPort);
+                Integer effectivePort = processManager.start(projectDir, buildTool, httpPort);
                 LOG.infof("Auto-started Quarkus app at: %s", projectDir);
-                return ToolResponse.success("Quarkus project created and starting in dev mode at: " + projectDir
+                String portInfo = effectivePort != null ? " (port: " + effectivePort + ")" : "";
+                return ToolResponse.success("Quarkus project created and starting in dev mode at: " + projectDir + portInfo
                         + ContainerRuntimeChecker.containerWarning(projectDir)
                         + "\n\nNEXT STEPS (follow this order strictly):"
                         + "\n1. STOP -- do NOT write any code yet. For each capability the user requested, "

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -30,9 +30,12 @@ public class LifecycleTools {
             + "RULES: Always write tests. Always keep README.md updated after changes.")
     ToolResponse start(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
-            @ToolArg(description = "Build tool to use: 'maven' or 'gradle' (auto-detected if omitted)", required = false) String buildTool) {
+            @ToolArg(description = "Build tool to use: 'maven' or 'gradle' (auto-detected if omitted)", required = false) String buildTool,
+            @ToolArg(description = "HTTP port for the Quarkus application (e.g. 8081). "
+                    + "If omitted, defaults to 8080. When 8080 is already in use, "
+                    + "an available port is assigned automatically.", required = false) Integer httpPort) {
         try {
-            processManager.start(projectDir, buildTool);
+            processManager.start(projectDir, buildTool, httpPort);
             String message = "Quarkus application starting in dev mode at: " + projectDir;
             message += ContainerRuntimeChecker.containerWarning(projectDir);
             return ToolResponse.success(message);

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -35,8 +35,11 @@ public class LifecycleTools {
                     + "If omitted, defaults to 8080. When 8080 is already in use, "
                     + "an available port is assigned automatically.", required = false) Integer httpPort) {
         try {
-            processManager.start(projectDir, buildTool, httpPort);
+            Integer effectivePort = processManager.start(projectDir, buildTool, httpPort);
             String message = "Quarkus application starting in dev mode at: " + projectDir;
+            if (effectivePort != null) {
+                message += " (port: " + effectivePort + ")";
+            }
             message += ContainerRuntimeChecker.containerWarning(projectDir);
             return ToolResponse.success(message);
         } catch (Exception e) {

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -39,6 +39,8 @@ public class QuarkusInstance {
     static final int MAX_LOG_LINES = 500;
 
     private final String projectDir;
+    private final String buildTool;
+    private final Integer requestedHttpPort;
     private final Process process;
     private final LinkedList<String> logBuffer = new LinkedList<>();
     private final AtomicReference<Status> status = new AtomicReference<>(Status.STARTING);
@@ -46,8 +48,11 @@ public class QuarkusInstance {
     private volatile PrintWriter logWriter;
     private volatile Path logFile;
 
-    public QuarkusInstance(String projectDir, Process process, ExecutorService executor) {
+    public QuarkusInstance(String projectDir, String buildTool, Integer requestedHttpPort, Process process,
+            ExecutorService executor) {
         this.projectDir = projectDir;
+        this.buildTool = buildTool;
+        this.requestedHttpPort = requestedHttpPort;
         this.process = process;
 
         executor.submit(() -> captureStream(process.getInputStream()));
@@ -219,6 +224,14 @@ public class QuarkusInstance {
 
     public int getHttpPort() {
         return httpPort;
+    }
+
+    public String getBuildTool() {
+        return buildTool;
+    }
+
+    public Integer getRequestedHttpPort() {
+        return requestedHttpPort;
     }
 
     public Path getLogFile() {

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -43,7 +43,7 @@ public class QuarkusProcessManager {
     static final int DEFAULT_HTTP_PORT = 8080;
     private static final int MAX_PORT_SCAN = 100;
 
-    public synchronized void start(String projectDir, String buildTool, Integer httpPort) {
+    public synchronized Integer start(String projectDir, String buildTool, Integer httpPort) {
         if (buildTool != null && !VALID_BUILD_TOOLS.contains(buildTool.toLowerCase())) {
             throw new IllegalArgumentException(
                     "Invalid build tool: '" + buildTool + "'. Must be 'maven' or 'gradle'.");
@@ -75,7 +75,7 @@ public class QuarkusProcessManager {
 
         try {
             Process process = pb.start();
-            QuarkusInstance instance = new QuarkusInstance(normalizedDir, process, executor);
+            QuarkusInstance instance = new QuarkusInstance(normalizedDir, detectedBuildTool, httpPort, process, executor);
             instances.put(normalizedDir, instance);
             if (appLogEnabled.orElse(false)) {
                 instance.enableFileLogging(computeLogFile(normalizedDir));
@@ -84,6 +84,7 @@ public class QuarkusProcessManager {
         } catch (IOException e) {
             throw new RuntimeException("Failed to start Quarkus dev mode: " + e.getMessage(), e);
         }
+        return effectivePort;
     }
 
     public synchronized void stop(String projectDir) {
@@ -106,8 +107,10 @@ public class QuarkusProcessManager {
         }
 
         if (!instance.isAlive()) {
+            String savedBuildTool = instance.getBuildTool();
+            Integer savedHttpPort = instance.getRequestedHttpPort();
             instances.remove(normalizedDir);
-            start(normalizedDir, null, null);
+            start(normalizedDir, savedBuildTool, savedHttpPort);
             LOG.infof("Re-started dead Quarkus instance at: %s", normalizedDir);
         } else {
             instance.restart();
@@ -247,7 +250,6 @@ public class QuarkusProcessManager {
 
     static boolean isPortAvailable(int port) {
         try (ServerSocket ss = new ServerSocket(port)) {
-            ss.setReuseAddress(true);
             return true;
         } catch (IOException e) {
             return false;

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -5,6 +5,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -39,11 +40,17 @@ public class QuarkusProcessManager {
     Optional<Boolean> appLogEnabled;
 
     private static final Set<String> VALID_BUILD_TOOLS = Set.of("maven", "gradle");
+    static final int DEFAULT_HTTP_PORT = 8080;
+    private static final int MAX_PORT_SCAN = 100;
 
-    public synchronized void start(String projectDir, String buildTool) {
+    public synchronized void start(String projectDir, String buildTool, Integer httpPort) {
         if (buildTool != null && !VALID_BUILD_TOOLS.contains(buildTool.toLowerCase())) {
             throw new IllegalArgumentException(
                     "Invalid build tool: '" + buildTool + "'. Must be 'maven' or 'gradle'.");
+        }
+        if (httpPort != null && (httpPort < 1 || httpPort > 65535)) {
+            throw new IllegalArgumentException(
+                    "Invalid HTTP port: " + httpPort + ". Must be between 1 and 65535.");
         }
         String normalizedDir = normalize(projectDir);
 
@@ -57,8 +64,14 @@ public class QuarkusProcessManager {
             LOG.infof("Cleaned up dead instance at: %s", normalizedDir);
         }
 
+        Integer effectivePort = httpPort;
+        if (effectivePort == null && !isPortAvailable(DEFAULT_HTTP_PORT)) {
+            effectivePort = findAvailablePort(DEFAULT_HTTP_PORT);
+            LOG.infof("Default port %d is in use, using port %d instead", DEFAULT_HTTP_PORT, effectivePort);
+        }
+
         String detectedBuildTool = buildTool != null ? buildTool : detectBuildTool(normalizedDir);
-        ProcessBuilder pb = createProcessBuilder(normalizedDir, detectedBuildTool);
+        ProcessBuilder pb = createProcessBuilder(normalizedDir, detectedBuildTool, effectivePort);
 
         try {
             Process process = pb.start();
@@ -94,7 +107,7 @@ public class QuarkusProcessManager {
 
         if (!instance.isAlive()) {
             instances.remove(normalizedDir);
-            start(normalizedDir, null);
+            start(normalizedDir, null, null);
             LOG.infof("Re-started dead Quarkus instance at: %s", normalizedDir);
         } else {
             instance.restart();
@@ -149,7 +162,7 @@ public class QuarkusProcessManager {
                 "Cannot detect build tool at: " + projectDir + ". No pom.xml or build.gradle found.");
     }
 
-    private ProcessBuilder createProcessBuilder(String projectDir, String buildTool) {
+    private ProcessBuilder createProcessBuilder(String projectDir, String buildTool, Integer httpPort) {
         File dir = new File(projectDir);
         if (!dir.isDirectory()) {
             throw new IllegalArgumentException("Not a directory: " + projectDir);
@@ -160,6 +173,11 @@ public class QuarkusProcessManager {
             pb = createGradleProcessBuilder(dir);
         } else {
             pb = createMavenProcessBuilder(dir);
+        }
+
+        if (httpPort != null) {
+            pb.command().add("-Dquarkus.http.port=" + httpPort);
+            pb.command().add("-Dquarkus.http.test-port=0");
         }
 
         pb.directory(dir);
@@ -225,6 +243,26 @@ public class QuarkusProcessManager {
                     + "Falling back to system build tool.", wrapper.getAbsolutePath(), e.getMessage());
             return false;
         }
+    }
+
+    static boolean isPortAvailable(int port) {
+        try (ServerSocket ss = new ServerSocket(port)) {
+            ss.setReuseAddress(true);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    static int findAvailablePort(int startPort) {
+        for (int port = startPort + 1; port <= startPort + MAX_PORT_SCAN; port++) {
+            if (isPortAvailable(port)) {
+                return port;
+            }
+        }
+        throw new IllegalStateException(
+                "Could not find an available port in range " + (startPort + 1) + "-" + (startPort + MAX_PORT_SCAN)
+                        + ". Specify a port explicitly using the httpPort parameter.");
     }
 
     static Path computeLogFile(String projectDir) {

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -24,7 +24,7 @@ class QuarkusInstanceTest {
     @Test
     void initialStatusIsStarting() throws Exception {
         process = new ProcessBuilder("sleep", "10").start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         assertEquals(QuarkusInstance.Status.STARTING, instance.getStatus());
         assertEquals(-1, instance.getHttpPort());
@@ -37,7 +37,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://localhost:8080' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         // Wait for the stream reader to process the output
         Thread.sleep(500);
@@ -51,7 +51,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: https://localhost:8443' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         Thread.sleep(500);
 
@@ -63,7 +63,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'installed features: [cdi, rest]' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         Thread.sleep(500);
 
@@ -76,7 +76,7 @@ class QuarkusInstanceTest {
     void detectsCrashOnProcessExit() throws Exception {
         process = new ProcessBuilder("bash", "-c", "echo 'starting' && exit 1")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         // Wait for process to exit and monitor to detect it
         Thread.sleep(500);
@@ -88,7 +88,7 @@ class QuarkusInstanceTest {
     @Test
     void stopSetsStatusToStopped() throws Exception {
         process = new ProcessBuilder("sleep", "30").start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         instance.stop();
 
@@ -102,7 +102,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "for i in $(seq 1 10); do echo \"line $i\"; done && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         Thread.sleep(500);
 
@@ -115,7 +115,7 @@ class QuarkusInstanceTest {
     @Test
     void getRecentLogsReturnsEmptyForNoLogs() throws Exception {
         process = new ProcessBuilder("sleep", "10").start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         assertEquals("", instance.getRecentLogs(50));
     }
@@ -125,7 +125,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://0.0.0.0:9090' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         Thread.sleep(500);
 
@@ -137,7 +137,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: not-a-url' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         Thread.sleep(500);
 
@@ -149,7 +149,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://localhost:8080 (some extra text)' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         Thread.sleep(500);
 
@@ -161,7 +161,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://localhost:8080' && cat")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         Thread.sleep(500);
         assertEquals(8080, instance.getHttpPort());
@@ -176,7 +176,7 @@ class QuarkusInstanceTest {
     @Test
     void restartThrowsIfProcessDead() throws Exception {
         process = new ProcessBuilder("bash", "-c", "exit 0").start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
 
         Thread.sleep(500);
 

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -164,8 +164,12 @@ class QuarkusProcessManagerTest {
     }
 
     @Test
-    void isPortAvailableReturnsTrueForFreePort() {
-        assertTrue(QuarkusProcessManager.isPortAvailable(0));
+    void isPortAvailableReturnsTrueForFreePort() throws Exception {
+        int port;
+        try (ServerSocket ss = new ServerSocket(0)) {
+            port = ss.getLocalPort();
+        }
+        assertTrue(QuarkusProcessManager.isPortAvailable(port));
     }
 
     @Test

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -3,10 +3,13 @@ package io.quarkus.agent.mcp;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -30,17 +33,17 @@ class QuarkusProcessManagerTest {
 
     @Test
     void startThrowsForNullProjectDir() {
-        assertThrows(IllegalArgumentException.class, () -> manager.start(null, null));
+        assertThrows(IllegalArgumentException.class, () -> manager.start(null, null, null));
     }
 
     @Test
     void startThrowsForEmptyProjectDir() {
-        assertThrows(IllegalArgumentException.class, () -> manager.start("", null));
+        assertThrows(IllegalArgumentException.class, () -> manager.start("", null, null));
     }
 
     @Test
     void startThrowsForBlankProjectDir() {
-        assertThrows(IllegalArgumentException.class, () -> manager.start("   ", null));
+        assertThrows(IllegalArgumentException.class, () -> manager.start("   ", null, null));
     }
 
     @Test
@@ -73,7 +76,7 @@ class QuarkusProcessManagerTest {
     void throwsWhenNoBuildToolDetected() {
         // tempDir has no pom.xml or build.gradle
         assertThrows(IllegalArgumentException.class,
-                () -> manager.start(tempDir.toString(), null));
+                () -> manager.start(tempDir.toString(), null, null));
     }
 
     @Test
@@ -82,7 +85,57 @@ class QuarkusProcessManagerTest {
         Files.writeString(file, "not a directory");
 
         assertThrows(IllegalArgumentException.class,
-                () -> manager.start(file.toString(), "maven"));
+                () -> manager.start(file.toString(), "maven", null));
+    }
+
+    @Test
+    void startThrowsForPortZero() {
+        assertThrows(IllegalArgumentException.class,
+                () -> manager.start(tempDir.toString(), "maven", 0));
+    }
+
+    @Test
+    void startThrowsForNegativePort() {
+        assertThrows(IllegalArgumentException.class,
+                () -> manager.start(tempDir.toString(), "maven", -1));
+    }
+
+    @Test
+    void startThrowsForPortAbove65535() {
+        assertThrows(IllegalArgumentException.class,
+                () -> manager.start(tempDir.toString(), "maven", 70000));
+    }
+
+    @Test
+    void processBuilderIncludesPortArgs() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields();
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", 9090);
+        assertTrue(pb.command().contains("-Dquarkus.http.port=9090"));
+        assertTrue(pb.command().contains("-Dquarkus.http.test-port=0"));
+    }
+
+    @Test
+    void processBuilderOmitsPortArgsWhenNull() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields();
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null);
+        assertFalse(pb.command().stream().anyMatch(arg -> arg.startsWith("-Dquarkus.http.port=")));
+        assertFalse(pb.command().stream().anyMatch(arg -> arg.startsWith("-Dquarkus.http.test-port=")));
+    }
+
+    private void initOptionalFields() throws Exception {
+        for (String fieldName : new String[] { "mvnCmd", "gradleCmd", "appLogEnabled" }) {
+            Field f = QuarkusProcessManager.class.getDeclaredField(fieldName);
+            f.setAccessible(true);
+            f.set(manager, Optional.empty());
+        }
     }
 
     @Test
@@ -108,6 +161,29 @@ class QuarkusProcessManagerTest {
         Method m = QuarkusProcessManager.class.getDeclaredMethod("detectBuildTool", String.class);
         m.setAccessible(true);
         assertEquals("gradle", m.invoke(manager, tempDir.toString()));
+    }
+
+    @Test
+    void isPortAvailableReturnsTrueForFreePort() {
+        assertTrue(QuarkusProcessManager.isPortAvailable(0));
+    }
+
+    @Test
+    void isPortAvailableReturnsFalseForOccupiedPort() throws Exception {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int port = ss.getLocalPort();
+            assertFalse(QuarkusProcessManager.isPortAvailable(port));
+        }
+    }
+
+    @Test
+    void findAvailablePortSkipsOccupiedPort() throws Exception {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            int occupied = ss.getLocalPort();
+            int found = QuarkusProcessManager.findAvailablePort(occupied);
+            assertTrue(found > occupied);
+            assertTrue(QuarkusProcessManager.isPortAvailable(found));
+        }
     }
 
     @Test


### PR DESCRIPTION
When running multiple Quarkus apps simultaneously (e.g. different Roq sites), they clash on the default port 8080. This adds two mechanisms to solve the problem:

1. **Auto-assignment**: when no port is specified and 8080 is already in use, the next available port is automatically assigned. The first app still gets 8080, subsequent apps get the next free port.

2. **Explicit `httpPort` parameter**: exposed on both `quarkus_start` and `quarkus_create` for users who want a specific port. When set, `-Dquarkus.http.port=<port>` and `-Dquarkus.http.test-port=0` are passed to the spawned process.

Closes #116