### PR TITLE
Guide LLMs to retry searchDocs with projectDir when results are empty

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -121,7 +121,9 @@ public class DocSearchTools {
                     + "'REST client configuration', 'native image build'.") String query,
             @ToolArg(description = "Maximum number of documentation chunks to return (default: 4).", required = false) Integer maxResults,
             @ToolArg(description = "Absolute path to the Quarkus project directory. "
-                    + "If provided, documentation matching the project's Quarkus version is used.", required = false) String projectDir) {
+                    + "Strongly recommended -- documentation is loaded from the project's extension "
+                    + "dependencies, so searches without projectDir may return no results. "
+                    + "Also selects documentation matching the project's Quarkus version.", required = false) String projectDir) {
         try {
             if (query == null || query.isBlank()) {
                 return ToolResponse.error("Search query must not be empty.");
@@ -191,7 +193,17 @@ public class DocSearchTools {
             }
 
             if (results.isEmpty()) {
-                return ToolResponse.success("No documentation found matching: " + query);
+                StringBuilder msg = new StringBuilder("No documentation found matching: " + query);
+                if (projectDir == null || projectDir.isBlank()) {
+                    msg.append("\n\nHint: You did not provide a projectDir. Documentation is loaded from "
+                            + "the project's extension dependencies, so results are significantly more "
+                            + "accurate when projectDir is set. Retry with the projectDir parameter.");
+                } else {
+                    msg.append("\n\nHint: Try rephrasing your query with different or simpler keywords. "
+                            + "Documentation is loaded from extension JARs in the project -- if the "
+                            + "relevant extension is not a project dependency, its docs won't appear here.");
+                }
+                return ToolResponse.success(msg.toString());
             }
 
             String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(results);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,13 +9,13 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   WORKFLOW for new projects:\n\
   1. quarkus_create -- create and auto-start a Quarkus app (NEVER use 'mvn' or CLI manually)\n\
   2. quarkus_skills -- MUST call before writing ANY code or tests to learn correct patterns for each extension\n\
-  3. quarkus_searchDocs -- search Quarkus documentation for APIs, config, and best practices\n\
+  3. quarkus_searchDocs -- search Quarkus documentation for APIs, config, and best practices. ALWAYS pass projectDir -- docs are loaded from extension JARs, so searches without it often return nothing. If results are empty, retry with simpler or rephrased keywords before falling back to other sources\n\
   4. quarkus_searchTools -- discover Dev MCP tools on the running app (testing, config, extensions)\n\
   5. quarkus_callTool -- invoke discovered tools (run tests, add extensions, update config)\n\n\
   WORKFLOW for existing projects:\n\
   1. quarkus_start -- start the app in dev mode if not running\n\
   2. quarkus_skills -- MUST call before writing code to learn extension-specific patterns. Query for 'quarkus-update' to check if the project version is up-to-date\n\
-  3. quarkus_searchDocs -- look up Quarkus APIs and configuration\n\
+  3. quarkus_searchDocs -- look up Quarkus APIs and configuration. ALWAYS pass projectDir\n\
   4. Write code following the patterns from skills and docs\n\
   5. quarkus_searchTools + quarkus_callTool -- run tests, manage extensions\n\n\
   TESTING:\n\
@@ -44,7 +44,7 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   - Call quarkus_app_log with action 'disable' and projectDir to stop file logging (the log file is preserved)\n\n\
   KEY RULES:\n\
   - NEVER skip quarkus_skills -- it contains critical patterns that prevent common mistakes\n\
-  - NEVER use web search or generic documentation tools (Context7, etc.) for Quarkus questions -- always use quarkus_searchDocs first, even without a project directory\n\
+  - NEVER use web search or generic documentation tools (Context7, etc.) for Quarkus questions -- always use quarkus_searchDocs first, and ALWAYS pass projectDir when a project exists. If searchDocs returns no results, retry with simpler keywords before giving up\n\
   - NEVER run build commands manually -- use quarkus_start, quarkus_callTool for testing\n\
   - NEVER run 'mvn clean' or 'gradle clean' while dev mode is running -- it breaks the test runner\n\
   - ALWAYS write tests for every feature\n\


### PR DESCRIPTION
Documentation is loaded from extension JARs in the project, so `quarkus_searchDocs` calls without `projectDir` often return nothing. When this happened, the tool returned a generic "No documentation found" message with no guidance, causing LLMs to silently move on and write code without consulting docs.

This was observed in practice: during a session building a vinyl collection app, all `searchDocs` calls were made before the project existed (no `projectDir` to pass) and returned empty — the LLM never retried after the project was created.

**Changes:**

- **Empty-result response** (`DocSearchTools.java`): now includes an actionable hint. If `projectDir` was omitted, it tells the LLM to retry with it. If `projectDir` was provided, it suggests rephrasing the query and explains the extension JAR dependency.

- **`projectDir` parameter description** (`DocSearchTools.java`): changed from "If provided, documentation matching the project's Quarkus version is used" to "Strongly recommended — searches without projectDir may return no results", making it clear that omitting it degrades results rather than just losing version matching.

- **Server instructions** (`application.properties`): both workflow sections and KEY RULES now say "ALWAYS pass projectDir" and "retry with simpler keywords if empty".