### PR TITLE
Fall back to legacy image for Quarkus 3.36.0 and load non-core extension docs for all containers

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
@@ -28,6 +28,7 @@ public class ContainerManager {
 
     private static final Logger LOG = Logger.getLogger(ContainerManager.class);
     static final int RAG_SQL_MIN_MINOR = 36;
+    static final int RAG_SQL_MIN_PATCH_AT_36 = 1;
 
     @ConfigProperty(name = "agent-mcp.doc-search.image", defaultValue = "pgvector/pgvector:pg17")
     String image;
@@ -122,6 +123,7 @@ public class ContainerManager {
             }
         } else {
             startLegacyContainer(versionKey, quarkusVersion);
+            loadNonCoreRagData(versionKey, quarkusVersion, projectDir);
         }
     }
 
@@ -137,13 +139,10 @@ public class ContainerManager {
     /**
      * Loads any new RAG SQL fragments into an already-running container.
      * Called after extensions are added to a project to pick up their docs.
-     * No-op for legacy containers (data is baked into the image).
+     * For legacy containers, only non-core extension docs are loaded (core docs are baked in).
      */
     public void loadIncrementalRagData(String quarkusVersion, String projectDir) {
         String versionKey = quarkusVersion != null ? quarkusVersion : "default";
-        if (!ragSqlVersions.contains(versionKey)) {
-            return;
-        }
         GenericContainer<?> container = containers.get(versionKey);
         if (container == null || !container.isRunning()) {
             LOG.debugf("No running container for version %s — skipping incremental RAG load", versionKey);
@@ -205,7 +204,14 @@ public class ContainerManager {
             String[] parts = version.split("[.\\-]");
             int major = Integer.parseInt(parts[0]);
             int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
-            return major > 3 || (major == 3 && minor >= RAG_SQL_MIN_MINOR);
+            if (major > 3 || (major == 3 && minor > RAG_SQL_MIN_MINOR)) {
+                return true;
+            }
+            if (major == 3 && minor == RAG_SQL_MIN_MINOR) {
+                int patch = parts.length > 2 ? Integer.parseInt(parts[2]) : 0;
+                return patch >= RAG_SQL_MIN_PATCH_AT_36;
+            }
+            return false;
         } catch (NumberFormatException e) {
             return false;
         }
@@ -287,6 +293,24 @@ public class ContainerManager {
                 quarkusVersion, projectDir,
                 container.getHost(), container.getMappedPort(5432),
                 pgDatabase, pgUser, pgPassword);
+    }
+
+    private void loadNonCoreRagData(String versionKey, String quarkusVersion, String projectDir) {
+        if (projectDir == null) {
+            return;
+        }
+        GenericContainer<?> container = containers.get(versionKey);
+        if (container == null || !container.isRunning()) {
+            return;
+        }
+        try {
+            ragSqlLoader.ensureLoaded(
+                    quarkusVersion, projectDir,
+                    container.getHost(), container.getMappedPort(5432),
+                    pgDatabase, pgUser, pgPassword);
+        } catch (Exception e) {
+            LOG.warnf("Failed to load non-core extension docs: %s", e.getMessage());
+        }
     }
 
     private GenericContainer<?> getContainer(String quarkusVersion) {

--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -82,6 +82,9 @@ public class RagSqlLoader {
     public void ensureLoaded(String quarkusVersion, String projectDir,
             String host, int port, String database, String user, String password) {
         String versionKey = quarkusVersion != null ? quarkusVersion : "default";
+        String jdbcUrl = "jdbc:postgresql://" + host + ":" + port + "/" + database;
+
+        ensureSchema(jdbcUrl, user, password);
 
         String resolvedVersion = quarkusVersion != null ? quarkusVersion : detectLatestInstalledVersion();
         if (resolvedVersion == null) {
@@ -94,8 +97,6 @@ public class RagSqlLoader {
             LOG.infof("No RAG SQL fragments found for Quarkus %s", resolvedVersion);
             return;
         }
-
-        String jdbcUrl = "jdbc:postgresql://" + host + ":" + port + "/" + database;
 
         Set<String> alreadyLoaded = loadedSources.computeIfAbsent(versionKey,
                 k -> ConcurrentHashMap.newKeySet());
@@ -314,6 +315,16 @@ public class RagSqlLoader {
             return m.group(1);
         }
         return fallbackSource;
+    }
+
+    private void ensureSchema(String jdbcUrl, String user, String password) {
+        try (Connection conn = DriverManager.getConnection(jdbcUrl, user, password);
+                Statement stmt = conn.createStatement()) {
+            stmt.execute(CREATE_EXTENSION_DDL);
+            stmt.execute(CREATE_TABLE_DDL);
+        } catch (SQLException e) {
+            LOG.warnf("Failed to create RAG schema: %s", e.getMessage());
+        }
     }
 
     private Set<String> queryExistingSources(String jdbcUrl, String user, String password) {

--- a/src/test/java/io/quarkus/agent/mcp/ContainerManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/ContainerManagerTest.java
@@ -22,8 +22,8 @@ class ContainerManagerTest {
 
     @Test
     void supportsRagSqlForModernVersions() {
-        assertTrue(ContainerManager.supportsRagSql("3.36.0"));
         assertTrue(ContainerManager.supportsRagSql("3.36.1"));
+        assertTrue(ContainerManager.supportsRagSql("3.36.2"));
         assertTrue(ContainerManager.supportsRagSql("3.37.0"));
         assertTrue(ContainerManager.supportsRagSql("3.40.0"));
         assertTrue(ContainerManager.supportsRagSql("4.0.0"));
@@ -31,6 +31,7 @@ class ContainerManagerTest {
 
     @Test
     void supportsRagSqlReturnsFalseForOlderVersions() {
+        assertFalse(ContainerManager.supportsRagSql("3.36.0"));
         assertFalse(ContainerManager.supportsRagSql("3.35.0"));
         assertFalse(ContainerManager.supportsRagSql("3.35.2"));
         assertFalse(ContainerManager.supportsRagSql("3.21.0"));
@@ -40,8 +41,9 @@ class ContainerManagerTest {
 
     @Test
     void supportsRagSqlHandlesQualifiedVersions() {
-        assertTrue(ContainerManager.supportsRagSql("3.36.0.Final"));
-        assertTrue(ContainerManager.supportsRagSql("3.36.0.CR1"));
+        assertFalse(ContainerManager.supportsRagSql("3.36.0.Final"));
+        assertFalse(ContainerManager.supportsRagSql("3.36.0.CR1"));
+        assertTrue(ContainerManager.supportsRagSql("3.36.1.Final"));
         assertFalse(ContainerManager.supportsRagSql("3.35.0.Final"));
     }
 


### PR DESCRIPTION
The aggregated `quarkus-documentation-core-rag:3.36.0` artifact was published empty because the RAG generation enablement PR (quarkusio/quarkus#54270) missed the 3.36 branch cutoff. Users on 3.36.0 got an empty documentation database and couldn't search any docs.

This PR:

- Excludes 3.36.0 from the RAG SQL path so it falls back to the pre-built Docker image with baked-in documentation. 3.36.1+ will use the new path once the RAG artifact ships with actual data.
- Creates the `rag_documents` schema unconditionally in `ensureLoaded()` so queries never fail with "relation does not exist" even when no SQL fragments are found.
- Loads non-core extension docs (Quarkiverse, third-party) into legacy containers too, so users get documentation for all their extensions regardless of which container path is used.
- Enables incremental RAG loading for all container types so newly added non-core extensions are picked up on legacy containers as well.

Supersedes #164.