### PR TITLE
Detect Quarkus version inherited from parent POM or Gradle conventions

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.jboss.logging.Logger;
 
@@ -82,10 +83,21 @@ final class ProcessUtils {
     }
 
     static String runAndCapture(ProcessBuilder pb, long timeout, TimeUnit unit) {
-        Process process = null;
+        Process process;
         try {
             process = pb.start();
-            String output = captureOutput(process);
+        } catch (Exception e) {
+            LOG.debugf("Failed to start process: %s", e.getMessage());
+            return null;
+        }
+        try {
+            CompletableFuture<String> outputFuture = CompletableFuture.supplyAsync(() -> {
+                try {
+                    return captureOutput(process);
+                } catch (IOException e) {
+                    return null;
+                }
+            });
             if (!process.waitFor(timeout, unit)) {
                 process.destroyForcibly();
                 LOG.debugf("Process timed out: %s", String.join(" ", pb.command()));
@@ -95,7 +107,7 @@ final class ProcessUtils {
                 LOG.debugf("Process exited with code %d: %s", process.exitValue(), String.join(" ", pb.command()));
                 return null;
             }
-            return output;
+            return outputFuture.get(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return null;
@@ -103,9 +115,7 @@ final class ProcessUtils {
             LOG.debugf("Failed to run process: %s", e.getMessage());
             return null;
         } finally {
-            if (process != null) {
-                process.destroyForcibly();
-            }
+            process.destroyForcibly();
         }
     }
 

--- a/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 import org.jboss.logging.Logger;
 
 final class ProcessUtils {
@@ -77,6 +78,34 @@ final class ProcessUtils {
             LOG.warnf("Could not verify wrapper script '%s' against git: %s. "
                     + "Falling back to system build tool.", wrapper.getAbsolutePath(), e.getMessage());
             return false;
+        }
+    }
+
+    static String runAndCapture(ProcessBuilder pb, long timeout, TimeUnit unit) {
+        Process process = null;
+        try {
+            process = pb.start();
+            String output = captureOutput(process);
+            if (!process.waitFor(timeout, unit)) {
+                process.destroyForcibly();
+                LOG.debugf("Process timed out: %s", String.join(" ", pb.command()));
+                return null;
+            }
+            if (process.exitValue() != 0) {
+                LOG.debugf("Process exited with code %d: %s", process.exitValue(), String.join(" ", pb.command()));
+                return null;
+            }
+            return output;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (Exception e) {
+            LOG.debugf("Failed to run process: %s", e.getMessage());
+            return null;
+        } finally {
+            if (process != null) {
+                process.destroyForcibly();
+            }
         }
     }
 

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusVersionDetector.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusVersionDetector.java
@@ -154,7 +154,7 @@ public final class QuarkusVersionDetector {
                 "-Dexpression=quarkus.platform.version",
                 "-q", "-DforceStdout", "-N")
                 .directory(dir)
-                .redirectErrorStream(true);
+                .redirectError(ProcessBuilder.Redirect.DISCARD);
         String output = ProcessUtils.runAndCapture(pb, 30, TimeUnit.SECONDS);
         return parseMavenEvaluateOutput(output);
     }
@@ -165,7 +165,7 @@ public final class QuarkusVersionDetector {
                 gradleCmd, "properties",
                 "-q", "--property", "quarkusPlatformVersion")
                 .directory(dir)
-                .redirectErrorStream(true);
+                .redirectError(ProcessBuilder.Redirect.DISCARD);
         String output = ProcessUtils.runAndCapture(pb, 30, TimeUnit.SECONDS);
         return parseGradlePropertiesOutput(output);
     }

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusVersionDetector.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusVersionDetector.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jboss.logging.Logger;
@@ -91,6 +92,16 @@ public final class QuarkusVersionDetector {
             }
         }
 
+        // Fallback: shell out to Maven/Gradle to resolve inherited properties
+        if (version == null && pomFile.isFile()) {
+            version = detectFromMavenBuildTool(dir);
+        }
+        if (version == null) {
+            if (new File(dir, "build.gradle").isFile() || new File(dir, "build.gradle.kts").isFile()) {
+                version = detectFromGradleBuildTool(dir);
+            }
+        }
+
         if (version == null) {
             return null;
         }
@@ -132,6 +143,56 @@ public final class QuarkusVersionDetector {
             }
         } catch (IOException e) {
             LOG.debugf("Failed to read gradle.properties: %s", e.getMessage());
+        }
+        return null;
+    }
+
+    private static String detectFromMavenBuildTool(File dir) {
+        String mvnCmd = ProcessUtils.resolveMavenCommand(dir);
+        ProcessBuilder pb = new ProcessBuilder(
+                mvnCmd, "help:evaluate",
+                "-Dexpression=quarkus.platform.version",
+                "-q", "-DforceStdout", "-N")
+                .directory(dir)
+                .redirectErrorStream(true);
+        String output = ProcessUtils.runAndCapture(pb, 30, TimeUnit.SECONDS);
+        return parseMavenEvaluateOutput(output);
+    }
+
+    private static String detectFromGradleBuildTool(File dir) {
+        String gradleCmd = ProcessUtils.resolveGradleCommand(dir);
+        ProcessBuilder pb = new ProcessBuilder(
+                gradleCmd, "properties",
+                "-q", "--property", "quarkusPlatformVersion")
+                .directory(dir)
+                .redirectErrorStream(true);
+        String output = ProcessUtils.runAndCapture(pb, 30, TimeUnit.SECONDS);
+        return parseGradlePropertiesOutput(output);
+    }
+
+    static String parseMavenEvaluateOutput(String output) {
+        if (output == null) {
+            return null;
+        }
+        String trimmed = output.trim();
+        if (trimmed.isEmpty() || trimmed.equalsIgnoreCase("null") || trimmed.contains("${")) {
+            return null;
+        }
+        return trimmed;
+    }
+
+    static String parseGradlePropertiesOutput(String output) {
+        if (output == null || output.isBlank()) {
+            return null;
+        }
+        for (String line : output.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("quarkusPlatformVersion:")) {
+                String value = trimmed.substring("quarkusPlatformVersion:".length()).trim();
+                if (!value.isEmpty()) {
+                    return value;
+                }
+            }
         }
         return null;
     }

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusVersionDetectorTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusVersionDetectorTest.java
@@ -230,4 +230,73 @@ class QuarkusVersionDetectorTest {
 
         assertEquals("3.30.1", QuarkusVersionDetector.detect(tempDir.toString()));
     }
+
+    // --- Maven evaluate output parsing ---
+
+    @Test
+    void parseMavenEvaluateOutputExtractsVersion() {
+        assertEquals("3.35.2", QuarkusVersionDetector.parseMavenEvaluateOutput("3.35.2\n"));
+    }
+
+    @Test
+    void parseMavenEvaluateOutputReturnsNullForNullLiteral() {
+        assertNull(QuarkusVersionDetector.parseMavenEvaluateOutput("null\n"));
+    }
+
+    @Test
+    void parseMavenEvaluateOutputReturnsNullForUnresolved() {
+        assertNull(QuarkusVersionDetector.parseMavenEvaluateOutput("${quarkus.platform.version}"));
+    }
+
+    @Test
+    void parseMavenEvaluateOutputReturnsNullForEmpty() {
+        assertNull(QuarkusVersionDetector.parseMavenEvaluateOutput(""));
+    }
+
+    @Test
+    void parseMavenEvaluateOutputReturnsNullForNull() {
+        assertNull(QuarkusVersionDetector.parseMavenEvaluateOutput(null));
+    }
+
+    @Test
+    void parseMavenEvaluateOutputTrimsWhitespace() {
+        assertEquals("3.35.2", QuarkusVersionDetector.parseMavenEvaluateOutput("  3.35.2  \n"));
+    }
+
+    // --- Gradle properties output parsing ---
+
+    @Test
+    void parseGradlePropertiesOutputExtractsVersion() {
+        assertEquals("3.35.2", QuarkusVersionDetector.parseGradlePropertiesOutput("quarkusPlatformVersion: 3.35.2\n"));
+    }
+
+    @Test
+    void parseGradlePropertiesOutputReturnsNullWhenMissing() {
+        assertNull(QuarkusVersionDetector.parseGradlePropertiesOutput("otherProp: value\n"));
+    }
+
+    @Test
+    void parseGradlePropertiesOutputReturnsNullForEmpty() {
+        assertNull(QuarkusVersionDetector.parseGradlePropertiesOutput(""));
+    }
+
+    @Test
+    void parseGradlePropertiesOutputReturnsNullForNull() {
+        assertNull(QuarkusVersionDetector.parseGradlePropertiesOutput(null));
+    }
+
+    @Test
+    void parseGradlePropertiesOutputHandlesNoSpace() {
+        assertEquals("3.35.2", QuarkusVersionDetector.parseGradlePropertiesOutput("quarkusPlatformVersion:3.35.2"));
+    }
+
+    @Test
+    void parseGradlePropertiesOutputHandlesMultipleLines() {
+        String output = """
+                someOtherProperty: foo
+                quarkusPlatformVersion: 3.30.1
+                anotherProperty: bar
+                """;
+        assertEquals("3.30.1", QuarkusVersionDetector.parseGradlePropertiesOutput(output));
+    }
 }


### PR DESCRIPTION
When the Quarkus version is defined in a parent POM (or via Gradle build conventions) rather than in the project's own `pom.xml` or `gradle.properties`, the regex-based scan in `QuarkusVersionDetector` finds nothing and all version-dependent features (update reports, skill loading, doc search) silently degrade.

This adds a build-tool fallback that runs after the fast regex scan fails:

- **Maven:** `mvn help:evaluate -Dexpression=quarkus.platform.version -q -DforceStdout -N`
- **Gradle:** `./gradlew properties -q --property quarkusPlatformVersion`

Both use wrapper resolution from `ProcessUtils`, run with a 30-second timeout, and are cached after the first call so the latency cost is paid at most once per project. Results still pass through the existing `VALID_VERSION` validation.

A reusable `ProcessUtils.runAndCapture()` helper is added for running a command with a timeout and returning its stdout.

Fixes #137