### PR TITLE
Strip ANSI escape codes before parsing the HTTP port

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -17,6 +17,7 @@ import java.util.LinkedList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
@@ -37,6 +38,10 @@ public class QuarkusInstance {
     }
 
     static final int MAX_LOG_LINES = 500;
+
+    // Quarkus dev output may be wrapped in ANSI escape codes (Gradle forces color
+    // on the forked dev JVM), which must be stripped before URI parsing.
+    private static final Pattern ANSI = Pattern.compile("\\u001B\\[[0-9;]*m");
 
     private final String projectDir;
     private final String buildTool;
@@ -100,13 +105,14 @@ public class QuarkusInstance {
     }
 
     private void parsePort(String line) {
-        int idx = line.indexOf("http://");
+        String clean = ANSI.matcher(line).replaceAll("");
+        int idx = clean.indexOf("http://");
         if (idx < 0) {
-            idx = line.indexOf("https://");
+            idx = clean.indexOf("https://");
         }
         if (idx >= 0) {
             try {
-                String url = line.substring(idx).trim();
+                String url = clean.substring(idx).trim();
                 int spaceIdx = url.indexOf(' ');
                 if (spaceIdx > 0) {
                     url = url.substring(0, spaceIdx);

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -47,6 +47,22 @@ class QuarkusInstanceTest {
     }
 
     @Test
+    void detectsPortFromAnsiColoredListeningOnLog() throws Exception {
+        // Gradle's dev JVM forces ANSI color, so the port is followed by escape
+        // sequences with no space: "http://localhost:8080[38;5;231m[39m".
+        // printf emits the real ESC bytes the MCP captures from the child process.
+        process = new ProcessBuilder("bash", "-c",
+                "printf 'Listening on: http://localhost:8080\\033[38;5;231m\\033[39m\\n' && sleep 5")
+                .start();
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
+
+        Thread.sleep(500);
+
+        assertEquals(8080, instance.getHttpPort());
+        assertEquals(QuarkusInstance.Status.RUNNING, instance.getStatus());
+    }
+
+    @Test
     void detectsPortFromHttpsUrl() throws Exception {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: https://localhost:8443' && sleep 5")


### PR DESCRIPTION
Gradle launches the forked dev JVM with -Dio.quarkus.force-color-support=true, so the Listening on: line arrives with ANSI escape sequences attached directly to the URL — no space between the port number and the escape bytes. URI.create() throws on the first escape character, leaving httpPort at -1 forever. Since isStartedLine uses a plain .contains() check that survives ANSI, the status correctly flips to RUNNING while the port stays undetected — which is exactly the asymmetry users see: quarkus_status returns running, but quarkus_callTool and quarkus_searchTools fail with "Could not detect HTTP port".

The fix strips ANSI codes inside parsePort() only, before locating the URL. The log ring buffer and file logging are untouched, so captured logs keep their color.

A regression test (detectsPortFromAnsiColoredListeningOnLog) was added to QuarkusInstanceTest — it feeds a log line with real ESC bytes and asserts the port is extracted correctly. The test fails on the current code and passes after this fix.