### PR TITLE
Load RAG documentation from SQL fragments instead of pre-built Docker image

### DIFF
--- a/docs/contributing-extension-docs.md
+++ b/docs/contributing-extension-docs.md
@@ -1,0 +1,96 @@
+# Contributing Extension Documentation to RAG Search
+
+This guide explains how to make your extension's documentation searchable by the Quarkus AI assistant. When a developer asks the assistant about your extension, it searches a vector database of documentation chunks to find relevant answers.
+
+## How it works
+
+The [quarkus-documentation-rag](https://github.com/quarkusio/quarkus-documentation-rag) Maven plugin processes your AsciiDoc guide into vector embeddings and outputs a SQL file (`META-INF/quarkus-rag.sql`) in your deployment JAR. At runtime, the Quarkus Agent MCP server discovers these SQL files and loads them into a pgvector database for semantic search.
+
+The pipeline:
+
+1. **Build time** — the Maven plugin parses your AsciiDoc, splits it into semantic chunks at section boundaries, generates 384-dimension vector embeddings (BGE Small EN v1.5), and writes idempotent SQL (`DELETE` by source + `INSERT` with embeddings and metadata).
+2. **Runtime** — the MCP server starts a generic `pgvector/pgvector:pg17` container and loads all discovered SQL fragments into it.
+
+No centralized rebuild is needed — each extension independently produces its own SQL fragment.
+
+## Quarkiverse extensions
+
+Once [quarkiverse-parent#235](https://github.com/quarkiverse/quarkiverse-parent/pull/235) is merged, Quarkiverse extensions can opt in by setting a single property in their **deployment** module's `pom.xml`:
+
+```xml
+<properties>
+    <quarkus-rag.guide>docs/modules/ROOT/pages/index.adoc</quarkus-rag.guide>
+</properties>
+```
+
+Then build with the RAG profile:
+
+```bash
+mvn install -Prag
+```
+
+That's it. The plugin uses your `${project.artifactId}` as the source name and silently skips modules where the property is not set.
+
+### What the property points to
+
+The `quarkus-rag.guide` property should be a path (relative to the module root) to your extension's main AsciiDoc guide. This is typically the Antora page that documents your extension's usage.
+
+### Multiple guides
+
+If your extension has multiple documentation pages, point to the main one. The plugin processes a single guide per module. If you need to include multiple pages, you can set up additional executions of the plugin manually — see the [plugin README](https://github.com/quarkusio/quarkus-documentation-rag) for configuration options.
+
+## Quarkus core extensions
+
+Core Quarkus documentation is handled centrally by the `devtools/extension-rag/` module ([quarkus#54119](https://github.com/quarkusio/quarkus/pull/54119)), which processes all ~274 AsciiDoc guides into a single aggregated artifact (`io.quarkus:quarkus-documentation-core-rag`). Individual core extensions don't need to do anything — the aggregated artifact covers all core guides.
+
+The aggregated artifact is published to Maven Central with each Quarkus release and downloaded automatically by the MCP server when needed.
+
+## Third-party libraries (non-Quarkiverse)
+
+If your project doesn't inherit from `quarkiverse-parent`, you can add the plugin directly:
+
+```xml
+<plugin>
+    <groupId>io.quarkus</groupId>
+    <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
+    <version>${quarkus-documentation-rag.version}</version>
+    <executions>
+        <execution>
+            <goals><goal>generate-rag</goal></goals>
+            <configuration>
+                <guides>
+                    <guide>${project.basedir}/docs/guide.adoc</guide>
+                </guides>
+                <extensionName>${project.artifactId}</extensionName>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+The SQL file will be placed in `META-INF/quarkus-rag.sql` inside your deployment JAR. The MCP server discovers it automatically when the JAR is in the user's local Maven repository.
+
+## How discovery works
+
+The MCP server searches for RAG SQL in this order:
+
+1. **Aggregated artifact** — checks for `io.quarkus:quarkus-documentation-core-rag:{version}` in `~/.m2/repository`. Downloads from Maven Central if not found locally (release versions only).
+2. **Individual extension JARs** — scans `~/.m2/repository/io/quarkus/quarkus-*-deployment/{version}/` for JARs containing `META-INF/quarkus-rag.sql`.
+
+If the aggregated artifact is found, individual extension JARs are not scanned (the aggregated artifact already contains all core extension docs). Quarkiverse and third-party extension JARs are always discovered independently.
+
+## Verifying your contribution
+
+After building with `-Prag`, verify the SQL was generated:
+
+```bash
+jar tf your-extension-deployment/target/your-extension-deployment-*.jar | grep quarkus-rag
+```
+
+You should see `META-INF/quarkus-rag.sql`. You can inspect it — it contains `DELETE` and `INSERT` statements with vector embeddings.
+
+To test end-to-end, start the Quarkus Agent MCP server and search for a term from your documentation:
+
+```
+quarkus_searchDocs query="your extension feature"
+```

--- a/docs/contributing-extension-docs.md
+++ b/docs/contributing-extension-docs.md
@@ -75,9 +75,10 @@ The SQL file will be placed in `META-INF/quarkus-rag.sql` inside your deployment
 The MCP server searches for RAG SQL in this order:
 
 1. **Aggregated artifact** — checks for `io.quarkus:quarkus-documentation-core-rag:{version}` in `~/.m2/repository`. Downloads from Maven Central if not found locally (release versions only).
-2. **Individual extension JARs** — scans `~/.m2/repository/io/quarkus/quarkus-*-deployment/{version}/` for JARs containing `META-INF/quarkus-rag.sql`.
+2. **Individual core extension JARs** — if no aggregated artifact is found, scans `~/.m2/repository/io/quarkus/quarkus-*-deployment/{version}/` for JARs containing `META-INF/quarkus-rag.sql`.
+3. **Non-core extension JARs** — always parses the project's `pom.xml` to find Quarkiverse and third-party dependencies, then checks their deployment JARs for `META-INF/quarkus-rag.sql`.
 
-If the aggregated artifact is found, individual extension JARs are not scanned (the aggregated artifact already contains all core extension docs). Quarkiverse and third-party extension JARs are always discovered independently.
+Loading is incremental — when you add an extension to a project, the MCP server automatically discovers and loads its documentation without restarting. Each SQL fragment is identified by its source name, and only new sources are loaded.
 
 ## Verifying your contribution
 

--- a/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
@@ -56,7 +56,7 @@ public class ContainerManager {
         defaultWarmupStarted = true;
         Thread.ofVirtual().name("container-warmup").start(() -> {
             try {
-                ensureRunning(null);
+                ensureRunning(null, null);
                 defaultWarmupDone = true;
             } catch (Exception e) {
                 LOG.warn("Background container warm-up failed: " + e.getMessage());
@@ -83,8 +83,9 @@ public class ContainerManager {
      * Starts a generic pgvector container if needed, then loads RAG SQL fragments.
      *
      * @param quarkusVersion the Quarkus version for docs, or null for default
+     * @param projectDir     the project directory for non-core extension discovery, or null
      */
-    public synchronized void ensureRunning(String quarkusVersion) {
+    public synchronized void ensureRunning(String quarkusVersion, String projectDir) {
         checkDockerAvailable();
 
         String versionKey = quarkusVersion != null ? quarkusVersion : "default";
@@ -96,13 +97,31 @@ public class ContainerManager {
 
         try {
             startContainer(versionKey);
-            loadRagData(versionKey, quarkusVersion);
+            loadRagData(versionKey, quarkusVersion, projectDir);
         } catch (Exception e) {
             throw new RuntimeException(
                     "Failed to start documentation container (" + image + "). "
                             + "Ensure Docker/Podman is running. Error: " + e.getMessage(),
                     e);
         }
+    }
+
+    /**
+     * Loads any new RAG SQL fragments into an already-running container.
+     * Called after extensions are added to a project to pick up their docs.
+     */
+    public void loadIncrementalRagData(String quarkusVersion, String projectDir) {
+        String versionKey = quarkusVersion != null ? quarkusVersion : "default";
+        GenericContainer<?> container = containers.get(versionKey);
+        if (container == null || !container.isRunning()) {
+            LOG.debugf("No running container for version %s — skipping incremental RAG load", versionKey);
+            return;
+        }
+
+        ragSqlLoader.ensureLoaded(
+                quarkusVersion, projectDir,
+                container.getHost(), container.getMappedPort(5432),
+                pgDatabase, pgUser, pgPassword);
     }
 
     /**
@@ -162,12 +181,11 @@ public class ContainerManager {
                 versionKey, container.getMappedPort(5432));
     }
 
-    private void loadRagData(String versionKey, String quarkusVersion) {
+    private void loadRagData(String versionKey, String quarkusVersion, String projectDir) {
         GenericContainer<?> container = containers.get(versionKey);
         ragSqlLoader.ensureLoaded(
-                quarkusVersion,
-                container.getHost(),
-                container.getMappedPort(5432),
+                quarkusVersion, projectDir,
+                container.getHost(), container.getMappedPort(5432),
                 pgDatabase, pgUser, pgPassword);
     }
 

--- a/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
@@ -3,6 +3,7 @@ package io.quarkus.agent.mcp;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -13,8 +14,11 @@ import org.testcontainers.utility.DockerImageName;
 
 /**
  * Manages pgvector containers for Quarkus documentation search.
- * Uses a generic pgvector image — documentation data is loaded from SQL fragments
- * discovered in extension deployment JARs by {@link RagSqlLoader}.
+ * <p>
+ * For Quarkus 3.36+ (which ships RAG SQL artifacts), uses a generic pgvector image
+ * with documentation loaded from SQL fragments by {@link RagSqlLoader}.
+ * For older versions, falls back to the pre-built {@code chappie-ingestion-quarkus} image
+ * with documentation baked in.
  * <p>
  * Containers are version-specific (each Quarkus version gets its own container)
  * and reusable across MCP server restarts.
@@ -23,9 +27,16 @@ import org.testcontainers.utility.DockerImageName;
 public class ContainerManager {
 
     private static final Logger LOG = Logger.getLogger(ContainerManager.class);
+    static final int RAG_SQL_MIN_MINOR = 36;
 
     @ConfigProperty(name = "agent-mcp.doc-search.image", defaultValue = "pgvector/pgvector:pg17")
     String image;
+
+    @ConfigProperty(name = "agent-mcp.doc-search.image-prefix", defaultValue = "ghcr.io/quarkusio/chappie-ingestion-quarkus")
+    String imagePrefix;
+
+    @ConfigProperty(name = "agent-mcp.doc-search.image-tag", defaultValue = "latest")
+    String defaultImageTag;
 
     @ConfigProperty(name = "agent-mcp.doc-search.pg-user", defaultValue = "quarkus")
     String pgUser;
@@ -40,6 +51,8 @@ public class ContainerManager {
     RagSqlLoader ragSqlLoader;
 
     private final ConcurrentHashMap<String, GenericContainer<?>> containers = new ConcurrentHashMap<>();
+    private final Set<String> fallbackVersions = ConcurrentHashMap.newKeySet();
+    private final Set<String> ragSqlVersions = ConcurrentHashMap.newKeySet();
     private volatile Boolean dockerAvailable;
     private volatile boolean defaultWarmupStarted;
     private volatile boolean defaultWarmupDone;
@@ -80,7 +93,8 @@ public class ContainerManager {
 
     /**
      * Ensure a pgvector container is running for the given Quarkus version.
-     * Starts a generic pgvector container if needed, then loads RAG SQL fragments.
+     * For 3.36+, starts a generic pgvector container and loads RAG SQL fragments.
+     * For older versions, starts the pre-built chappie-ingestion image.
      *
      * @param quarkusVersion the Quarkus version for docs, or null for default
      * @param projectDir     the project directory for non-core extension discovery, or null
@@ -95,23 +109,41 @@ public class ContainerManager {
             return;
         }
 
-        try {
-            startContainer(versionKey);
-            loadRagData(versionKey, quarkusVersion, projectDir);
-        } catch (Exception e) {
-            throw new RuntimeException(
-                    "Failed to start documentation container (" + image + "). "
-                            + "Ensure Docker/Podman is running. Error: " + e.getMessage(),
-                    e);
+        if (supportsRagSql(quarkusVersion)) {
+            try {
+                startGenericContainer(versionKey);
+                loadRagData(versionKey, quarkusVersion, projectDir);
+                ragSqlVersions.add(versionKey);
+            } catch (Exception e) {
+                throw new RuntimeException(
+                        "Failed to start documentation container (" + image + "). "
+                                + "Ensure Docker/Podman is running. Error: " + e.getMessage(),
+                        e);
+            }
+        } else {
+            startLegacyContainer(versionKey, quarkusVersion);
         }
+    }
+
+    /**
+     * Returns true if the given version fell back to the default image tag
+     * (only applicable to the legacy pre-built image path).
+     */
+    public boolean isUsingFallback(String quarkusVersion) {
+        String versionKey = quarkusVersion != null ? quarkusVersion : "default";
+        return fallbackVersions.contains(versionKey);
     }
 
     /**
      * Loads any new RAG SQL fragments into an already-running container.
      * Called after extensions are added to a project to pick up their docs.
+     * No-op for legacy containers (data is baked into the image).
      */
     public void loadIncrementalRagData(String quarkusVersion, String projectDir) {
         String versionKey = quarkusVersion != null ? quarkusVersion : "default";
+        if (!ragSqlVersions.contains(versionKey)) {
+            return;
+        }
         GenericContainer<?> container = containers.get(versionKey);
         if (container == null || !container.isRunning()) {
             LOG.debugf("No running container for version %s — skipping incremental RAG load", versionKey);
@@ -162,10 +194,78 @@ public class ContainerManager {
         }
     }
 
-    private void startContainer(String versionKey) {
+    static boolean supportsRagSql(String version) {
+        if (version == null || version.isBlank()) {
+            return true;
+        }
+        if (version.contains("SNAPSHOT")) {
+            return true;
+        }
+        try {
+            String[] parts = version.split("[.\\-]");
+            int major = Integer.parseInt(parts[0]);
+            int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+            return major > 3 || (major == 3 && minor >= RAG_SQL_MIN_MINOR);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private void startGenericContainer(String versionKey) {
         LOG.infof("Starting pgvector container for Quarkus %s docs (%s)...", versionKey, image);
 
         GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse(image))
+                .withExposedPorts(5432)
+                .withEnv("POSTGRES_USER", pgUser)
+                .withEnv("POSTGRES_PASSWORD", pgPassword)
+                .withEnv("POSTGRES_DB", pgDatabase)
+                .withReuse(true)
+                .withLabel("quarkus-agent-mcp", "doc-search")
+                .withLabel("quarkus-agent-mcp.version", versionKey)
+                .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*\\n", 2));
+
+        container.start();
+        containers.put(versionKey, container);
+        LOG.infof("pgvector container started for Quarkus %s (mapped port: %d)",
+                versionKey, container.getMappedPort(5432));
+    }
+
+    private void startLegacyContainer(String versionKey, String quarkusVersion) {
+        String tag = quarkusVersion != null ? quarkusVersion : defaultImageTag;
+
+        try {
+            startLegacyImage(versionKey, tag);
+            return;
+        } catch (Exception e) {
+            if (tag.equals(defaultImageTag)) {
+                throw new RuntimeException(
+                        "Failed to start documentation container (image: " + imagePrefix + ":" + tag + "). "
+                                + "Ensure Docker/Podman is running. Error: " + e.getMessage(),
+                        e);
+            }
+            LOG.warnf(e, "Failed to start documentation image %s:%s, falling back to %s:%s",
+                    imagePrefix, tag, imagePrefix, defaultImageTag);
+        }
+
+        try {
+            startLegacyImage(versionKey, defaultImageTag);
+            fallbackVersions.add(versionKey);
+            LOG.infof("Using '%s' docs instead of '%s' — docs may not exactly match your Quarkus version",
+                    defaultImageTag, tag);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to start documentation container for Quarkus " + tag
+                            + ". Tried version-specific image and fallback (" + defaultImageTag + "). "
+                            + "Error: " + e.getMessage(),
+                    e);
+        }
+    }
+
+    private void startLegacyImage(String versionKey, String tag) {
+        String fullImage = imagePrefix + ":" + tag;
+        LOG.infof("Starting pgvector container with Quarkus %s docs (%s)...", versionKey, fullImage);
+
+        GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse(fullImage))
                 .withExposedPorts(5432)
                 .withEnv("POSTGRES_USER", pgUser)
                 .withEnv("POSTGRES_PASSWORD", pgPassword)

--- a/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
@@ -2,7 +2,7 @@ package io.quarkus.agent.mcp;
 
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
-import java.util.Set;
+import jakarta.inject.Inject;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -12,22 +12,20 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 /**
- * Manages pgvector containers with pre-indexed Quarkus documentation.
- * Uses Testcontainers for Docker/Podman abstraction.
- * Supports version-specific containers — each Quarkus version gets its own container
- * with documentation matching that version.
- * Containers are reusable — they persist across MCP server restarts.
+ * Manages pgvector containers for Quarkus documentation search.
+ * Uses a generic pgvector image — documentation data is loaded from SQL fragments
+ * discovered in extension deployment JARs by {@link RagSqlLoader}.
+ * <p>
+ * Containers are version-specific (each Quarkus version gets its own container)
+ * and reusable across MCP server restarts.
  */
 @ApplicationScoped
 public class ContainerManager {
 
     private static final Logger LOG = Logger.getLogger(ContainerManager.class);
 
-    @ConfigProperty(name = "agent-mcp.doc-search.image-prefix", defaultValue = "ghcr.io/quarkusio/chappie-ingestion-quarkus")
-    String imagePrefix;
-
-    @ConfigProperty(name = "agent-mcp.doc-search.image-tag", defaultValue = "latest")
-    String defaultImageTag;
+    @ConfigProperty(name = "agent-mcp.doc-search.image", defaultValue = "pgvector/pgvector:pg17")
+    String image;
 
     @ConfigProperty(name = "agent-mcp.doc-search.pg-user", defaultValue = "quarkus")
     String pgUser;
@@ -38,8 +36,10 @@ public class ContainerManager {
     @ConfigProperty(name = "agent-mcp.doc-search.pg-database", defaultValue = "quarkus")
     String pgDatabase;
 
+    @Inject
+    RagSqlLoader ragSqlLoader;
+
     private final ConcurrentHashMap<String, GenericContainer<?>> containers = new ConcurrentHashMap<>();
-    private final Set<String> fallbackVersions = ConcurrentHashMap.newKeySet();
     private volatile Boolean dockerAvailable;
     private volatile boolean defaultWarmupStarted;
     private volatile boolean defaultWarmupDone;
@@ -80,56 +80,29 @@ public class ContainerManager {
 
     /**
      * Ensure a pgvector container is running for the given Quarkus version.
-     * Starts it via Testcontainers if needed. If the version-specific image
-     * is not available, falls back to the default image tag.
+     * Starts a generic pgvector container if needed, then loads RAG SQL fragments.
      *
      * @param quarkusVersion the Quarkus version for docs, or null for default
      */
     public synchronized void ensureRunning(String quarkusVersion) {
         checkDockerAvailable();
 
-        String tag = resolveImageTag(quarkusVersion);
+        String versionKey = quarkusVersion != null ? quarkusVersion : "default";
 
-        GenericContainer<?> existing = containers.get(tag);
+        GenericContainer<?> existing = containers.get(versionKey);
         if (existing != null && existing.isRunning()) {
             return;
         }
 
         try {
-            startContainer(tag);
-            return;
-        } catch (Exception e) {
-            if (tag.equals(defaultImageTag)) {
-                throw new RuntimeException(
-                        "Failed to start documentation container (image: " + imagePrefix + ":" + tag + "). "
-                                + "Ensure Docker/Podman is running. Error: " + e.getMessage(),
-                        e);
-            }
-            LOG.warnf(e, "Failed to start documentation image %s:%s, falling back to %s:%s",
-                    imagePrefix, tag, imagePrefix, defaultImageTag);
-        }
-
-        try {
-            startContainer(defaultImageTag);
-            containers.put(tag, containers.get(defaultImageTag));
-            fallbackVersions.add(tag);
-            LOG.infof("Using '%s' docs instead of '%s' — docs may not exactly match your Quarkus version",
-                    defaultImageTag, tag);
+            startContainer(versionKey);
+            loadRagData(versionKey, quarkusVersion);
         } catch (Exception e) {
             throw new RuntimeException(
-                    "Failed to start documentation container for Quarkus " + tag
-                            + ". Tried version-specific image and fallback (" + defaultImageTag + "). "
-                            + "Error: " + e.getMessage(),
+                    "Failed to start documentation container (" + image + "). "
+                            + "Ensure Docker/Podman is running. Error: " + e.getMessage(),
                     e);
         }
-    }
-
-    /**
-     * Returns true if the given version fell back to the default image tag.
-     */
-    public boolean isUsingFallback(String quarkusVersion) {
-        String tag = resolveImageTag(quarkusVersion);
-        return fallbackVersions.contains(tag);
     }
 
     /**
@@ -170,9 +143,8 @@ public class ContainerManager {
         }
     }
 
-    private void startContainer(String tag) {
-        String image = imagePrefix + ":" + tag;
-        LOG.infof("Starting pgvector container with Quarkus %s docs (%s)...", tag, image);
+    private void startContainer(String versionKey) {
+        LOG.infof("Starting pgvector container for Quarkus %s docs (%s)...", versionKey, image);
 
         GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse(image))
                 .withExposedPorts(5432)
@@ -181,20 +153,30 @@ public class ContainerManager {
                 .withEnv("POSTGRES_DB", pgDatabase)
                 .withReuse(true)
                 .withLabel("quarkus-agent-mcp", "doc-search")
-                .withLabel("quarkus-agent-mcp.version", tag)
+                .withLabel("quarkus-agent-mcp.version", versionKey)
                 .waitingFor(Wait.forLogMessage(".*database system is ready to accept connections.*\\n", 2));
 
         container.start();
-        containers.put(tag, container);
-        LOG.infof("pgvector container started for Quarkus %s (mapped port: %d)", tag, container.getMappedPort(5432));
+        containers.put(versionKey, container);
+        LOG.infof("pgvector container started for Quarkus %s (mapped port: %d)",
+                versionKey, container.getMappedPort(5432));
+    }
+
+    private void loadRagData(String versionKey, String quarkusVersion) {
+        GenericContainer<?> container = containers.get(versionKey);
+        ragSqlLoader.ensureLoaded(
+                quarkusVersion,
+                container.getHost(),
+                container.getMappedPort(5432),
+                pgDatabase, pgUser, pgPassword);
     }
 
     private GenericContainer<?> getContainer(String quarkusVersion) {
-        String tag = resolveImageTag(quarkusVersion);
-        GenericContainer<?> container = containers.get(tag);
+        String versionKey = quarkusVersion != null ? quarkusVersion : "default";
+        GenericContainer<?> container = containers.get(versionKey);
         if (container == null || !container.isRunning()) {
             throw new IllegalStateException(
-                    "pgvector container is not running for version " + tag + ". Call ensureRunning() first.");
+                    "pgvector container is not running for version " + versionKey + ". Call ensureRunning() first.");
         }
         return container;
     }
@@ -214,12 +196,5 @@ public class ContainerManager {
             }
         }
         containers.clear();
-    }
-
-    private String resolveImageTag(String quarkusVersion) {
-        if (quarkusVersion != null && !quarkusVersion.isBlank()) {
-            return quarkusVersion;
-        }
-        return defaultImageTag;
     }
 }

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -69,6 +69,9 @@ public class DevMcpProxyTools {
     @Inject
     ObjectMapper mapper;
 
+    @Inject
+    ContainerManager containerManager;
+
     @ConfigProperty(name = "agent-mcp.local-skills-dir")
     Optional<String> localSkillsDir;
 
@@ -459,6 +462,18 @@ public class DevMcpProxyTools {
                     && (toolName.contains("extension") || toolName.contains("add")
                             || toolName.contains("remove"))) {
                 DependencyResolver.invalidate(projectDir);
+
+                // Load any new extension's RAG documentation in the background
+                if (containerManager.isDefaultReady()) {
+                    String qVersion = QuarkusVersionDetector.detect(projectDir);
+                    Thread.ofVirtual().name("rag-incremental-load").start(() -> {
+                        try {
+                            containerManager.loadIncrementalRagData(qVersion, projectDir);
+                        } catch (Exception e) {
+                            LOG.debugf("Background incremental RAG load failed: %s", e.getMessage());
+                        }
+                    });
+                }
                 String resultText = extractTextFromResult(result);
                 return ToolResponse.success(resultText
                         + "\n\nREMINDER: Update README.md to reflect this change (features, extensions, guide links)."

--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -102,9 +102,11 @@ public class DocSearchTools {
     ObjectMapper mapper;
 
     private static final String DEFAULT_VERSION_KEY = "__default__";
+    private static final long INCREMENTAL_CHECK_INTERVAL_MS = 60_000;
 
     private final Object initLock = new Object();
     private final ConcurrentHashMap<String, PgVectorEmbeddingStore> embeddingStores = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Long> lastIncrementalCheck = new ConcurrentHashMap<>();
 
     @Tool(name = "quarkus_searchDocs", description = "Search Quarkus documentation for APIs, annotations, "
             + "configuration, and best practices. Use this for ANY Quarkus-related question -- "
@@ -150,7 +152,12 @@ public class DocSearchTools {
                     LOG.infof("Using Quarkus %s docs for project at %s", quarkusVersion, projectDir);
                 }
             }
-            PgVectorEmbeddingStore store = ensureInitialized(quarkusVersion);
+            PgVectorEmbeddingStore store = ensureInitialized(quarkusVersion, projectDir);
+
+            // Check for newly added extensions (rate-limited)
+            if (projectDir != null && !projectDir.isBlank()) {
+                maybeLoadIncrementalRagData(quarkusVersion, projectDir);
+            }
 
             Embedding queryEmbedding = embeddingModelLoader.getModel().embed(query).content();
 
@@ -197,7 +204,7 @@ public class DocSearchTools {
         }
     }
 
-    private PgVectorEmbeddingStore ensureInitialized(String quarkusVersion) {
+    private PgVectorEmbeddingStore ensureInitialized(String quarkusVersion, String projectDir) {
         String key = quarkusVersion != null ? quarkusVersion : DEFAULT_VERSION_KEY;
 
         PgVectorEmbeddingStore existing = embeddingStores.get(key);
@@ -206,13 +213,12 @@ public class DocSearchTools {
         }
 
         synchronized (initLock) {
-            // Double-check after acquiring lock
             existing = embeddingStores.get(key);
             if (existing != null) {
                 return existing;
             }
 
-            containerManager.ensureRunning(quarkusVersion);
+            containerManager.ensureRunning(quarkusVersion, projectDir);
 
             String host = containerManager.getHost(quarkusVersion);
             int port = containerManager.getMappedPort(quarkusVersion);
@@ -234,6 +240,22 @@ public class DocSearchTools {
 
             embeddingStores.put(key, store);
             return store;
+        }
+    }
+
+    private void maybeLoadIncrementalRagData(String quarkusVersion, String projectDir) {
+        String key = projectDir + ":" + (quarkusVersion != null ? quarkusVersion : "default");
+        long now = System.currentTimeMillis();
+        Long lastCheck = lastIncrementalCheck.get(key);
+        if (lastCheck != null && (now - lastCheck) < INCREMENTAL_CHECK_INTERVAL_MS) {
+            return;
+        }
+        lastIncrementalCheck.put(key, now);
+
+        try {
+            containerManager.loadIncrementalRagData(quarkusVersion, projectDir);
+        } catch (Exception e) {
+            LOG.debugf("Incremental RAG check failed: %s", e.getMessage());
         }
     }
 

--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -195,6 +195,10 @@ public class DocSearchTools {
             }
 
             String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(results);
+            if (quarkusVersion != null && containerManager.isUsingFallback(quarkusVersion)) {
+                json += "\n\nNote: Version-specific docs for Quarkus " + quarkusVersion
+                        + " are not available. Results are from the latest documentation.";
+            }
             return ToolResponse.success(json);
         } catch (JsonProcessingException e) {
             return ToolResponse.error("Failed to serialize results: " + e.getMessage());

--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -24,11 +24,13 @@ import org.jboss.logging.Logger;
 
 /**
  * MCP tool for semantic search over Quarkus documentation.
- * Uses BGE Small EN v1.5 embeddings + pgvector with pre-indexed docs
- * from chappie-docling-rag.
+ * Uses BGE Small EN v1.5 embeddings + pgvector with RAG SQL fragments
+ * loaded from extension deployment JARs.
  * <p>
- * The pgvector container is started lazily on first search via Testcontainers.
- * The embedding store is created after the container is up, using the dynamic mapped port.
+ * A generic pgvector container is started lazily on first search via Testcontainers.
+ * SQL fragments (from {@code META-INF/quarkus-rag.sql} in deployment JARs) are loaded
+ * into the container by {@link RagSqlLoader}. The embedding store is created after
+ * the container is up, using the dynamic mapped port.
  */
 public class DocSearchTools {
 
@@ -150,8 +152,6 @@ public class DocSearchTools {
             }
             PgVectorEmbeddingStore store = ensureInitialized(quarkusVersion);
 
-            boolean usingFallback = quarkusVersion != null && containerManager.isUsingFallback(quarkusVersion);
-
             Embedding queryEmbedding = embeddingModelLoader.getModel().embed(query).content();
 
             EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
@@ -188,10 +188,6 @@ public class DocSearchTools {
             }
 
             String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(results);
-            if (usingFallback) {
-                json += "\n\nNote: Version-specific docs for Quarkus " + quarkusVersion
-                        + " are not available. Results are from the latest documentation.";
-            }
             return ToolResponse.success(json);
         } catch (JsonProcessingException e) {
             return ToolResponse.error("Failed to serialize results: " + e.getMessage());

--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -18,17 +18,25 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jboss.logging.Logger;
 
 /**
  * Discovers {@code META-INF/quarkus-rag.sql} fragments from extension deployment JARs
  * in the local Maven repository and loads them into a pgvector database.
- * Follows the same JAR scanning pattern as {@link SkillReader}.
+ * <p>
+ * Supports incremental loading: when new extensions are added to a project,
+ * only the new extension's SQL is loaded without reloading existing data.
+ * Non-core extensions (Quarkiverse, third-party) are discovered by parsing
+ * the project's {@code pom.xml}, following the same pattern as {@link SkillReader}.
  */
 @ApplicationScoped
 public class RagSqlLoader {
@@ -36,6 +44,7 @@ public class RagSqlLoader {
     private static final Logger LOG = Logger.getLogger(RagSqlLoader.class);
 
     private static final String RAG_SQL_PATH = "META-INF/quarkus-rag.sql";
+    private static final String RAG_DATA_SQL_PATH = "META-INF/quarkus-rag-data.sql";
     private static final String DEPLOYMENT_SUFFIX = "-deployment";
     private static final String CORE_GROUP_ID = "io.quarkus";
     private static final String RAG_DOCUMENTS_TABLE = "rag_documents";
@@ -52,81 +61,138 @@ public class RagSqlLoader {
             CREATE INDEX IF NOT EXISTS idx_rag_embedding ON rag_documents
                 USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)""";
 
-    private final Set<String> loadedVersions = ConcurrentHashMap.newKeySet();
+    private static final String AGGREGATED_ARTIFACT_ID = "quarkus-documentation-core-rag";
+    private static final String AGGREGATED_GROUP_PATH = "io/quarkus";
+
+    private static final Pattern SOURCE_PATTERN = Pattern.compile(
+            "metadata\\s*->>\\s*'source'\\s*=\\s*'([^']+)'");
+
+    record RagFragment(String source, String sql) {
+    }
+
+    private final Map<String, Set<String>> loadedSources = new ConcurrentHashMap<>();
 
     /**
      * Ensures RAG data is loaded for the given Quarkus version.
-     * Discovers SQL fragments from extension JARs, creates the schema if needed,
-     * and loads the data. Skips if already loaded for this version.
+     * Discovers SQL fragments from core and non-core extension JARs,
+     * filters out already-loaded sources, and loads only new data.
+     * On first call for a version with a reused container, seeds tracking
+     * from the database to avoid redundant loading.
      */
-    public void ensureLoaded(String quarkusVersion, String host, int port,
-            String database, String user, String password) {
+    public void ensureLoaded(String quarkusVersion, String projectDir,
+            String host, int port, String database, String user, String password) {
         String versionKey = quarkusVersion != null ? quarkusVersion : "default";
-        if (loadedVersions.contains(versionKey)) {
-            return;
-        }
 
         String resolvedVersion = quarkusVersion != null ? quarkusVersion : detectLatestInstalledVersion();
         if (resolvedVersion == null) {
             LOG.warn("Could not determine Quarkus version for RAG loading — no SQL fragments will be loaded");
-            loadedVersions.add(versionKey);
             return;
         }
 
-        List<String> fragments = discoverSqlFragments(resolvedVersion);
-        if (fragments.isEmpty()) {
+        List<RagFragment> allFragments = discoverSqlFragments(resolvedVersion, projectDir);
+        if (allFragments.isEmpty()) {
             LOG.infof("No RAG SQL fragments found for Quarkus %s", resolvedVersion);
-            loadedVersions.add(versionKey);
             return;
         }
 
         String jdbcUrl = "jdbc:postgresql://" + host + ":" + port + "/" + database;
-        loadSql(jdbcUrl, user, password, fragments, resolvedVersion);
-        loadedVersions.add(versionKey);
-    }
 
-    private static final String AGGREGATED_ARTIFACT_ID = "quarkus-documentation-core-rag";
-    private static final String AGGREGATED_GROUP_PATH = "io/quarkus";
+        Set<String> alreadyLoaded = loadedSources.computeIfAbsent(versionKey,
+                k -> ConcurrentHashMap.newKeySet());
+
+        // On first call for this version, seed from the database (handles container reuse)
+        if (alreadyLoaded.isEmpty()) {
+            Set<String> existingSources = queryExistingSources(jdbcUrl, user, password);
+            alreadyLoaded.addAll(existingSources);
+        }
+
+        List<RagFragment> newFragments = allFragments.stream()
+                .filter(f -> !alreadyLoaded.contains(f.source()))
+                .toList();
+
+        if (newFragments.isEmpty()) {
+            LOG.debugf("All %d RAG source(s) already loaded for %s", allFragments.size(), versionKey);
+            return;
+        }
+
+        loadSql(jdbcUrl, user, password, newFragments, resolvedVersion);
+
+        for (RagFragment f : newFragments) {
+            alreadyLoaded.add(f.source());
+        }
+    }
 
     /**
      * Discovers RAG SQL fragments from extension deployment JARs in ~/.m2/repository.
-     * If the aggregated artifact is not found locally, downloads it from Maven Central.
+     * Checks for the aggregated core artifact first, then scans individual core JARs
+     * as a fallback. Always scans non-core extension JARs from the project's pom.xml.
      */
-    List<String> discoverSqlFragments(String quarkusVersion) {
+    List<RagFragment> discoverSqlFragments(String quarkusVersion, String projectDir) {
         Path m2Repo = Path.of(System.getProperty("user.home"), ".m2", "repository");
 
-        List<String> fragments = new ArrayList<>();
+        List<RagFragment> fragments = new ArrayList<>();
 
-        // 1. Check for aggregated artifact locally
+        // 1. Core docs: aggregated artifact (preferred) or individual JARs (fallback)
         Path aggregatedJarPath = resolveAggregatedJarPath(quarkusVersion, m2Repo);
-        if (Files.isRegularFile(aggregatedJarPath)) {
-            String sql = readSqlFromJar(aggregatedJarPath);
-            if (sql != null) {
-                fragments.add(sql);
-                LOG.infof("Found aggregated RAG SQL artifact locally for Quarkus %s", quarkusVersion);
-                return fragments;
-            }
-        }
-
-        // 2. Download aggregated artifact from Maven Central if not found locally
-        if (fragments.isEmpty()) {
+        RagFragment aggregated = readFragmentFromJar(aggregatedJarPath, "quarkus-documentation");
+        if (aggregated != null) {
+            fragments.add(aggregated);
+            LOG.infof("Found aggregated RAG SQL artifact locally for Quarkus %s", quarkusVersion);
+        } else {
+            // Try downloading from Maven Central
             Path downloaded = downloadFromMavenCentral(quarkusVersion, aggregatedJarPath);
             if (downloaded != null) {
-                String sql = readSqlFromJar(downloaded);
-                if (sql != null) {
-                    fragments.add(sql);
+                aggregated = readFragmentFromJar(downloaded, "quarkus-documentation");
+                if (aggregated != null) {
+                    fragments.add(aggregated);
                     LOG.infof("Downloaded aggregated RAG SQL artifact for Quarkus %s", quarkusVersion);
-                    return fragments;
                 }
             }
         }
 
-        // 3. Scan individual core extension deployment JARs
-        if (Files.isDirectory(m2Repo)) {
+        // Fall back to individual core extension JARs if no aggregated artifact
+        if (aggregated == null && Files.isDirectory(m2Repo)) {
             fragments.addAll(scanCoreExtensionJars(m2Repo, quarkusVersion));
         }
 
+        // 2. Non-core extensions: always scan (Quarkiverse, third-party)
+        fragments.addAll(scanNonCoreExtensionJars(m2Repo, projectDir));
+
         LOG.infof("Discovered %d RAG SQL fragment(s) for Quarkus %s", fragments.size(), quarkusVersion);
+        return fragments;
+    }
+
+    private List<RagFragment> scanNonCoreExtensionJars(Path m2Repo, String projectDir) {
+        if (projectDir == null) {
+            return List.of();
+        }
+
+        List<DependencyResolver.Dependency> deps = DependencyResolver.resolve(projectDir);
+        if (deps.isEmpty()) {
+            return List.of();
+        }
+
+        List<RagFragment> fragments = new ArrayList<>();
+        for (DependencyResolver.Dependency dep : deps) {
+            if (CORE_GROUP_ID.equals(dep.groupId())) {
+                continue;
+            }
+            String groupPath = dep.groupId().replace('.', '/');
+            Path deploymentJar = m2Repo.resolve(groupPath)
+                    .resolve(dep.artifactId() + DEPLOYMENT_SUFFIX)
+                    .resolve(dep.version())
+                    .resolve(dep.artifactId() + DEPLOYMENT_SUFFIX + "-" + dep.version() + ".jar");
+
+            if (!Files.isRegularFile(deploymentJar)) {
+                continue;
+            }
+
+            RagFragment fragment = readFragmentFromJar(deploymentJar, dep.artifactId());
+            if (fragment != null) {
+                fragments.add(fragment);
+                LOG.debugf("Found RAG SQL in non-core extension %s", dep.artifactId());
+            }
+        }
         return fragments;
     }
 
@@ -182,19 +248,21 @@ public class RagSqlLoader {
         }
     }
 
-    private List<String> scanCoreExtensionJars(Path m2Repo, String version) {
+    private List<RagFragment> scanCoreExtensionJars(Path m2Repo, String version) {
         Path quarkusDir = m2Repo.resolve("io/quarkus");
         if (!Files.isDirectory(quarkusDir)) {
             return List.of();
         }
 
-        List<String> fragments = new ArrayList<>();
+        List<RagFragment> fragments = new ArrayList<>();
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(quarkusDir,
                 entry -> Files.isDirectory(entry)
                         && entry.getFileName().toString().startsWith("quarkus-")
                         && entry.getFileName().toString().endsWith(DEPLOYMENT_SUFFIX))) {
             for (Path extDir : stream) {
                 String deploymentArtifactId = extDir.getFileName().toString();
+                String artifactId = deploymentArtifactId.substring(0,
+                        deploymentArtifactId.length() - DEPLOYMENT_SUFFIX.length());
                 Path deploymentJar = extDir.resolve(version)
                         .resolve(deploymentArtifactId + "-" + version + ".jar");
 
@@ -202,9 +270,9 @@ public class RagSqlLoader {
                     continue;
                 }
 
-                String sql = readSqlFromJar(deploymentJar);
-                if (sql != null) {
-                    fragments.add(sql);
+                RagFragment fragment = readFragmentFromJar(deploymentJar, artifactId);
+                if (fragment != null) {
+                    fragments.add(fragment);
                     LOG.debugf("Found RAG SQL in %s", deploymentArtifactId);
                 }
             }
@@ -215,10 +283,12 @@ public class RagSqlLoader {
         return fragments;
     }
 
-    private String readSqlFromJar(Path jarPath) {
+    private RagFragment readFragmentFromJar(Path jarPath, String fallbackSource) {
+        if (!Files.isRegularFile(jarPath)) {
+            return null;
+        }
         try (JarFile jar = new JarFile(jarPath.toFile())) {
-            // Check data file first (aggregated artifact), then individual fragment
-            JarEntry entry = jar.getJarEntry("META-INF/quarkus-rag-data.sql");
+            JarEntry entry = jar.getJarEntry(RAG_DATA_SQL_PATH);
             if (entry == null) {
                 entry = jar.getJarEntry(RAG_SQL_PATH);
             }
@@ -226,57 +296,80 @@ public class RagSqlLoader {
                 return null;
             }
 
+            String sql;
             try (InputStream is = jar.getInputStream(entry)) {
-                return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                sql = new String(is.readAllBytes(), StandardCharsets.UTF_8);
             }
+            String source = extractSource(sql, fallbackSource);
+            return new RagFragment(source, sql);
         } catch (IOException e) {
             LOG.debugf("Failed to read RAG SQL from %s: %s", jarPath, e.getMessage());
             return null;
         }
     }
 
+    static String extractSource(String sql, String fallbackSource) {
+        Matcher m = SOURCE_PATTERN.matcher(sql);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return fallbackSource;
+    }
+
+    private Set<String> queryExistingSources(String jdbcUrl, String user, String password) {
+        Set<String> sources = new HashSet<>();
+        try (Connection conn = DriverManager.getConnection(jdbcUrl, user, password);
+                Statement stmt = conn.createStatement()) {
+            // Table might not exist yet
+            stmt.execute(CREATE_EXTENSION_DDL);
+            stmt.execute(CREATE_TABLE_DDL);
+            try (ResultSet rs = stmt.executeQuery(
+                    "SELECT DISTINCT metadata->>'source' FROM " + RAG_DOCUMENTS_TABLE)) {
+                while (rs.next()) {
+                    String source = rs.getString(1);
+                    if (source != null) {
+                        sources.add(source);
+                    }
+                }
+            }
+            if (!sources.isEmpty()) {
+                LOG.infof("Container already has RAG data for %d source(s)", sources.size());
+            }
+        } catch (SQLException e) {
+            LOG.debugf("Failed to query existing RAG sources: %s", e.getMessage());
+        }
+        return sources;
+    }
+
     private void loadSql(String jdbcUrl, String user, String password,
-            List<String> fragments, String version) {
+            List<RagFragment> fragments, String version) {
         LOG.infof("Loading %d RAG SQL fragment(s) for Quarkus %s...", fragments.size(), version);
 
         try (Connection conn = DriverManager.getConnection(jdbcUrl, user, password)) {
             conn.setAutoCommit(false);
 
             try (Statement stmt = conn.createStatement()) {
-                // Create schema if needed
                 stmt.execute(CREATE_EXTENSION_DDL);
                 stmt.execute(CREATE_TABLE_DDL);
 
-                // Check if data already exists (container might be reused)
-                try (ResultSet rs = stmt.executeQuery(
-                        "SELECT COUNT(*) FROM " + RAG_DOCUMENTS_TABLE)) {
-                    if (rs.next() && rs.getLong(1) > 0) {
-                        LOG.infof("RAG data already loaded (%d rows) — skipping", rs.getLong(1));
-                        conn.rollback();
-                        return;
-                    }
-                }
-
-                // Load each fragment
-                for (String fragment : fragments) {
-                    for (String statement : splitSqlStatements(fragment)) {
+                for (RagFragment fragment : fragments) {
+                    for (String statement : splitSqlStatements(fragment.sql())) {
                         if (!statement.isBlank()) {
                             stmt.execute(statement);
                         }
                     }
+                    LOG.debugf("Loaded RAG source: %s", fragment.source());
                 }
 
-                // Create index after bulk insert
                 stmt.execute(CREATE_INDEX_DDL);
             }
 
             conn.commit();
 
-            // Log final count
             try (Statement stmt = conn.createStatement();
                     ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + RAG_DOCUMENTS_TABLE)) {
                 if (rs.next()) {
-                    LOG.infof("RAG data loaded: %d documents for Quarkus %s", rs.getLong(1), version);
+                    LOG.infof("RAG data loaded: %d total documents for Quarkus %s", rs.getLong(1), version);
                 }
             }
         } catch (SQLException e) {

--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -1,0 +1,361 @@
+package io.quarkus.agent.mcp;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.jboss.logging.Logger;
+
+/**
+ * Discovers {@code META-INF/quarkus-rag.sql} fragments from extension deployment JARs
+ * in the local Maven repository and loads them into a pgvector database.
+ * Follows the same JAR scanning pattern as {@link SkillReader}.
+ */
+@ApplicationScoped
+public class RagSqlLoader {
+
+    private static final Logger LOG = Logger.getLogger(RagSqlLoader.class);
+
+    private static final String RAG_SQL_PATH = "META-INF/quarkus-rag.sql";
+    private static final String DEPLOYMENT_SUFFIX = "-deployment";
+    private static final String CORE_GROUP_ID = "io.quarkus";
+    private static final String RAG_DOCUMENTS_TABLE = "rag_documents";
+
+    private static final String CREATE_EXTENSION_DDL = "CREATE EXTENSION IF NOT EXISTS vector";
+    private static final String CREATE_TABLE_DDL = """
+            CREATE TABLE IF NOT EXISTS rag_documents (
+                embedding_id UUID PRIMARY KEY,
+                embedding vector(384),
+                text TEXT,
+                metadata JSONB
+            )""";
+    private static final String CREATE_INDEX_DDL = """
+            CREATE INDEX IF NOT EXISTS idx_rag_embedding ON rag_documents
+                USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)""";
+
+    private final Set<String> loadedVersions = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Ensures RAG data is loaded for the given Quarkus version.
+     * Discovers SQL fragments from extension JARs, creates the schema if needed,
+     * and loads the data. Skips if already loaded for this version.
+     */
+    public void ensureLoaded(String quarkusVersion, String host, int port,
+            String database, String user, String password) {
+        String versionKey = quarkusVersion != null ? quarkusVersion : "default";
+        if (loadedVersions.contains(versionKey)) {
+            return;
+        }
+
+        String resolvedVersion = quarkusVersion != null ? quarkusVersion : detectLatestInstalledVersion();
+        if (resolvedVersion == null) {
+            LOG.warn("Could not determine Quarkus version for RAG loading — no SQL fragments will be loaded");
+            loadedVersions.add(versionKey);
+            return;
+        }
+
+        List<String> fragments = discoverSqlFragments(resolvedVersion);
+        if (fragments.isEmpty()) {
+            LOG.infof("No RAG SQL fragments found for Quarkus %s", resolvedVersion);
+            loadedVersions.add(versionKey);
+            return;
+        }
+
+        String jdbcUrl = "jdbc:postgresql://" + host + ":" + port + "/" + database;
+        loadSql(jdbcUrl, user, password, fragments, resolvedVersion);
+        loadedVersions.add(versionKey);
+    }
+
+    private static final String AGGREGATED_ARTIFACT_ID = "quarkus-documentation-core-rag";
+    private static final String AGGREGATED_GROUP_PATH = "io/quarkus";
+
+    /**
+     * Discovers RAG SQL fragments from extension deployment JARs in ~/.m2/repository.
+     * If the aggregated artifact is not found locally, downloads it from Maven Central.
+     */
+    List<String> discoverSqlFragments(String quarkusVersion) {
+        Path m2Repo = Path.of(System.getProperty("user.home"), ".m2", "repository");
+
+        List<String> fragments = new ArrayList<>();
+
+        // 1. Check for aggregated artifact locally
+        Path aggregatedJarPath = resolveAggregatedJarPath(quarkusVersion, m2Repo);
+        if (Files.isRegularFile(aggregatedJarPath)) {
+            String sql = readSqlFromJar(aggregatedJarPath);
+            if (sql != null) {
+                fragments.add(sql);
+                LOG.infof("Found aggregated RAG SQL artifact locally for Quarkus %s", quarkusVersion);
+                return fragments;
+            }
+        }
+
+        // 2. Download aggregated artifact from Maven Central if not found locally
+        if (fragments.isEmpty()) {
+            Path downloaded = downloadFromMavenCentral(quarkusVersion, aggregatedJarPath);
+            if (downloaded != null) {
+                String sql = readSqlFromJar(downloaded);
+                if (sql != null) {
+                    fragments.add(sql);
+                    LOG.infof("Downloaded aggregated RAG SQL artifact for Quarkus %s", quarkusVersion);
+                    return fragments;
+                }
+            }
+        }
+
+        // 3. Scan individual core extension deployment JARs
+        if (Files.isDirectory(m2Repo)) {
+            fragments.addAll(scanCoreExtensionJars(m2Repo, quarkusVersion));
+        }
+
+        LOG.infof("Discovered %d RAG SQL fragment(s) for Quarkus %s", fragments.size(), quarkusVersion);
+        return fragments;
+    }
+
+    private Path resolveAggregatedJarPath(String version, Path m2Repo) {
+        return m2Repo.resolve(AGGREGATED_GROUP_PATH)
+                .resolve(AGGREGATED_ARTIFACT_ID)
+                .resolve(version)
+                .resolve(AGGREGATED_ARTIFACT_ID + "-" + version + ".jar");
+    }
+
+    private Path downloadFromMavenCentral(String version, Path targetPath) {
+        if (version.endsWith("-SNAPSHOT")) {
+            LOG.debugf("Skipping remote download for SNAPSHOT version %s", version);
+            return null;
+        }
+
+        String baseUrl = SkillReader.resolveMavenRepoBaseUrl(null);
+        String artifactPath = "/" + AGGREGATED_GROUP_PATH + "/" + AGGREGATED_ARTIFACT_ID
+                + "/" + version
+                + "/" + AGGREGATED_ARTIFACT_ID + "-" + version + ".jar";
+        String url = baseUrl + artifactPath;
+
+        LOG.infof("RAG SQL not found locally, downloading from %s...", url);
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(60))
+                    .GET()
+                    .build();
+
+            HttpResponse<InputStream> response = HttpClientProvider.getHttpClient().send(request,
+                    HttpResponse.BodyHandlers.ofInputStream());
+
+            if (response.statusCode() == 200) {
+                Files.createDirectories(targetPath.getParent());
+                try (InputStream body = response.body()) {
+                    Files.copy(body, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                }
+                LOG.infof("Downloaded RAG SQL artifact to %s", targetPath);
+                return targetPath;
+            } else {
+                LOG.warnf("RAG SQL artifact not available at %s (HTTP %d) — documentation search will be limited",
+                        url, response.statusCode());
+                return null;
+            }
+        } catch (IOException | InterruptedException e) {
+            LOG.warnf("Failed to download RAG SQL from %s: %s", url, e.getMessage());
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return null;
+        }
+    }
+
+    private List<String> scanCoreExtensionJars(Path m2Repo, String version) {
+        Path quarkusDir = m2Repo.resolve("io/quarkus");
+        if (!Files.isDirectory(quarkusDir)) {
+            return List.of();
+        }
+
+        List<String> fragments = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(quarkusDir,
+                entry -> Files.isDirectory(entry)
+                        && entry.getFileName().toString().startsWith("quarkus-")
+                        && entry.getFileName().toString().endsWith(DEPLOYMENT_SUFFIX))) {
+            for (Path extDir : stream) {
+                String deploymentArtifactId = extDir.getFileName().toString();
+                Path deploymentJar = extDir.resolve(version)
+                        .resolve(deploymentArtifactId + "-" + version + ".jar");
+
+                if (!Files.isRegularFile(deploymentJar)) {
+                    continue;
+                }
+
+                String sql = readSqlFromJar(deploymentJar);
+                if (sql != null) {
+                    fragments.add(sql);
+                    LOG.debugf("Found RAG SQL in %s", deploymentArtifactId);
+                }
+            }
+        } catch (IOException e) {
+            LOG.debugf("Failed to scan extension JARs: %s", e.getMessage());
+        }
+
+        return fragments;
+    }
+
+    private String readSqlFromJar(Path jarPath) {
+        try (JarFile jar = new JarFile(jarPath.toFile())) {
+            // Check data file first (aggregated artifact), then individual fragment
+            JarEntry entry = jar.getJarEntry("META-INF/quarkus-rag-data.sql");
+            if (entry == null) {
+                entry = jar.getJarEntry(RAG_SQL_PATH);
+            }
+            if (entry == null) {
+                return null;
+            }
+
+            try (InputStream is = jar.getInputStream(entry)) {
+                return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            }
+        } catch (IOException e) {
+            LOG.debugf("Failed to read RAG SQL from %s: %s", jarPath, e.getMessage());
+            return null;
+        }
+    }
+
+    private void loadSql(String jdbcUrl, String user, String password,
+            List<String> fragments, String version) {
+        LOG.infof("Loading %d RAG SQL fragment(s) for Quarkus %s...", fragments.size(), version);
+
+        try (Connection conn = DriverManager.getConnection(jdbcUrl, user, password)) {
+            conn.setAutoCommit(false);
+
+            try (Statement stmt = conn.createStatement()) {
+                // Create schema if needed
+                stmt.execute(CREATE_EXTENSION_DDL);
+                stmt.execute(CREATE_TABLE_DDL);
+
+                // Check if data already exists (container might be reused)
+                try (ResultSet rs = stmt.executeQuery(
+                        "SELECT COUNT(*) FROM " + RAG_DOCUMENTS_TABLE)) {
+                    if (rs.next() && rs.getLong(1) > 0) {
+                        LOG.infof("RAG data already loaded (%d rows) — skipping", rs.getLong(1));
+                        conn.rollback();
+                        return;
+                    }
+                }
+
+                // Load each fragment
+                for (String fragment : fragments) {
+                    for (String statement : splitSqlStatements(fragment)) {
+                        if (!statement.isBlank()) {
+                            stmt.execute(statement);
+                        }
+                    }
+                }
+
+                // Create index after bulk insert
+                stmt.execute(CREATE_INDEX_DDL);
+            }
+
+            conn.commit();
+
+            // Log final count
+            try (Statement stmt = conn.createStatement();
+                    ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + RAG_DOCUMENTS_TABLE)) {
+                if (rs.next()) {
+                    LOG.infof("RAG data loaded: %d documents for Quarkus %s", rs.getLong(1), version);
+                }
+            }
+        } catch (SQLException e) {
+            LOG.errorf(e, "Failed to load RAG SQL for Quarkus %s", version);
+        }
+    }
+
+    /**
+     * Splits a SQL string into individual statements.
+     * Handles the fact that text values can contain semicolons.
+     */
+    static List<String> splitSqlStatements(String sql) {
+        List<String> statements = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inSingleQuote = false;
+        boolean inLineComment = false;
+
+        for (int i = 0; i < sql.length(); i++) {
+            char c = sql.charAt(i);
+
+            if (c == '\n') {
+                inLineComment = false;
+                current.append(c);
+                continue;
+            }
+
+            if (inLineComment) {
+                continue;
+            }
+
+            if (c == '-' && i + 1 < sql.length() && sql.charAt(i + 1) == '-' && !inSingleQuote) {
+                inLineComment = true;
+                continue;
+            }
+
+            if (c == '\'' && !isEscaped(sql, i)) {
+                inSingleQuote = !inSingleQuote;
+            }
+
+            if (c == ';' && !inSingleQuote) {
+                String stmt = current.toString().trim();
+                if (!stmt.isEmpty()) {
+                    statements.add(stmt);
+                }
+                current = new StringBuilder();
+            } else {
+                current.append(c);
+            }
+        }
+
+        String remaining = current.toString().trim();
+        if (!remaining.isEmpty()) {
+            statements.add(remaining);
+        }
+
+        return statements;
+    }
+
+    private static boolean isEscaped(String sql, int pos) {
+        return pos > 0 && sql.charAt(pos - 1) == '\'';
+    }
+
+    private String detectLatestInstalledVersion() {
+        Path quarkusDir = Path.of(System.getProperty("user.home"), ".m2", "repository", "io", "quarkus", "quarkus-core");
+        if (!Files.isDirectory(quarkusDir)) {
+            return null;
+        }
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(quarkusDir, Files::isDirectory)) {
+            String latest = null;
+            for (Path versionDir : stream) {
+                String v = versionDir.getFileName().toString();
+                if (!v.contains("SNAPSHOT") && (latest == null || v.compareTo(latest) > 0)) {
+                    latest = v;
+                }
+            }
+            return latest;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -64,10 +64,9 @@ quarkus.mcp.server.tools.name-pattern=^[A-Za-z0-9_.-]{1,128}$
 # Can also be set via AGENT_MCP_SKILLS_INCLUDE_TRANSITIVE environment variable
 agent-mcp.skills.include-transitive=false
 
-# Doc search - pgvector container with pre-indexed Quarkus docs (from chappie-docling-rag)
-# Image tag is resolved per-project from the Quarkus version in pom.xml/build.gradle
-agent-mcp.doc-search.image-prefix=ghcr.io/quarkusio/chappie-ingestion-quarkus
-agent-mcp.doc-search.image-tag=latest
+# Doc search - generic pgvector container, data loaded from SQL fragments
+# in extension deployment JARs (META-INF/quarkus-rag.sql)
+agent-mcp.doc-search.image=pgvector/pgvector:pg17
 agent-mcp.doc-search.pg-user=quarkus
 agent-mcp.doc-search.pg-password=quarkus
 agent-mcp.doc-search.pg-database=quarkus

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -64,9 +64,12 @@ quarkus.mcp.server.tools.name-pattern=^[A-Za-z0-9_.-]{1,128}$
 # Can also be set via AGENT_MCP_SKILLS_INCLUDE_TRANSITIVE environment variable
 agent-mcp.skills.include-transitive=false
 
-# Doc search - generic pgvector container, data loaded from SQL fragments
+# Doc search - Quarkus 3.36+: generic pgvector container, data loaded from SQL fragments
 # in extension deployment JARs (META-INF/quarkus-rag.sql)
 agent-mcp.doc-search.image=pgvector/pgvector:pg17
+# Doc search - pre-3.36: pre-built image with documentation baked in
+agent-mcp.doc-search.image-prefix=ghcr.io/quarkusio/chappie-ingestion-quarkus
+agent-mcp.doc-search.image-tag=latest
 agent-mcp.doc-search.pg-user=quarkus
 agent-mcp.doc-search.pg-password=quarkus
 agent-mcp.doc-search.pg-database=quarkus

--- a/src/test/java/io/quarkus/agent/mcp/ContainerManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/ContainerManagerTest.java
@@ -1,0 +1,53 @@
+package io.quarkus.agent.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ContainerManagerTest {
+
+    @Test
+    void supportsRagSqlForNullAndBlank() {
+        assertTrue(ContainerManager.supportsRagSql(null));
+        assertTrue(ContainerManager.supportsRagSql(""));
+        assertTrue(ContainerManager.supportsRagSql("  "));
+    }
+
+    @Test
+    void supportsRagSqlForSnapshots() {
+        assertTrue(ContainerManager.supportsRagSql("999-SNAPSHOT"));
+        assertTrue(ContainerManager.supportsRagSql("3.36.0-SNAPSHOT"));
+        assertTrue(ContainerManager.supportsRagSql("3.35.0-SNAPSHOT"));
+    }
+
+    @Test
+    void supportsRagSqlForModernVersions() {
+        assertTrue(ContainerManager.supportsRagSql("3.36.0"));
+        assertTrue(ContainerManager.supportsRagSql("3.36.1"));
+        assertTrue(ContainerManager.supportsRagSql("3.37.0"));
+        assertTrue(ContainerManager.supportsRagSql("3.40.0"));
+        assertTrue(ContainerManager.supportsRagSql("4.0.0"));
+    }
+
+    @Test
+    void supportsRagSqlReturnsFalseForOlderVersions() {
+        assertFalse(ContainerManager.supportsRagSql("3.35.0"));
+        assertFalse(ContainerManager.supportsRagSql("3.35.2"));
+        assertFalse(ContainerManager.supportsRagSql("3.21.0"));
+        assertFalse(ContainerManager.supportsRagSql("3.0.0"));
+        assertFalse(ContainerManager.supportsRagSql("2.16.0"));
+    }
+
+    @Test
+    void supportsRagSqlHandlesQualifiedVersions() {
+        assertTrue(ContainerManager.supportsRagSql("3.36.0.Final"));
+        assertTrue(ContainerManager.supportsRagSql("3.36.0.CR1"));
+        assertFalse(ContainerManager.supportsRagSql("3.35.0.Final"));
+    }
+
+    @Test
+    void supportsRagSqlReturnsFalseForUnparseable() {
+        assertFalse(ContainerManager.supportsRagSql("not-a-version"));
+        assertFalse(ContainerManager.supportsRagSql("abc"));
+    }
+}

--- a/src/test/java/io/quarkus/agent/mcp/RagSqlLoaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/RagSqlLoaderTest.java
@@ -1,0 +1,52 @@
+package io.quarkus.agent.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class RagSqlLoaderTest {
+
+    @Test
+    void discoversAggregatedArtifactForSnapshot() {
+        RagSqlLoader loader = new RagSqlLoader();
+        List<String> fragments = loader.discoverSqlFragments("999-SNAPSHOT");
+
+        assertFalse(fragments.isEmpty(), "Should discover the quarkus-documentation-core-rag artifact");
+        assertEquals(1, fragments.size(), "Should find exactly one aggregated fragment");
+
+        String sql = fragments.get(0);
+        assertTrue(sql.contains("INSERT INTO rag_documents"), "SQL should contain INSERT statements");
+        assertTrue(sql.contains("quarkus-rest"), "SQL should contain REST guide data");
+        assertTrue(sql.contains("quarkus-arc"), "SQL should contain CDI guide data");
+        assertTrue(sql.contains("::vector"), "SQL should contain vector casts");
+        assertTrue(sql.contains("::jsonb"), "SQL should contain jsonb casts");
+
+        long insertCount = sql.lines()
+                .filter(line -> line.startsWith("INSERT INTO"))
+                .count();
+        assertTrue(insertCount > 7000, "Should have 7000+ inserts, got: " + insertCount);
+
+        System.out.println("Discovered SQL: " + sql.length() + " chars, " + insertCount + " INSERTs");
+    }
+
+    @Test
+    void splitSqlStatementsHandlesSemicolonsInQuotedStrings() {
+        String sql = "DELETE FROM t WHERE x = 'a;b';\nINSERT INTO t VALUES ('c;d');";
+        List<String> stmts = RagSqlLoader.splitSqlStatements(sql);
+
+        assertEquals(2, stmts.size());
+        assertTrue(stmts.get(0).contains("'a;b'"));
+        assertTrue(stmts.get(1).contains("'c;d'"));
+    }
+
+    @Test
+    void splitSqlStatementsSkipsComments() {
+        String sql = "-- this is a comment\nINSERT INTO t VALUES (1);";
+        List<String> stmts = RagSqlLoader.splitSqlStatements(sql);
+
+        assertEquals(1, stmts.size());
+        assertTrue(stmts.get(0).startsWith("INSERT"));
+    }
+}

--- a/src/test/java/io/quarkus/agent/mcp/RagSqlLoaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/RagSqlLoaderTest.java
@@ -11,12 +11,15 @@ class RagSqlLoaderTest {
     @Test
     void discoversAggregatedArtifactForSnapshot() {
         RagSqlLoader loader = new RagSqlLoader();
-        List<String> fragments = loader.discoverSqlFragments("999-SNAPSHOT");
+        List<RagSqlLoader.RagFragment> fragments = loader.discoverSqlFragments("999-SNAPSHOT", null);
 
         assertFalse(fragments.isEmpty(), "Should discover the quarkus-documentation-core-rag artifact");
         assertEquals(1, fragments.size(), "Should find exactly one aggregated fragment");
 
-        String sql = fragments.get(0);
+        RagSqlLoader.RagFragment fragment = fragments.get(0);
+        assertNotNull(fragment.source(), "Fragment should have a source identifier");
+
+        String sql = fragment.sql();
         assertTrue(sql.contains("INSERT INTO rag_documents"), "SQL should contain INSERT statements");
         assertTrue(sql.contains("quarkus-rest"), "SQL should contain REST guide data");
         assertTrue(sql.contains("quarkus-arc"), "SQL should contain CDI guide data");
@@ -48,5 +51,24 @@ class RagSqlLoaderTest {
 
         assertEquals(1, stmts.size());
         assertTrue(stmts.get(0).startsWith("INSERT"));
+    }
+
+    @Test
+    void extractSourceParsesDeleteStatement() {
+        String sql = "DELETE FROM rag_documents WHERE metadata->>'source' = 'quarkus-rest';\n"
+                + "INSERT INTO rag_documents VALUES (1);";
+        assertEquals("quarkus-rest", RagSqlLoader.extractSource(sql, "fallback"));
+    }
+
+    @Test
+    void extractSourceUsesFallbackWhenNoDeletePresent() {
+        String sql = "INSERT INTO rag_documents VALUES (1);";
+        assertEquals("my-extension", RagSqlLoader.extractSource(sql, "my-extension"));
+    }
+
+    @Test
+    void extractSourceHandlesWhitespaceVariations() {
+        String sql = "DELETE FROM rag_documents WHERE metadata ->>'source'  =  'quarkus-hibernate-orm';\n";
+        assertEquals("quarkus-hibernate-orm", RagSqlLoader.extractSource(sql, "fallback"));
     }
 }


### PR DESCRIPTION
The current approach uses a monolithic `chappie-ingestion-quarkus` Docker image that contains a pre-built vector store of the Quarkus core documentation. This makes it difficult for non-core extensions (Quarkiverse, Hibernate, etc.) to contribute their own documentation to the RAG search.

This switches to a generic `pgvector/pgvector:pg17` container with SQL fragments loaded at runtime. A new `RagSqlLoader` discovers `META-INF/quarkus-rag.sql` files from extension deployment JARs and loads them into the database on first use. The discovery strategy is:

1. Check for an aggregated `quarkus-documentation-core-rag` artifact locally
2. Download it from Maven Central if not found
3. Fall back to scanning individual extension deployment JARs

This aligns with the ecosystem-wide tooling being introduced in:
- [quarkus-documentation-rag](https://github.com/quarkusio/quarkus-documentation-rag) — Maven plugin that generates SQL from AsciiDoc guides
- [quarkus#54119](https://github.com/quarkusio/quarkus/pull/54119) — Aggregated core docs artifact
- [quarkiverse-parent#235](https://github.com/quarkiverse/quarkiverse-parent/pull/235) — Opt-in profile for Quarkiverse extensions