### PR TITLE
Unfold YAML multi-line string continuations in extension metadata

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -565,6 +565,12 @@ public final class SkillReader {
     static ExtensionMetadata parseExtensionYaml(String yaml) {
         ExtensionMetadata meta = new ExtensionMetadata();
 
+        // Unfold YAML double-quoted string line continuations (\<newline><whitespace>)
+        // and unescape \<space> to a literal space, so multi-line values like
+        // "REST\<LF>  \ Client" become "REST Client"
+        yaml = yaml.replaceAll("\\\\\n\\s*", "");
+        yaml = yaml.replace("\\ ", " ");
+
         Matcher m = YAML_NAME.matcher(yaml);
         if (m.find()) {
             meta.name = m.group(1).trim();

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -1281,6 +1281,24 @@ class SkillReaderTest {
     }
 
     @Test
+    void parseExtensionYamlUnfoldsMultilineDescription() {
+        String yaml = """
+                ---
+                name: "REST Client"
+                description: "Type-safe HTTP client for consuming REST APIs using MicroProfile REST\\
+                  \\ Client"
+                artifact: "io.quarkus:quarkus-rest-client:3.35.2"
+                ...
+                """;
+
+        SkillReader.ExtensionMetadata meta = SkillReader.parseExtensionYaml(yaml);
+
+        assertEquals("REST Client", meta.name);
+        assertEquals("Type-safe HTTP client for consuming REST APIs using MicroProfile REST Client",
+                meta.description);
+    }
+
+    @Test
     void parseExtensionYamlHandlesMinimalContent() {
         SkillReader.ExtensionMetadata meta = SkillReader.parseExtensionYaml("name: Foo\n");
 


### PR DESCRIPTION
Maven's JAR packaging can fold long double-quoted YAML values across multiple lines using continuation syntax (`\<newline><whitespace>\ `). This caused `parseExtensionYaml` to truncate descriptions at the first newline, since the regex stops at `\n`.

For example, the REST Client extension's description:
```yaml
description: "Type-safe HTTP client for consuming REST APIs using MicroProfile REST\
  \ Client"
```
was parsed as just `Type-safe HTTP client for consuming REST APIs using MicroProfile REST\`.

The fix preprocesses the YAML string before regex matching — unfolding `\<newline><whitespace>` continuations and unescaping `\ ` to a literal space. This handles all fields, not just description.

Fixes #140