### PR TITLE
Fall back to Maven/Gradle plugin when quarkus CLI is unavailable for update

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
@@ -1,6 +1,7 @@
 package io.quarkus.agent.mcp;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -30,6 +31,49 @@ final class ProcessUtils {
             if (p != null) {
                 p.destroyForcibly();
             }
+        }
+    }
+
+    static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase().contains("win");
+    }
+
+    static String resolveMavenCommand(File projectDir) {
+        File wrapper = isWindows() ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
+        if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
+            return isWindows() ? "mvnw.cmd" : "./mvnw";
+        }
+        return "mvn";
+    }
+
+    static String resolveGradleCommand(File projectDir) {
+        File wrapper = isWindows() ? new File(projectDir, "gradlew.bat") : new File(projectDir, "gradlew");
+        if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
+            return isWindows() ? "gradlew.bat" : "./gradlew";
+        }
+        return "gradle";
+    }
+
+    static boolean verifyTrustedWrapper(File wrapper) {
+        try {
+            Process p = new ProcessBuilder("git", "ls-files", "--error-unmatch", wrapper.getName())
+                    .directory(wrapper.getParentFile())
+                    .redirectErrorStream(true)
+                    .start();
+            p.getInputStream().transferTo(java.io.OutputStream.nullOutputStream());
+            int exit = p.waitFor();
+            if (exit != 0) {
+                throw new IllegalStateException(
+                        "Wrapper script '" + wrapper.getAbsolutePath() + "' is NOT tracked by git. "
+                                + "It could be malicious. Add it to git or use the system-installed build tool.");
+            }
+            return true;
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            LOG.warnf("Could not verify wrapper script '%s' against git: %s. "
+                    + "Falling back to system build tool.", wrapper.getAbsolutePath(), e.getMessage());
+            return false;
         }
     }
 

--- a/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
@@ -15,9 +15,10 @@ final class ProcessUtils {
     }
 
     static boolean isCommandAvailable(String command) {
+        String checker = isWindows() ? "where" : "which";
         Process p = null;
         try {
-            p = new ProcessBuilder("which", command)
+            p = new ProcessBuilder(checker, command)
                     .redirectErrorStream(true)
                     .start();
             p.getInputStream().transferTo(java.io.OutputStream.nullOutputStream());
@@ -39,17 +40,19 @@ final class ProcessUtils {
     }
 
     static String resolveMavenCommand(File projectDir) {
-        File wrapper = isWindows() ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
+        boolean win = isWindows();
+        File wrapper = win ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
         if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
-            return isWindows() ? "mvnw.cmd" : "./mvnw";
+            return win ? "mvnw.cmd" : "./mvnw";
         }
         return "mvn";
     }
 
     static String resolveGradleCommand(File projectDir) {
-        File wrapper = isWindows() ? new File(projectDir, "gradlew.bat") : new File(projectDir, "gradlew");
+        boolean win = isWindows();
+        File wrapper = win ? new File(projectDir, "gradlew.bat") : new File(projectDir, "gradlew");
         if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
-            return isWindows() ? "gradlew.bat" : "./gradlew";
+            return win ? "gradlew.bat" : "./gradlew";
         }
         return "gradle";
     }

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -189,63 +189,15 @@ public class QuarkusProcessManager {
     }
 
     private ProcessBuilder createMavenProcessBuilder(File projectDir) {
-        String cmd;
-        if (mvnCmd.isPresent()) {
-            cmd = mvnCmd.get();
-        } else {
-            File wrapper = isWindows() ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
-            if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
-                cmd = isWindows() ? "mvnw.cmd" : "./mvnw";
-            } else {
-                cmd = "mvn";
-            }
-        }
+        String cmd = mvnCmd.orElseGet(() -> ProcessUtils.resolveMavenCommand(projectDir));
         return new ProcessBuilder(cmd, "quarkus:dev", "-Dquarkus.console.basic=true",
                 "-Dquarkus.dev-mcp.enabled=true");
     }
 
     private ProcessBuilder createGradleProcessBuilder(File projectDir) {
-        String cmd;
-        if (gradleCmd.isPresent()) {
-            cmd = gradleCmd.get();
-        } else {
-            File wrapper = isWindows() ? new File(projectDir, "gradlew.bat") : new File(projectDir, "gradlew");
-            if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
-                cmd = isWindows() ? "gradlew.bat" : "./gradlew";
-            } else {
-                cmd = "gradle";
-            }
-        }
+        String cmd = gradleCmd.orElseGet(() -> ProcessUtils.resolveGradleCommand(projectDir));
         return new ProcessBuilder(cmd, "quarkusDev", "-Dquarkus.console.basic=true",
                 "-Dquarkus.dev-mcp.enabled=true");
-    }
-
-    /**
-     * Returns true if the wrapper is tracked by git (trusted), false if verification
-     * failed and the caller should fall back to the system build tool.
-     * Throws if the wrapper is explicitly untracked (potential supply-chain attack).
-     */
-    private boolean verifyTrustedWrapper(File wrapper) {
-        try {
-            Process p = new ProcessBuilder("git", "ls-files", "--error-unmatch", wrapper.getName())
-                    .directory(wrapper.getParentFile())
-                    .redirectErrorStream(true)
-                    .start();
-            p.getInputStream().transferTo(java.io.OutputStream.nullOutputStream());
-            int exit = p.waitFor();
-            if (exit != 0) {
-                throw new IllegalStateException(
-                        "Wrapper script '" + wrapper.getAbsolutePath() + "' is NOT tracked by git. "
-                                + "It could be malicious. Add it to git or use the system-installed build tool.");
-            }
-            return true;
-        } catch (IllegalStateException e) {
-            throw e;
-        } catch (Exception e) {
-            LOG.warnf("Could not verify wrapper script '%s' against git: %s. "
-                    + "Falling back to system build tool.", wrapper.getAbsolutePath(), e.getMessage());
-            return false;
-        }
     }
 
     static boolean isPortAvailable(int port) {
@@ -272,7 +224,4 @@ public class QuarkusProcessManager {
         return Path.of(System.getProperty("user.home"), ".quarkus", "apps", dirName, "quarkus-dev.log");
     }
 
-    private boolean isWindows() {
-        return System.getProperty("os.name", "").toLowerCase().contains("win");
-    }
 }

--- a/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
@@ -28,7 +28,8 @@ import org.jboss.logging.Logger;
  * MCP tool for checking and updating Quarkus projects to the latest version.
  * Compares project build files against reference projects from
  * <a href="https://github.com/quarkusio/code-with-quarkus-compare">code-with-quarkus-compare</a>,
- * runs {@code quarkus update --dry-run} if the CLI is available, and produces
+ * runs {@code quarkus update --dry-run} (or the equivalent Maven/Gradle plugin goal
+ * when the CLI is unavailable), and produces
  * a unified upgrade report.
  */
 public class UpdateTools {
@@ -54,7 +55,7 @@ public class UpdateTools {
 
     @Tool(name = "quarkus_update", description = "Check if a Quarkus project is up-to-date and provide an upgrade report. "
             + "Detects the current version, checks for newer releases, compares build files against "
-            + "reference projects, and optionally runs 'quarkus update --dry-run' to preview migrations. "
+            + "reference projects, and runs 'quarkus update --dry-run' (or the equivalent Maven/Gradle plugin goal) to preview migrations. "
             + "IMPORTANT: For existing Quarkus projects, ALWAYS call this tool (via a subagent if supported) BEFORE "
             + "starting any development work to ensure the project is on the latest version.",
             // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
@@ -135,7 +136,7 @@ public class UpdateTools {
             }
 
             // Step 3b: Run quarkus update --dry-run
-            String dryRunReport = runQuarkusUpdateDryRun(projectDir, additionalUpdateRecipes);
+            String dryRunReport = runQuarkusUpdateDryRun(projectDir, additionalUpdateRecipes, buildInfo);
             if (dryRunReport != null) {
                 report.append("## Automated Migration Preview (`quarkus update --dry-run`)\n\n");
                 report.append(dryRunReport).append("\n");
@@ -303,23 +304,18 @@ public class UpdateTools {
     }
 
     /**
-     * Runs {@code quarkus update --dry-run} and returns the report, or null if CLI not available.
+     * Runs {@code quarkus update --dry-run} and returns the report.
+     * Falls back to the Maven or Gradle plugin when the Quarkus CLI is unavailable.
+     * Returns null only when no suitable build tool can be found.
      */
-    private String runQuarkusUpdateDryRun(String projectDir, String additionalUpdateRecipes) {
-        // Check if quarkus CLI is available
-        if (!isCommandAvailable("quarkus")) {
+    private String runQuarkusUpdateDryRun(String projectDir, String additionalUpdateRecipes, BuildInfo buildInfo) {
+        List<String> cmd = buildUpdateCommand(projectDir, additionalUpdateRecipes, buildInfo);
+        if (cmd == null) {
             return null;
         }
 
+        String cmdDescription = String.join(" ", cmd);
         try {
-            List<String> cmd = new ArrayList<>();
-            cmd.add("quarkus");
-            cmd.add("update");
-            cmd.add("--dry-run");
-            if (hasValue(additionalUpdateRecipes)) {
-                cmd.add("--additional-update-recipes=" + additionalUpdateRecipes);
-            }
-
             ProcessBuilder pb = new ProcessBuilder(cmd)
                     .directory(new File(projectDir))
                     .redirectErrorStream(true);
@@ -341,7 +337,6 @@ public class UpdateTools {
             StringBuilder report = new StringBuilder();
             report.append("Console output:\n```\n").append(output.trim()).append("\n```\n\n");
 
-            // Read the generated patch if available
             Path patchFile = Path.of(projectDir, "target", "rewrite", "rewrite.patch");
             if (Files.isRegularFile(patchFile)) {
                 String patch = Files.readString(patchFile, StandardCharsets.UTF_8);
@@ -352,14 +347,62 @@ public class UpdateTools {
             }
 
             if (exitCode != 0) {
-                report.insert(0, "**Note:** `quarkus update --dry-run` exited with code " + exitCode + "\n\n");
+                report.insert(0, "**Note:** `" + cmdDescription + "` exited with code " + exitCode + "\n\n");
             }
 
             return report.toString();
         } catch (Exception e) {
-            LOG.debugf("Failed to run quarkus update --dry-run: %s", e.getMessage());
-            return "Failed to run `quarkus update --dry-run`: " + e.getMessage() + "\n";
+            LOG.debugf("Failed to run update dry-run: %s", e.getMessage());
+            return "Failed to run `" + cmdDescription + "`: " + e.getMessage() + "\n";
         }
+    }
+
+    /**
+     * Builds the command to run the update dry-run.
+     * Prefers the Quarkus CLI, then falls back to Maven/Gradle plugin.
+     */
+    List<String> buildUpdateCommand(String projectDir, String additionalUpdateRecipes, BuildInfo buildInfo) {
+        if (isCommandAvailable("quarkus")) {
+            List<String> cmd = new ArrayList<>();
+            cmd.add("quarkus");
+            cmd.add("update");
+            cmd.add("--dry-run");
+            if (hasValue(additionalUpdateRecipes)) {
+                cmd.add("--additional-update-recipes=" + additionalUpdateRecipes);
+            }
+            return cmd;
+        }
+
+        File dir = new File(projectDir);
+        if ("Maven".equals(buildInfo.buildTool())) {
+            return buildMavenUpdateCommand(dir, additionalUpdateRecipes, buildInfo.version());
+        }
+        if ("Gradle".equals(buildInfo.buildTool()) || "Gradle Kotlin DSL".equals(buildInfo.buildTool())) {
+            return buildGradleUpdateCommand(dir);
+        }
+
+        return null;
+    }
+
+    List<String> buildMavenUpdateCommand(File projectDir, String additionalUpdateRecipes, String version) {
+        String cmd = ProcessUtils.resolveMavenCommand(projectDir);
+        List<String> args = new ArrayList<>();
+        args.add(cmd);
+        args.add("io.quarkus.platform:quarkus-maven-plugin:" + version + ":update");
+        args.add("-DrewriteDryRun=true");
+        args.add("-DquarkusRegistryClient=true");
+        if (hasValue(additionalUpdateRecipes)) {
+            args.add("-DadditionalUpdateRecipes=" + additionalUpdateRecipes);
+        }
+        args.add("-e");
+        args.add("-N");
+        args.add("-ntp");
+        return args;
+    }
+
+    List<String> buildGradleUpdateCommand(File projectDir) {
+        String cmd = ProcessUtils.resolveGradleCommand(projectDir);
+        return List.of(cmd, "quarkusUpdate");
     }
 
     private boolean isCommandAvailable(String command) {

--- a/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
@@ -136,7 +136,7 @@ public class UpdateTools {
             }
 
             // Step 3b: Run quarkus update --dry-run
-            String dryRunReport = runQuarkusUpdateDryRun(projectDir, additionalUpdateRecipes, buildInfo);
+            String dryRunReport = runQuarkusUpdateDryRun(projectDir, additionalUpdateRecipes, buildInfo, latestVersion);
             if (dryRunReport != null) {
                 report.append("## Automated Migration Preview (`quarkus update --dry-run`)\n\n");
                 report.append(dryRunReport).append("\n");
@@ -308,8 +308,9 @@ public class UpdateTools {
      * Falls back to the Maven or Gradle plugin when the Quarkus CLI is unavailable.
      * Returns null only when no suitable build tool can be found.
      */
-    private String runQuarkusUpdateDryRun(String projectDir, String additionalUpdateRecipes, BuildInfo buildInfo) {
-        List<String> cmd = buildUpdateCommand(projectDir, additionalUpdateRecipes, buildInfo);
+    private String runQuarkusUpdateDryRun(String projectDir, String additionalUpdateRecipes, BuildInfo buildInfo,
+            String latestVersion) {
+        List<String> cmd = buildUpdateCommand(projectDir, additionalUpdateRecipes, buildInfo, latestVersion);
         if (cmd == null) {
             return null;
         }
@@ -361,7 +362,8 @@ public class UpdateTools {
      * Builds the command to run the update dry-run.
      * Prefers the Quarkus CLI, then falls back to Maven/Gradle plugin.
      */
-    List<String> buildUpdateCommand(String projectDir, String additionalUpdateRecipes, BuildInfo buildInfo) {
+    List<String> buildUpdateCommand(String projectDir, String additionalUpdateRecipes, BuildInfo buildInfo,
+            String latestVersion) {
         if (isCommandAvailable("quarkus")) {
             List<String> cmd = new ArrayList<>();
             cmd.add("quarkus");
@@ -375,20 +377,20 @@ public class UpdateTools {
 
         File dir = new File(projectDir);
         if ("Maven".equals(buildInfo.buildTool())) {
-            return buildMavenUpdateCommand(dir, additionalUpdateRecipes, buildInfo.version());
+            return buildMavenUpdateCommand(dir, additionalUpdateRecipes, latestVersion);
         }
         if ("Gradle".equals(buildInfo.buildTool()) || "Gradle Kotlin DSL".equals(buildInfo.buildTool())) {
-            return buildGradleUpdateCommand(dir);
+            return buildGradleUpdateCommand(dir, additionalUpdateRecipes);
         }
 
         return null;
     }
 
-    List<String> buildMavenUpdateCommand(File projectDir, String additionalUpdateRecipes, String version) {
+    List<String> buildMavenUpdateCommand(File projectDir, String additionalUpdateRecipes, String latestVersion) {
         String cmd = ProcessUtils.resolveMavenCommand(projectDir);
         List<String> args = new ArrayList<>();
         args.add(cmd);
-        args.add("io.quarkus.platform:quarkus-maven-plugin:" + version + ":update");
+        args.add("io.quarkus.platform:quarkus-maven-plugin:" + latestVersion + ":update");
         args.add("-DrewriteDryRun=true");
         args.add("-DquarkusRegistryClient=true");
         if (hasValue(additionalUpdateRecipes)) {
@@ -400,9 +402,16 @@ public class UpdateTools {
         return args;
     }
 
-    List<String> buildGradleUpdateCommand(File projectDir) {
+    List<String> buildGradleUpdateCommand(File projectDir, String additionalUpdateRecipes) {
         String cmd = ProcessUtils.resolveGradleCommand(projectDir);
-        return List.of(cmd, "quarkusUpdate");
+        List<String> args = new ArrayList<>();
+        args.add(cmd);
+        args.add("quarkusUpdate");
+        args.add("--rewriteDryRun");
+        if (hasValue(additionalUpdateRecipes)) {
+            args.add("--additionalUpdateRecipes=" + additionalUpdateRecipes);
+        }
+        return args;
     }
 
     private boolean isCommandAvailable(String command) {

--- a/src/test/java/io/quarkus/agent/mcp/UpdateToolsTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/UpdateToolsTest.java
@@ -157,14 +157,33 @@ class UpdateToolsTest {
     }
 
     @Test
-    void buildGradleUpdateCommand() {
+    void buildGradleUpdateCommandIncludesDryRun() {
         UpdateTools tools = new UpdateTools();
 
-        List<String> cmd = tools.buildGradleUpdateCommand(tempDir.toFile());
+        List<String> cmd = tools.buildGradleUpdateCommand(tempDir.toFile(), null);
 
         assertNotNull(cmd);
-        assertEquals(2, cmd.size());
         assertTrue(cmd.contains("quarkusUpdate"));
+        assertTrue(cmd.contains("--rewriteDryRun"));
+    }
+
+    @Test
+    void buildGradleUpdateCommandIncludesAdditionalRecipes() {
+        UpdateTools tools = new UpdateTools();
+
+        List<String> cmd = tools.buildGradleUpdateCommand(tempDir.toFile(), "org.acme:my-recipes:1.0.0");
+
+        assertTrue(cmd.contains("--rewriteDryRun"));
+        assertTrue(cmd.contains("--additionalUpdateRecipes=org.acme:my-recipes:1.0.0"));
+    }
+
+    @Test
+    void buildGradleUpdateCommandOmitsRecipesWhenNull() {
+        UpdateTools tools = new UpdateTools();
+
+        List<String> cmd = tools.buildGradleUpdateCommand(tempDir.toFile(), null);
+
+        assertTrue(cmd.stream().noneMatch(a -> a.startsWith("--additionalUpdateRecipes=")));
     }
 
     @Test
@@ -172,7 +191,7 @@ class UpdateToolsTest {
         UpdateTools tools = new UpdateTools();
         UpdateTools.BuildInfo info = new UpdateTools.BuildInfo("Maven", "maven-", "pom.xml", "3.21.2");
 
-        List<String> cmd = tools.buildUpdateCommand(tempDir.toString(), null, info);
+        List<String> cmd = tools.buildUpdateCommand(tempDir.toString(), null, info, "3.22.0");
 
         assertNotNull(cmd);
         if (ProcessUtils.isCommandAvailable("quarkus")) {
@@ -180,7 +199,7 @@ class UpdateToolsTest {
             assertTrue(cmd.contains("update"));
             assertTrue(cmd.contains("--dry-run"));
         } else {
-            assertEquals("io.quarkus.platform:quarkus-maven-plugin:3.21.2:update", cmd.get(1));
+            assertEquals("io.quarkus.platform:quarkus-maven-plugin:3.22.0:update", cmd.get(1));
         }
     }
 

--- a/src/test/java/io/quarkus/agent/mcp/UpdateToolsTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/UpdateToolsTest.java
@@ -124,6 +124,67 @@ class UpdateToolsTest {
     }
 
     @Test
+    void buildMavenUpdateCommandIncludesRequiredFlags() {
+        UpdateTools tools = new UpdateTools();
+
+        List<String> cmd = tools.buildMavenUpdateCommand(tempDir.toFile(), null, "3.21.2");
+
+        assertNotNull(cmd);
+        assertEquals("io.quarkus.platform:quarkus-maven-plugin:3.21.2:update", cmd.get(1));
+        assertTrue(cmd.contains("-DrewriteDryRun=true"));
+        assertTrue(cmd.contains("-DquarkusRegistryClient=true"));
+        assertTrue(cmd.contains("-e"));
+        assertTrue(cmd.contains("-N"));
+        assertTrue(cmd.contains("-ntp"));
+    }
+
+    @Test
+    void buildMavenUpdateCommandIncludesAdditionalRecipes() {
+        UpdateTools tools = new UpdateTools();
+
+        List<String> cmd = tools.buildMavenUpdateCommand(tempDir.toFile(), "org.acme:my-recipes:1.0.0", "3.21.2");
+
+        assertTrue(cmd.contains("-DadditionalUpdateRecipes=org.acme:my-recipes:1.0.0"));
+    }
+
+    @Test
+    void buildMavenUpdateCommandOmitsRecipesWhenNull() {
+        UpdateTools tools = new UpdateTools();
+
+        List<String> cmd = tools.buildMavenUpdateCommand(tempDir.toFile(), null, "3.21.2");
+
+        assertTrue(cmd.stream().noneMatch(a -> a.startsWith("-DadditionalUpdateRecipes=")));
+    }
+
+    @Test
+    void buildGradleUpdateCommand() {
+        UpdateTools tools = new UpdateTools();
+
+        List<String> cmd = tools.buildGradleUpdateCommand(tempDir.toFile());
+
+        assertNotNull(cmd);
+        assertEquals(2, cmd.size());
+        assertTrue(cmd.contains("quarkusUpdate"));
+    }
+
+    @Test
+    void buildUpdateCommandPrefersQuarkusCli() {
+        UpdateTools tools = new UpdateTools();
+        UpdateTools.BuildInfo info = new UpdateTools.BuildInfo("Maven", "maven-", "pom.xml", "3.21.2");
+
+        List<String> cmd = tools.buildUpdateCommand(tempDir.toString(), null, info);
+
+        assertNotNull(cmd);
+        if (ProcessUtils.isCommandAvailable("quarkus")) {
+            assertEquals("quarkus", cmd.get(0));
+            assertTrue(cmd.contains("update"));
+            assertTrue(cmd.contains("--dry-run"));
+        } else {
+            assertEquals("io.quarkus.platform:quarkus-maven-plugin:3.21.2:update", cmd.get(1));
+        }
+    }
+
+    @Test
     void fetchLatestVersionReturnsVersion() {
         // This test requires network access — it fetches real tags from GitHub
         String latest = UpdateTools.fetchLatestVersion("maven-");


### PR DESCRIPTION
When the `quarkus` CLI is not installed, `runQuarkusUpdateDryRun()` returned `null` and the update report silently skipped the migration preview entirely. This adds fallback support so the equivalent Maven plugin goal (or Gradle task) is used instead.

For Maven projects, the fallback command mirrors what the CLI generates internally:
```
./mvnw io.quarkus.platform:quarkus-maven-plugin:<version>:update \
  -DrewriteDryRun=true -DquarkusRegistryClient=true \
  [-DadditionalUpdateRecipes=...] -e -N -ntp
```

For Gradle projects: `./gradlew quarkusUpdate`

Wrapper resolution (`mvnw`/`gradlew` with git-tracking verification) is extracted into `ProcessUtils` as shared utilities, eliminating duplication between `QuarkusProcessManager` and `UpdateTools`.

Fixes #135