### PR TITLE
Warn agents about mvn clean breaking the test runner in dev mode

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -205,7 +205,9 @@ public class CreateTools {
                         + "\n8. After code changes, trigger a reload via quarkus_callTool with toolName 'devui-logstream_forceRestart'. Do NOT restart the app manually."
                         + "\n   IMPORTANT: After pom.xml/build.gradle changes (adding dependencies or extensions), you MUST do a full quarkus_stop + quarkus_start. forceRestart only recompiles source -- it does NOT re-resolve dependencies."
                         + "\n9. Update README.md with: app description, features, endpoints, how to run, and links to Quarkus guides."
-                        + "\n10. After core features work, suggest to the user: security, observability, health checks, OpenAPI.");
+                        + "\n10. After core features work, suggest to the user: security, observability, health checks, OpenAPI."
+                        + "\n\nWARNING: NEVER run 'mvn clean' or 'gradle clean' while dev mode is running -- it deletes target/test-classes and breaks the test runner. "
+                        + "If the test runner gets stuck returning 'Tests already in progress', do a full quarkus_stop + quarkus_start cycle to reset it.");
             } catch (Exception startError) {
                 LOG.warnf("Project created but failed to auto-start: %s", startError.getMessage());
                 return ToolResponse.success("Quarkus project created at: " + projectDir
@@ -513,6 +515,8 @@ public class CreateTools {
                     - Use `devui-testing_runTest` with arguments `{"className":"com.example.MyTest"}` to run a specific test class.
                     - Do NOT run Maven/Gradle test commands manually -- the Dev MCP test tools handle compilation, hot reload, and result reporting.
                     - After fixing test failures, re-run tests (via a subagent if supported) to verify the fix.
+                    - **NEVER run `mvn clean` or `gradle clean` while dev mode is running** -- it deletes `target/test-classes` and breaks the test runner with no automatic recovery.
+                    - If the test runner gets stuck returning "Tests already in progress", do a full `quarkus_stop` + `quarkus_start` cycle to reset the test runner state.
 
                     ## Error Handling
 

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -349,7 +349,9 @@ public class DevMcpProxyTools {
 
     @Tool(name = "quarkus_callTool", description = "Invoke a Dev MCP tool by name on the running Quarkus app. "
             + "Use quarkus_searchTools first to discover tool names and parameters. "
-            + "After structural changes (adding extensions, endpoints), update README.md.")
+            + "After structural changes (adding extensions, endpoints), update README.md. "
+            + "NEVER run 'mvn clean' or 'gradle clean' while dev mode is running -- it deletes target/test-classes and breaks the test runner. "
+            + "If the test runner returns 'Tests already in progress' and won't recover, do a full quarkus_stop + quarkus_start cycle to reset it.")
     ToolResponse callTool(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
             @ToolArg(description = "The name of the Dev MCP tool to call (as returned by quarkus_searchTools)") String toolName,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,9 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   - If your agent supports subagents, run tests in a subagent so the main conversation stays responsive\n\
   - Use quarkus_callTool with toolName 'devui-testing_runTests' to run all tests\n\
   - Use quarkus_callTool with toolName 'devui-testing_runTest' and toolArguments '{"className":"com.example.MyTest"}' to run a specific test\n\
-  - Do NOT run Maven/Gradle test commands manually\n\n\
+  - Do NOT run Maven/Gradle test commands manually\n\
+  - NEVER run 'mvn clean' or 'gradle clean' while dev mode is running -- it deletes target/test-classes and breaks the test runner\n\
+  - If the test runner returns 'Tests already in progress' and won't recover, do a full quarkus_stop + quarkus_start cycle to reset it\n\n\
   ERROR HANDLING:\n\
   - When something goes wrong (compilation error, deployment failure, runtime exception), use quarkus_callTool with toolName 'devui-exceptions_getLastException' to get structured exception details (class, message, stack trace, user code location)\n\
   - After fixing the issue, call 'devui-exceptions_clearLastException' to clear the recorded exception\n\
@@ -45,6 +47,7 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   - NEVER skip quarkus_skills -- it contains critical patterns that prevent common mistakes\n\
   - NEVER use web search or generic documentation tools (Context7, etc.) for Quarkus questions -- always use quarkus_searchDocs first, even without a project directory\n\
   - NEVER run build commands manually -- use quarkus_start, quarkus_callTool for testing\n\
+  - NEVER run 'mvn clean' or 'gradle clean' while dev mode is running -- it breaks the test runner\n\
   - ALWAYS write tests for every feature\n\
   - ALWAYS keep README.md updated\n\
   - ALWAYS summarize after completing work -- when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment)


### PR DESCRIPTION
Running `mvn clean` or `gradle clean` while dev mode is active deletes `target/test-classes`, which breaks the Dev MCP test runner. Worse, after the failure the test runner gets permanently stuck returning "Tests already in progress" with no way to recover except falling back to raw Maven commands.

Until the underlying issues are fixed in Quarkus core (quarkusio/quarkus#53952, quarkusio/quarkus#53953, quarkusio/quarkus#53954), this adds agent-facing guidance to prevent the problem and document the recovery path:

- **MCP server instructions** (`application.properties`): warns in both the TESTING and KEY RULES sections
- **`quarkus_callTool` tool description**: inline warning so agents see it when invoking test tools
- **Generated AGENTS.md**: adds the guidance to the Testing section of new project instructions
- **Post-creation next steps**: WARNING block at the end of the creation output

Recovery workaround: `quarkus_stop` + `quarkus_start` resets the stuck test runner state.

Closes #118