### PR TITLE
Resolve local Maven repository path from settings.xml

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -162,7 +162,7 @@ public final class SkillReader {
         // Layer 1: Scan extension runtime JARs and compose skills on-the-fly
         String version = QuarkusVersionDetector.detect(projectDir);
         if (version != null) {
-            Path m2Repo = Path.of(System.getProperty("user.home"), ".m2", "repository");
+            Path m2Repo = resolveLocalMavenRepo(projectDir);
 
             // 1a: Scan core extension runtime JARs (io.quarkus) by version
             for (SkillInfo skill : scanCoreExtensionSkills(version, m2Repo, metadataOnly)) {
@@ -1026,6 +1026,51 @@ public final class SkillReader {
     }
 
     /**
+     * Resolves the local Maven repository path by checking settings files in priority order:
+     * <ol>
+     *   <li>{@code .mvn/maven.config} custom settings file</li>
+     *   <li>{@code ~/.m2/settings.xml} — user-level settings</li>
+     *   <li>{@code ${MAVEN_HOME}/conf/settings.xml} — global Maven settings</li>
+     * </ol>
+     * Falls back to {@code ~/.m2/repository} if no {@code <localRepository>} is configured.
+     */
+    static Path resolveLocalMavenRepo(String projectDir) {
+        // 1. Check .mvn/maven.config for a custom settings file
+        if (projectDir != null) {
+            Path customSettings = parseSettingsFromMvnConfig(Path.of(projectDir));
+            if (customSettings != null && Files.isRegularFile(customSettings)) {
+                Path localRepo = parseLocalRepository(customSettings);
+                if (localRepo != null) {
+                    LOG.debugf("Using local repository from .mvn/maven.config settings: %s", localRepo);
+                    return localRepo;
+                }
+            }
+        }
+
+        // 2. Check user-level settings.xml
+        Path userSettings = Path.of(System.getProperty("user.home"), ".m2", "settings.xml");
+        if (Files.isRegularFile(userSettings)) {
+            Path localRepo = parseLocalRepository(userSettings);
+            if (localRepo != null) {
+                LOG.debugf("Using local repository from user settings.xml: %s", localRepo);
+                return localRepo;
+            }
+        }
+
+        // 3. Check global Maven settings.xml
+        Path globalSettings = resolveGlobalSettingsPath();
+        if (globalSettings != null && Files.isRegularFile(globalSettings)) {
+            Path localRepo = parseLocalRepository(globalSettings);
+            if (localRepo != null) {
+                LOG.debugf("Using local repository from global settings.xml: %s", localRepo);
+                return localRepo;
+            }
+        }
+
+        return Path.of(System.getProperty("user.home"), ".m2", "repository");
+    }
+
+    /**
      * Parses {@code .mvn/maven.config} in the project directory for a {@code -s}
      * or {@code --settings} flag pointing to a custom settings file.
      * Returns the resolved path, or null if not found.
@@ -1101,6 +1146,29 @@ public final class SkillReader {
                 if (mirrorOf != null && url != null && mirrorOfMatchesCentral(mirrorOf)) {
                     // Strip trailing slash for consistent path joining
                     return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+                }
+            }
+        } catch (Exception e) {
+            LOG.warnf("Failed to parse settings.xml at %s: %s", settingsFile, e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Parses {@code settings.xml} for a {@code <localRepository>} element.
+     * Returns the configured path, or null if not found or blank.
+     */
+    static Path parseLocalRepository(Path settingsFile) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            Document doc = factory.newDocumentBuilder().parse(settingsFile.toFile());
+
+            NodeList nodes = doc.getElementsByTagName("localRepository");
+            if (nodes.getLength() > 0) {
+                String text = nodes.item(0).getTextContent();
+                if (text != null && !text.trim().isEmpty()) {
+                    return Path.of(text.trim());
                 }
             }
         } catch (Exception e) {

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -23,6 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.function.Function;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
@@ -990,59 +991,37 @@ public final class SkillReader {
      * @param projectDir the project directory (may be null)
      */
     static String resolveMavenRepoBaseUrl(String projectDir) {
-        // 1. Check .mvn/maven.config for a custom settings file
-        if (projectDir != null) {
-            Path customSettings = parseSettingsFromMvnConfig(Path.of(projectDir));
-            if (customSettings != null && Files.isRegularFile(customSettings)) {
-                String mirrorUrl = parseMirrorUrl(customSettings);
-                if (mirrorUrl != null) {
-                    LOG.debugf("Using mirror from .mvn/maven.config settings: %s", mirrorUrl);
-                    return mirrorUrl;
-                }
-            }
-        }
-
-        // 2. Check user-level settings.xml
-        Path userSettings = Path.of(System.getProperty("user.home"), ".m2", "settings.xml");
-        if (Files.isRegularFile(userSettings)) {
-            String mirrorUrl = parseMirrorUrl(userSettings);
-            if (mirrorUrl != null) {
-                LOG.debugf("Using mirror from user settings.xml: %s", mirrorUrl);
-                return mirrorUrl;
-            }
-        }
-
-        // 3. Check global Maven settings.xml
-        Path globalSettings = resolveGlobalSettingsPath();
-        if (globalSettings != null && Files.isRegularFile(globalSettings)) {
-            String mirrorUrl = parseMirrorUrl(globalSettings);
-            if (mirrorUrl != null) {
-                LOG.debugf("Using mirror from global settings.xml: %s", mirrorUrl);
-                return mirrorUrl;
-            }
-        }
-
-        return MAVEN_CENTRAL_BASE;
+        String url = findInSettingsFiles(projectDir, "mirror", SkillReader::parseMirrorUrl);
+        return url != null ? url : MAVEN_CENTRAL_BASE;
     }
 
     /**
-     * Resolves the local Maven repository path by checking settings files in priority order:
+     * Resolves the local Maven repository path by checking settings files in priority order.
+     * Falls back to {@code ~/.m2/repository} if no {@code <localRepository>} is configured.
+     */
+    static Path resolveLocalMavenRepo(String projectDir) {
+        Path repo = findInSettingsFiles(projectDir, "local repository", SkillReader::parseLocalRepository);
+        return repo != null ? repo : Path.of(System.getProperty("user.home"), ".m2", "repository");
+    }
+
+    /**
+     * Walks Maven settings files in priority order, applying the extractor to each:
      * <ol>
      *   <li>{@code .mvn/maven.config} custom settings file</li>
      *   <li>{@code ~/.m2/settings.xml} — user-level settings</li>
      *   <li>{@code ${MAVEN_HOME}/conf/settings.xml} — global Maven settings</li>
      * </ol>
-     * Falls back to {@code ~/.m2/repository} if no {@code <localRepository>} is configured.
+     * Returns the first non-null result, or null if none matched.
      */
-    static Path resolveLocalMavenRepo(String projectDir) {
+    static <T> T findInSettingsFiles(String projectDir, String description, Function<Path, T> extractor) {
         // 1. Check .mvn/maven.config for a custom settings file
         if (projectDir != null) {
             Path customSettings = parseSettingsFromMvnConfig(Path.of(projectDir));
             if (customSettings != null && Files.isRegularFile(customSettings)) {
-                Path localRepo = parseLocalRepository(customSettings);
-                if (localRepo != null) {
-                    LOG.debugf("Using local repository from .mvn/maven.config settings: %s", localRepo);
-                    return localRepo;
+                T result = extractor.apply(customSettings);
+                if (result != null) {
+                    LOG.debugf("Using %s from .mvn/maven.config settings: %s", description, result);
+                    return result;
                 }
             }
         }
@@ -1050,24 +1029,24 @@ public final class SkillReader {
         // 2. Check user-level settings.xml
         Path userSettings = Path.of(System.getProperty("user.home"), ".m2", "settings.xml");
         if (Files.isRegularFile(userSettings)) {
-            Path localRepo = parseLocalRepository(userSettings);
-            if (localRepo != null) {
-                LOG.debugf("Using local repository from user settings.xml: %s", localRepo);
-                return localRepo;
+            T result = extractor.apply(userSettings);
+            if (result != null) {
+                LOG.debugf("Using %s from user settings.xml: %s", description, result);
+                return result;
             }
         }
 
         // 3. Check global Maven settings.xml
         Path globalSettings = resolveGlobalSettingsPath();
         if (globalSettings != null && Files.isRegularFile(globalSettings)) {
-            Path localRepo = parseLocalRepository(globalSettings);
-            if (localRepo != null) {
-                LOG.debugf("Using local repository from global settings.xml: %s", localRepo);
-                return localRepo;
+            T result = extractor.apply(globalSettings);
+            if (result != null) {
+                LOG.debugf("Using %s from global settings.xml: %s", description, result);
+                return result;
             }
         }
 
-        return Path.of(System.getProperty("user.home"), ".m2", "repository");
+        return null;
     }
 
     /**
@@ -1168,7 +1147,8 @@ public final class SkillReader {
             if (nodes.getLength() > 0) {
                 String text = nodes.item(0).getTextContent();
                 if (text != null && !text.trim().isEmpty()) {
-                    return Path.of(text.trim());
+                    String path = text.trim().replace("${user.home}", System.getProperty("user.home"));
+                    return Path.of(path);
                 }
             }
         } catch (Exception e) {

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -374,6 +374,101 @@ class SkillReaderTest {
         assertNull(url);
     }
 
+    // --- parseLocalRepository tests ---
+
+    @Test
+    void parseLocalRepositoryFromSettingsXml() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <localRepository>/custom/maven/repo</localRepository>
+                </settings>
+                """);
+
+        Path result = SkillReader.parseLocalRepository(settingsFile);
+
+        assertEquals(Path.of("/custom/maven/repo"), result);
+    }
+
+    @Test
+    void parseLocalRepositoryReturnsNullWhenNotConfigured() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <profiles></profiles>
+                </settings>
+                """);
+
+        Path result = SkillReader.parseLocalRepository(settingsFile);
+
+        assertNull(result);
+    }
+
+    @Test
+    void parseLocalRepositoryReturnsNullForEmptyElement() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <localRepository>   </localRepository>
+                </settings>
+                """);
+
+        Path result = SkillReader.parseLocalRepository(settingsFile);
+
+        assertNull(result);
+    }
+
+    @Test
+    void parseLocalRepositoryHandlesMalformedXml() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, "this is not xml");
+
+        Path result = SkillReader.parseLocalRepository(settingsFile);
+
+        assertNull(result);
+    }
+
+    // --- resolveLocalMavenRepo tests ---
+
+    @Test
+    void resolveLocalMavenRepoDefaultsToM2Repository() {
+        Path result = SkillReader.resolveLocalMavenRepo(null);
+
+        assertEquals(Path.of(System.getProperty("user.home"), ".m2", "repository"), result);
+    }
+
+    @Test
+    void resolveLocalMavenRepoReadsFromMvnConfig() throws Exception {
+        Path projectDir = tempDir.resolve("project");
+        Files.createDirectories(projectDir.resolve(".mvn"));
+        Files.writeString(projectDir.resolve(".mvn/maven.config"), "-s custom-settings.xml");
+        Files.writeString(projectDir.resolve("custom-settings.xml"), """
+                <settings>
+                    <localRepository>/custom/repo</localRepository>
+                </settings>
+                """);
+
+        Path result = SkillReader.resolveLocalMavenRepo(projectDir.toString());
+
+        assertEquals(Path.of("/custom/repo"), result);
+    }
+
+    @Test
+    void resolveLocalMavenRepoFallsThroughLayers() throws Exception {
+        Path projectDir = tempDir.resolve("project");
+        Files.createDirectories(projectDir.resolve(".mvn"));
+        Files.writeString(projectDir.resolve(".mvn/maven.config"), "-s custom-settings.xml");
+        Files.writeString(projectDir.resolve("custom-settings.xml"), """
+                <settings>
+                    <profiles></profiles>
+                </settings>
+                """);
+
+        Path result = SkillReader.resolveLocalMavenRepo(projectDir.toString());
+
+        assertEquals(Path.of(System.getProperty("user.home"), ".m2", "repository"), result);
+    }
+
     // --- Enhance mode tests ---
 
     @Test

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -419,6 +419,20 @@ class SkillReaderTest {
     }
 
     @Test
+    void parseLocalRepositoryExpandsUserHome() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <localRepository>${user.home}/custom-repo</localRepository>
+                </settings>
+                """);
+
+        Path result = SkillReader.parseLocalRepository(settingsFile);
+
+        assertEquals(Path.of(System.getProperty("user.home"), "custom-repo"), result);
+    }
+
+    @Test
     void parseLocalRepositoryHandlesMalformedXml() throws Exception {
         Path settingsFile = tempDir.resolve("settings.xml");
         Files.writeString(settingsFile, "this is not xml");


### PR DESCRIPTION
The local Maven repository path was hardcoded to `~/.m2/repository`, so users with a custom `<localRepository>` in their `settings.xml` couldn't get non-core extension skills — the JARs simply weren't found.

This adds a `resolveLocalMavenRepo` method that checks for `<localRepository>` in Maven settings files using the same 3-layer lookup already used for mirror resolution:

1. `.mvn/maven.config` custom settings file
2. `~/.m2/settings.xml` (user-level)
3. `${MAVEN_HOME}/conf/settings.xml` (global)

Falls back to `~/.m2/repository` if no `<localRepository>` is configured, preserving current default behavior.

Fixes #139