### PR TITLE
Add --enable-native-access=ALL-UNNAMED to jbang catalog

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -6,7 +6,8 @@
       "java-version": "21+",
        "runtime-options": [
         "--add-opens",
-        "java.base/java.lang=ALL-UNNAMED"
+        "java.base/java.lang=ALL-UNNAMED",
+        "--enable-native-access=ALL-UNNAMED"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Adds `--enable-native-access=ALL-UNNAMED` to jbang runtime options
- Suppresses native access warnings on Java 21-23
- No-op on Java 24+ (flag is recognized but not needed)