### PR TITLE
Add support for additionalUpdateRecipes in quarkus_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ For existing projects, `quarkus_update` checks if the Quarkus version is current
 
 - Compares build files against [reference projects](https://github.com/quarkusio/code-with-quarkus-compare)
 - Runs `quarkus update --dry-run` (if CLI available) to preview automated migrations
-- Supports custom OpenRewrite recipes via `additionalUpdateRecipes` (e.g. `org.acme:my-recipes:1.0.0`)
+- Supports custom OpenRewrite recipes via `additionalUpdateRecipes` (e.g. `org.acme:my-recipes:1.0.0`), either per-call or configured globally with `agent-mcp.update.additional-recipes`
 - Links to the structural diff between versions
 - Recommends manual actions for changes that automated migration doesn't cover
 
@@ -373,6 +373,7 @@ Configuration via `application.properties`, system properties (`-D`), or environ
 | `agent-mcp.process.mvn-cmd` | _(auto-detect)_ | Override the Maven command used to start dev mode (e.g. `mvn` to skip wrapper detection) |
 | `agent-mcp.process.gradle-cmd` | _(auto-detect)_ | Override the Gradle command used to start dev mode (e.g. `gradle` to skip wrapper detection) |
 | `agent-mcp.log.enabled` | `false` | Enable file logging on startup — logs are written to `~/.quarkus/agent-mcp/agent-mcp.log` |
+| `agent-mcp.update.additional-recipes` | _(none)_ | Additional OpenRewrite recipe artifacts for `quarkus_update` (e.g. `org.acme:my-recipes:1.0.0`) |
 
 ## Building a Native Image
 

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ For existing projects, `quarkus_update` checks if the Quarkus version is current
 
 - Compares build files against [reference projects](https://github.com/quarkusio/code-with-quarkus-compare)
 - Runs `quarkus update --dry-run` (if CLI available) to preview automated migrations
+- Supports custom OpenRewrite recipes via `additionalUpdateRecipes` (e.g. `org.acme:my-recipes:1.0.0`)
 - Links to the structural diff between versions
 - Recommends manual actions for changes that automated migration doesn't cover
 
@@ -275,7 +276,7 @@ For existing projects, `quarkus_update` checks if the Quarkus version is current
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `quarkus_update` | Check if project is up-to-date, provide upgrade report | `projectDir` (required) |
+| `quarkus_update` | Check if project is up-to-date, provide upgrade report | `projectDir` (required), `additionalUpdateRecipes` |
 
 ### Extension Skills
 

--- a/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
@@ -50,7 +50,10 @@ public class UpdateTools {
             // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
             annotations = @Tool.Annotations(title = "quarkus_update", readOnlyHint = true, destructiveHint = false, idempotentHint = true))
     ToolResponse update(
-            @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir) {
+            @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
+            @ToolArg(description = "Additional OpenRewrite recipe artifacts to include in the update, "
+                    + "in the format 'groupId:artifactId:version' (e.g. 'org.acme:my-recipes:1.0.0'). "
+                    + "Multiple artifacts can be comma-separated.", required = false) String additionalUpdateRecipes) {
         try {
             Path dir = Path.of(projectDir);
             if (!Files.isDirectory(dir)) {
@@ -73,7 +76,11 @@ public class UpdateTools {
             report.append("# Quarkus Project Update Report\n\n");
             report.append("- **Build tool:** ").append(buildInfo.buildTool).append("\n");
             report.append("- **Current version:** ").append(buildInfo.version).append("\n");
-            report.append("- **Latest version:** ").append(latestVersion).append("\n\n");
+            report.append("- **Latest version:** ").append(latestVersion).append("\n");
+            if (additionalUpdateRecipes != null && !additionalUpdateRecipes.isBlank()) {
+                report.append("- **Additional update recipes:** ").append(additionalUpdateRecipes).append("\n");
+            }
+            report.append("\n");
 
             boolean isUpToDate = buildInfo.version.equals(latestVersion);
 
@@ -103,7 +110,7 @@ public class UpdateTools {
             }
 
             // Step 3b: Run quarkus update --dry-run
-            String dryRunReport = runQuarkusUpdateDryRun(projectDir);
+            String dryRunReport = runQuarkusUpdateDryRun(projectDir, additionalUpdateRecipes);
             if (dryRunReport != null) {
                 report.append("## Automated Migration Preview (`quarkus update --dry-run`)\n\n");
                 report.append(dryRunReport).append("\n");
@@ -123,7 +130,11 @@ public class UpdateTools {
 
             // Step 4: Recommended actions
             report.append("## Recommended Actions\n\n");
-            report.append("1. Run `quarkus update` to apply automated migrations");
+            report.append("1. Run `quarkus update");
+            if (additionalUpdateRecipes != null && !additionalUpdateRecipes.isBlank()) {
+                report.append(" --additional-update-recipes=").append(additionalUpdateRecipes);
+            }
+            report.append("` to apply automated migrations");
             if (dryRunReport == null) {
                 report.append(" (install the Quarkus CLI first: https://quarkus.io/guides/cli-tooling)");
             }
@@ -269,14 +280,22 @@ public class UpdateTools {
     /**
      * Runs {@code quarkus update --dry-run} and returns the report, or null if CLI not available.
      */
-    private String runQuarkusUpdateDryRun(String projectDir) {
+    private String runQuarkusUpdateDryRun(String projectDir, String additionalUpdateRecipes) {
         // Check if quarkus CLI is available
         if (!isCommandAvailable("quarkus")) {
             return null;
         }
 
         try {
-            ProcessBuilder pb = new ProcessBuilder("quarkus", "update", "--dry-run")
+            List<String> cmd = new ArrayList<>();
+            cmd.add("quarkus");
+            cmd.add("update");
+            cmd.add("--dry-run");
+            if (additionalUpdateRecipes != null && !additionalUpdateRecipes.isBlank()) {
+                cmd.add("--additional-update-recipes=" + additionalUpdateRecipes);
+            }
+
+            ProcessBuilder pb = new ProcessBuilder(cmd)
                     .directory(new File(projectDir))
                     .redirectErrorStream(true);
 

--- a/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
@@ -3,6 +3,7 @@ package io.quarkus.agent.mcp;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -17,8 +18,10 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 /**
@@ -31,6 +34,10 @@ import org.jboss.logging.Logger;
 public class UpdateTools {
 
     private static final Logger LOG = Logger.getLogger(UpdateTools.class);
+
+    @Inject
+    @ConfigProperty(name = "agent-mcp.update.additional-recipes")
+    Optional<String> configuredAdditionalRecipes;
 
     private static final String COMPARE_REPO = "quarkusio/code-with-quarkus-compare";
     private static final String RAW_BASE = "https://raw.githubusercontent.com/" + COMPARE_REPO;
@@ -58,6 +65,13 @@ public class UpdateTools {
             Path dir = Path.of(projectDir);
             if (!Files.isDirectory(dir)) {
                 return ToolResponse.error("Project directory does not exist: " + projectDir);
+            }
+
+            // Tool argument takes precedence over configured default
+            if ((additionalUpdateRecipes == null || additionalUpdateRecipes.isBlank())
+                    && configuredAdditionalRecipes.isPresent()
+                    && !configuredAdditionalRecipes.get().isBlank()) {
+                additionalUpdateRecipes = configuredAdditionalRecipes.get();
             }
 
             // Step 1: Detect build tool and version

--- a/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
@@ -47,6 +47,10 @@ public class UpdateTools {
     private static final Pattern VERSION_PATTERN = Pattern.compile(
             "^[0-9]+\\.[0-9]+\\.[0-9]+([.\\-][A-Za-z0-9]+)*$");
 
+    // Validates additionalUpdateRecipes: comma-separated groupId:artifactId:version entries
+    private static final Pattern RECIPE_ARTIFACT_PATTERN = Pattern.compile(
+            "^[a-zA-Z0-9._-]+:[a-zA-Z0-9._-]+:[a-zA-Z0-9._-]+(\\s*,\\s*[a-zA-Z0-9._-]+:[a-zA-Z0-9._-]+:[a-zA-Z0-9._-]+)*$");
+
 
     @Tool(name = "quarkus_update", description = "Check if a Quarkus project is up-to-date and provide an upgrade report. "
             + "Detects the current version, checks for newer releases, compares build files against "
@@ -68,10 +72,17 @@ public class UpdateTools {
             }
 
             // Tool argument takes precedence over configured default
-            if ((additionalUpdateRecipes == null || additionalUpdateRecipes.isBlank())
+            if (!hasValue(additionalUpdateRecipes)
                     && configuredAdditionalRecipes.isPresent()
-                    && !configuredAdditionalRecipes.get().isBlank()) {
+                    && hasValue(configuredAdditionalRecipes.get())) {
                 additionalUpdateRecipes = configuredAdditionalRecipes.get();
+            }
+
+            if (hasValue(additionalUpdateRecipes)
+                    && !RECIPE_ARTIFACT_PATTERN.matcher(additionalUpdateRecipes.trim()).matches()) {
+                return ToolResponse.error(
+                        "Invalid additionalUpdateRecipes format. Expected comma-separated 'groupId:artifactId:version' entries, got: "
+                                + additionalUpdateRecipes);
             }
 
             // Step 1: Detect build tool and version
@@ -91,7 +102,7 @@ public class UpdateTools {
             report.append("- **Build tool:** ").append(buildInfo.buildTool).append("\n");
             report.append("- **Current version:** ").append(buildInfo.version).append("\n");
             report.append("- **Latest version:** ").append(latestVersion).append("\n");
-            if (additionalUpdateRecipes != null && !additionalUpdateRecipes.isBlank()) {
+            if (hasValue(additionalUpdateRecipes)) {
                 report.append("- **Additional update recipes:** ").append(additionalUpdateRecipes).append("\n");
             }
             report.append("\n");
@@ -145,7 +156,7 @@ public class UpdateTools {
             // Step 4: Recommended actions
             report.append("## Recommended Actions\n\n");
             report.append("1. Run `quarkus update");
-            if (additionalUpdateRecipes != null && !additionalUpdateRecipes.isBlank()) {
+            if (hasValue(additionalUpdateRecipes)) {
                 report.append(" --additional-update-recipes=").append(additionalUpdateRecipes);
             }
             report.append("` to apply automated migrations");
@@ -305,7 +316,7 @@ public class UpdateTools {
             cmd.add("quarkus");
             cmd.add("update");
             cmd.add("--dry-run");
-            if (additionalUpdateRecipes != null && !additionalUpdateRecipes.isBlank()) {
+            if (hasValue(additionalUpdateRecipes)) {
                 cmd.add("--additional-update-recipes=" + additionalUpdateRecipes);
             }
 
@@ -353,6 +364,10 @@ public class UpdateTools {
 
     private boolean isCommandAvailable(String command) {
         return ProcessUtils.isCommandAvailable(command);
+    }
+
+    private static boolean hasValue(String s) {
+        return s != null && !s.isBlank();
     }
 
     record BuildInfo(String buildTool, String tagPrefix, String buildFile, String version) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,6 +59,11 @@ quarkus.mcp.server.tools.name-pattern=^[A-Za-z0-9_.-]{1,128}$
 # Uncomment for local testing against a SNAPSHOT build:
 # agent-mcp.default-quarkus-version=999-SNAPSHOT
 
+# Additional OpenRewrite recipe artifacts to include in quarkus_update (groupId:artifactId:version)
+# Example: agent-mcp.update.additional-recipes=org.acme:my-recipes:1.0.0
+# Can also be set via AGENT_MCP_UPDATE_ADDITIONAL_RECIPES environment variable
+# agent-mcp.update.additional-recipes=
+
 # Doc search - pgvector container with pre-indexed Quarkus docs (from chappie-docling-rag)
 # Image tag is resolved per-project from the Quarkus version in pom.xml/build.gradle
 agent-mcp.doc-search.image-prefix=ghcr.io/quarkusio/chappie-ingestion-quarkus

--- a/src/test/java/io/quarkus/agent/mcp/UpdateToolsTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/UpdateToolsTest.java
@@ -2,10 +2,12 @@ package io.quarkus.agent.mcp;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -90,6 +92,35 @@ class UpdateToolsTest {
         // 3.21.2 and 3.21.2.Final — both start with 3.21.2
         assertTrue(versions.indexOf("3.21.2") < versions.indexOf("3.21.2.Final")
                 || versions.indexOf("3.21.2.Final") < versions.indexOf("3.21.2"));
+    }
+
+    @Test
+    void recipeArtifactPatternAcceptsValidFormats() throws Exception {
+        Pattern pattern = getRecipePattern();
+
+        assertTrue(pattern.matcher("org.acme:my-recipes:1.0.0").matches());
+        assertTrue(pattern.matcher("com.example:recipes:2.3.1").matches());
+        assertTrue(pattern.matcher("io.quarkus:quarkus-update-recipes:3.21.2").matches());
+        assertTrue(pattern.matcher("org.acme:a:1.0,com.example:b:2.0").matches());
+        assertTrue(pattern.matcher("org.acme:a:1.0, com.example:b:2.0").matches());
+    }
+
+    @Test
+    void recipeArtifactPatternRejectsInvalidFormats() throws Exception {
+        Pattern pattern = getRecipePattern();
+
+        assertFalse(pattern.matcher("not-a-gav").matches());
+        assertFalse(pattern.matcher("only:two").matches());
+        assertFalse(pattern.matcher("has spaces:in:artifact").matches());
+        assertFalse(pattern.matcher("").matches());
+        assertFalse(pattern.matcher("; rm -rf /").matches());
+        assertFalse(pattern.matcher("org.acme:recipes:1.0 --some-flag").matches());
+    }
+
+    private static Pattern getRecipePattern() throws Exception {
+        Field field = UpdateTools.class.getDeclaredField("RECIPE_ARTIFACT_PATTERN");
+        field.setAccessible(true);
+        return (Pattern) field.get(null);
     }
 
     @Test


### PR DESCRIPTION
Users with custom OpenRewrite recipes need to pass them when running Quarkus updates. This adds an optional `additionalUpdateRecipes` parameter to the `quarkus_update` tool so custom recipe artifacts (e.g. `org.acme:my-recipes:1.0.0`) are included in the `quarkus update --dry-run` preview and shown in the recommended actions for the actual update run.

Fixes #134