### PR TITLE
add mavenProfiles parameter to quarkus_start tool

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -182,7 +182,7 @@ public class CreateTools {
 
             // Auto-start the app in dev mode
             try {
-                Integer effectivePort = processManager.start(projectDir, buildTool, httpPort);
+                Integer effectivePort = processManager.start(projectDir, buildTool, httpPort, null);
                 LOG.infof("Auto-started Quarkus app at: %s", projectDir);
                 String portInfo = effectivePort != null ? " (port: " + effectivePort + ")" : "";
                 return ToolResponse.success("Quarkus project created and starting in dev mode at: " + projectDir + portInfo

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -79,7 +79,9 @@ public class CreateTools {
                     + "If not specified, ask the user before creating the project.") boolean noWrapper,
             @ToolArg(description = "HTTP port for the Quarkus application when it auto-starts in dev mode (e.g. 8081). "
                     + "If omitted, defaults to 8080. When 8080 is already in use, "
-                    + "an available port is assigned automatically.", required = false) Integer httpPort) {
+                    + "an available port is assigned automatically.", required = false) Integer httpPort,
+            @ToolArg(description = "Comma-separated Maven profile(s) to activate when the app auto-starts in dev mode "
+                    + "(e.g. 'myprofile' or 'p1,p2'). Ignored for Gradle builds.", required = false) String mavenProfiles) {
         try {
             String resolvedGroupId = (groupId != null && !groupId.isBlank()) ? groupId : "org.acme";
             String resolvedArtifactId = (artifactId != null && !artifactId.isBlank()) ? artifactId : "quarkus-app";
@@ -182,7 +184,7 @@ public class CreateTools {
 
             // Auto-start the app in dev mode
             try {
-                Integer effectivePort = processManager.start(projectDir, buildTool, httpPort, null);
+                Integer effectivePort = processManager.start(projectDir, buildTool, httpPort, mavenProfiles);
                 LOG.infof("Auto-started Quarkus app at: %s", projectDir);
                 String portInfo = effectivePort != null ? " (port: " + effectivePort + ")" : "";
                 return ToolResponse.success("Quarkus project created and starting in dev mode at: " + projectDir + portInfo

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -33,9 +33,11 @@ public class LifecycleTools {
             @ToolArg(description = "Build tool to use: 'maven' or 'gradle' (auto-detected if omitted)", required = false) String buildTool,
             @ToolArg(description = "HTTP port for the Quarkus application (e.g. 8081). "
                     + "If omitted, defaults to 8080. When 8080 is already in use, "
-                    + "an available port is assigned automatically.", required = false) Integer httpPort) {
+                    + "an available port is assigned automatically.", required = false) Integer httpPort,
+            @ToolArg(description = "Comma-separated Maven profile(s) to activate (e.g. 'myprofile' or 'p1,p2'). "
+                    + "Ignored for Gradle builds.", required = false) String mavenProfiles) {
         try {
-            Integer effectivePort = processManager.start(projectDir, buildTool, httpPort);
+            Integer effectivePort = processManager.start(projectDir, buildTool, httpPort, mavenProfiles);
             String message = "Quarkus application starting in dev mode at: " + projectDir;
             if (effectivePort != null) {
                 message += " (port: " + effectivePort + ")";

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -41,6 +41,7 @@ public class QuarkusInstance {
     private final String projectDir;
     private final String buildTool;
     private final Integer requestedHttpPort;
+    private final String mavenProfiles;
     private final Process process;
     private final LinkedList<String> logBuffer = new LinkedList<>();
     private final AtomicReference<Status> status = new AtomicReference<>(Status.STARTING);
@@ -48,11 +49,12 @@ public class QuarkusInstance {
     private volatile PrintWriter logWriter;
     private volatile Path logFile;
 
-    public QuarkusInstance(String projectDir, String buildTool, Integer requestedHttpPort, Process process,
-            ExecutorService executor) {
+    public QuarkusInstance(String projectDir, String buildTool, Integer requestedHttpPort, String mavenProfiles,
+            Process process, ExecutorService executor) {
         this.projectDir = projectDir;
         this.buildTool = buildTool;
         this.requestedHttpPort = requestedHttpPort;
+        this.mavenProfiles = mavenProfiles;
         this.process = process;
 
         executor.submit(() -> captureStream(process.getInputStream()));
@@ -232,6 +234,10 @@ public class QuarkusInstance {
 
     public Integer getRequestedHttpPort() {
         return requestedHttpPort;
+    }
+
+    public String getMavenProfiles() {
+        return mavenProfiles;
     }
 
     public Path getLogFile() {

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -7,7 +7,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -43,7 +45,7 @@ public class QuarkusProcessManager {
     static final int DEFAULT_HTTP_PORT = 8080;
     private static final int MAX_PORT_SCAN = 100;
 
-    public synchronized Integer start(String projectDir, String buildTool, Integer httpPort) {
+    public synchronized Integer start(String projectDir, String buildTool, Integer httpPort, String mavenProfiles) {
         if (buildTool != null && !VALID_BUILD_TOOLS.contains(buildTool.toLowerCase())) {
             throw new IllegalArgumentException(
                     "Invalid build tool: '" + buildTool + "'. Must be 'maven' or 'gradle'.");
@@ -71,11 +73,11 @@ public class QuarkusProcessManager {
         }
 
         String detectedBuildTool = buildTool != null ? buildTool : detectBuildTool(normalizedDir);
-        ProcessBuilder pb = createProcessBuilder(normalizedDir, detectedBuildTool, effectivePort);
+        ProcessBuilder pb = createProcessBuilder(normalizedDir, detectedBuildTool, effectivePort, mavenProfiles);
 
         try {
             Process process = pb.start();
-            QuarkusInstance instance = new QuarkusInstance(normalizedDir, detectedBuildTool, httpPort, process, executor);
+            QuarkusInstance instance = new QuarkusInstance(normalizedDir, detectedBuildTool, httpPort, mavenProfiles, process, executor);
             instances.put(normalizedDir, instance);
             if (appLogEnabled.orElse(false)) {
                 instance.enableFileLogging(computeLogFile(normalizedDir));
@@ -109,8 +111,9 @@ public class QuarkusProcessManager {
         if (!instance.isAlive()) {
             String savedBuildTool = instance.getBuildTool();
             Integer savedHttpPort = instance.getRequestedHttpPort();
+            String savedMavenProfiles = instance.getMavenProfiles();
             instances.remove(normalizedDir);
-            start(normalizedDir, savedBuildTool, savedHttpPort);
+            start(normalizedDir, savedBuildTool, savedHttpPort, savedMavenProfiles);
             LOG.infof("Re-started dead Quarkus instance at: %s", normalizedDir);
         } else {
             instance.restart();
@@ -165,7 +168,7 @@ public class QuarkusProcessManager {
                 "Cannot detect build tool at: " + projectDir + ". No pom.xml or build.gradle found.");
     }
 
-    private ProcessBuilder createProcessBuilder(String projectDir, String buildTool, Integer httpPort) {
+    private ProcessBuilder createProcessBuilder(String projectDir, String buildTool, Integer httpPort, String mavenProfiles) {
         File dir = new File(projectDir);
         if (!dir.isDirectory()) {
             throw new IllegalArgumentException("Not a directory: " + projectDir);
@@ -175,7 +178,7 @@ public class QuarkusProcessManager {
         if ("gradle".equalsIgnoreCase(buildTool)) {
             pb = createGradleProcessBuilder(dir);
         } else {
-            pb = createMavenProcessBuilder(dir);
+            pb = createMavenProcessBuilder(dir, mavenProfiles);
         }
 
         if (httpPort != null) {
@@ -188,10 +191,14 @@ public class QuarkusProcessManager {
         return pb;
     }
 
-    private ProcessBuilder createMavenProcessBuilder(File projectDir) {
+    private ProcessBuilder createMavenProcessBuilder(File projectDir, String mavenProfiles) {
         String cmd = mvnCmd.orElseGet(() -> ProcessUtils.resolveMavenCommand(projectDir));
-        return new ProcessBuilder(cmd, "quarkus:dev", "-Dquarkus.console.basic=true",
-                "-Dquarkus.dev-mcp.enabled=true");
+        var command = new ArrayList<>(List.of(cmd, "quarkus:dev",
+                "-Dquarkus.console.basic=true", "-Dquarkus.dev-mcp.enabled=true"));
+        if (mavenProfiles != null && !mavenProfiles.isBlank()) {
+            command.add("-P" + mavenProfiles.trim());
+        }
+        return new ProcessBuilder(command);
     }
 
     private ProcessBuilder createGradleProcessBuilder(File projectDir) {

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -24,7 +24,7 @@ class QuarkusInstanceTest {
     @Test
     void initialStatusIsStarting() throws Exception {
         process = new ProcessBuilder("sleep", "10").start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         assertEquals(QuarkusInstance.Status.STARTING, instance.getStatus());
         assertEquals(-1, instance.getHttpPort());
@@ -37,7 +37,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://localhost:8080' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         // Wait for the stream reader to process the output
         Thread.sleep(500);
@@ -51,7 +51,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: https://localhost:8443' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         Thread.sleep(500);
 
@@ -63,7 +63,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'installed features: [cdi, rest]' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         Thread.sleep(500);
 
@@ -76,7 +76,7 @@ class QuarkusInstanceTest {
     void detectsCrashOnProcessExit() throws Exception {
         process = new ProcessBuilder("bash", "-c", "echo 'starting' && exit 1")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         // Wait for process to exit and monitor to detect it
         Thread.sleep(500);
@@ -88,7 +88,7 @@ class QuarkusInstanceTest {
     @Test
     void stopSetsStatusToStopped() throws Exception {
         process = new ProcessBuilder("sleep", "30").start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         instance.stop();
 
@@ -102,7 +102,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "for i in $(seq 1 10); do echo \"line $i\"; done && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         Thread.sleep(500);
 
@@ -115,7 +115,7 @@ class QuarkusInstanceTest {
     @Test
     void getRecentLogsReturnsEmptyForNoLogs() throws Exception {
         process = new ProcessBuilder("sleep", "10").start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         assertEquals("", instance.getRecentLogs(50));
     }
@@ -125,7 +125,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://0.0.0.0:9090' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         Thread.sleep(500);
 
@@ -137,7 +137,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: not-a-url' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         Thread.sleep(500);
 
@@ -149,7 +149,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://localhost:8080 (some extra text)' && sleep 5")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         Thread.sleep(500);
 
@@ -161,7 +161,7 @@ class QuarkusInstanceTest {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://localhost:8080' && cat")
                 .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         Thread.sleep(500);
         assertEquals(8080, instance.getHttpPort());
@@ -176,7 +176,7 @@ class QuarkusInstanceTest {
     @Test
     void restartThrowsIfProcessDead() throws Exception {
         process = new ProcessBuilder("bash", "-c", "exit 0").start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, process, executor);
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
 
         Thread.sleep(500);
 

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -33,17 +33,17 @@ class QuarkusProcessManagerTest {
 
     @Test
     void startThrowsForNullProjectDir() {
-        assertThrows(IllegalArgumentException.class, () -> manager.start(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> manager.start(null, null, null, null));
     }
 
     @Test
     void startThrowsForEmptyProjectDir() {
-        assertThrows(IllegalArgumentException.class, () -> manager.start("", null, null));
+        assertThrows(IllegalArgumentException.class, () -> manager.start("", null, null, null));
     }
 
     @Test
     void startThrowsForBlankProjectDir() {
-        assertThrows(IllegalArgumentException.class, () -> manager.start("   ", null, null));
+        assertThrows(IllegalArgumentException.class, () -> manager.start("   ", null, null, null));
     }
 
     @Test
@@ -76,7 +76,7 @@ class QuarkusProcessManagerTest {
     void throwsWhenNoBuildToolDetected() {
         // tempDir has no pom.xml or build.gradle
         assertThrows(IllegalArgumentException.class,
-                () -> manager.start(tempDir.toString(), null, null));
+                () -> manager.start(tempDir.toString(), null, null, null));
     }
 
     @Test
@@ -85,25 +85,25 @@ class QuarkusProcessManagerTest {
         Files.writeString(file, "not a directory");
 
         assertThrows(IllegalArgumentException.class,
-                () -> manager.start(file.toString(), "maven", null));
+                () -> manager.start(file.toString(), "maven", null, null));
     }
 
     @Test
     void startThrowsForPortZero() {
         assertThrows(IllegalArgumentException.class,
-                () -> manager.start(tempDir.toString(), "maven", 0));
+                () -> manager.start(tempDir.toString(), "maven", 0, null));
     }
 
     @Test
     void startThrowsForNegativePort() {
         assertThrows(IllegalArgumentException.class,
-                () -> manager.start(tempDir.toString(), "maven", -1));
+                () -> manager.start(tempDir.toString(), "maven", -1, null));
     }
 
     @Test
     void startThrowsForPortAbove65535() {
         assertThrows(IllegalArgumentException.class,
-                () -> manager.start(tempDir.toString(), "maven", 70000));
+                () -> manager.start(tempDir.toString(), "maven", 70000, null));
     }
 
     @Test
@@ -111,9 +111,9 @@ class QuarkusProcessManagerTest {
         Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
         initOptionalFields();
         Method m = QuarkusProcessManager.class.getDeclaredMethod(
-                "createProcessBuilder", String.class, String.class, Integer.class);
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class);
         m.setAccessible(true);
-        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", 9090);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", 9090, (String) null);
         assertTrue(pb.command().contains("-Dquarkus.http.port=9090"));
         assertTrue(pb.command().contains("-Dquarkus.http.test-port=0"));
     }
@@ -123,11 +123,55 @@ class QuarkusProcessManagerTest {
         Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
         initOptionalFields();
         Method m = QuarkusProcessManager.class.getDeclaredMethod(
-                "createProcessBuilder", String.class, String.class, Integer.class);
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class);
         m.setAccessible(true);
-        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, (String) null);
         assertFalse(pb.command().stream().anyMatch(arg -> arg.startsWith("-Dquarkus.http.port=")));
         assertFalse(pb.command().stream().anyMatch(arg -> arg.startsWith("-Dquarkus.http.test-port=")));
+    }
+
+    @Test
+    void processBuilderIncludesMavenProfile() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields();
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, "myprofile");
+        assertTrue(pb.command().contains("-Pmyprofile"));
+    }
+
+    @Test
+    void processBuilderIncludesMultipleMavenProfiles() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields();
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, "p1,p2");
+        assertTrue(pb.command().contains("-Pp1,p2"));
+    }
+
+    @Test
+    void processBuilderOmitsProfileArgWhenNull() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields();
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, (String) null);
+        assertFalse(pb.command().stream().anyMatch(arg -> arg.startsWith("-P")));
+    }
+
+    @Test
+    void processBuilderOmitsProfileArgWhenBlank() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields();
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, "   ");
+        assertFalse(pb.command().stream().anyMatch(arg -> arg.startsWith("-P")));
     }
 
     private void initOptionalFields() throws Exception {


### PR DESCRIPTION
I often use a trick to have some source code available in the dev mode, but not in the jars. A demo is [here](https://github.com/t1/quarkus-compose-devservice-demo).

But this requires the dev mode to be started with a maven profile. I'd like to use this pattern with the MCP, too.

WDYT?