### PR TITLE
Reduce MCP context overhead to cut agent cost and turn count

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/AgentLogTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/AgentLogTools.java
@@ -34,7 +34,9 @@ public class AgentLogTools {
         }
     }
 
-    @Tool(name = "quarkus_agent_log", description = "Manage the Quarkus Agent MCP server's own log file. "
+    @Tool(name = "quarkus_agent_log", description = "Read the Quarkus Agent MCP server's own log file. "
+            + "In stdio mode, server logs are not visible because stdout/stderr are used by the protocol. "
+            + "File logging can be enabled permanently via AGENT_MCP_LOG_ENABLED=true. "
             + "Actions: 'enable' starts file logging to ~/.quarkus/agent-mcp/agent-mcp.log, "
             + "'disable' stops file logging (preserves the file), "
             + "'read' (default) returns the most recent lines from the log file.",

--- a/src/main/java/io/quarkus/agent/mcp/AppLogTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/AppLogTools.java
@@ -19,6 +19,7 @@ public class AppLogTools {
     QuarkusProcessManager processManager;
 
     @Tool(name = "quarkus_app_log", description = "Manage file logging for a managed Quarkus application. "
+            + "Can be enabled permanently via AGENT_MCP_APP_LOG_ENABLED=true. "
             + "Actions: 'enable' starts capturing stdout/stderr to ~/.quarkus/apps/<project>/quarkus-dev.log, "
             + "'disable' stops file logging (preserves the file), "
             + "'read' (default) returns the most recent lines from the log file.",

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -106,7 +106,9 @@ public class CreateTools {
 
             File outDir = new File(outputDir);
             if (!outDir.isDirectory()) {
-                return ToolResponse.error("Output directory does not exist: " + outputDir);
+                if (!outDir.mkdirs()) {
+                    return ToolResponse.error("Failed to create output directory: " + outputDir);
+                }
             }
 
             boolean createInPlace = shouldCreateInPlace(createInCurrentDir, outDir, resolvedArtifactId);
@@ -182,34 +184,51 @@ public class CreateTools {
             // Generate .mcp.json so tools like Claude Code auto-discover quarkus-agent-mcp
             generateMcpConfig(projectDir);
 
-            // Auto-start the app in dev mode
+            // Auto-start the app in dev mode and wait for it to be ready
             try {
                 Integer effectivePort = processManager.start(projectDir, buildTool, httpPort, mavenProfiles);
                 LOG.infof("Auto-started Quarkus app at: %s", projectDir);
-                String portInfo = effectivePort != null ? " (port: " + effectivePort + ")" : "";
-                return ToolResponse.success("Quarkus project created and starting in dev mode at: " + projectDir + portInfo
-                        + ContainerRuntimeChecker.containerWarning(projectDir)
-                        + "\n\nNEXT STEPS (follow this order strictly):"
-                        + "\n1. STOP -- do NOT write any code yet. For each capability the user requested, "
-                        + "search for Quarkus extensions that provide it using quarkus_searchDocs and quarkus_searchTools query='extension'. "
-                        + "NEVER roll your own solution when an extension exists."
-                        + "\n2. PRESENT OPTIONS -- use search results from step 1 to list ALL matching extensions "
-                        + "to the user with a recommended default marked. "
-                        + "Wait for the user to choose before proceeding. Never silently pick one."
-                        + "\n3. LOAD SKILLS -- call quarkus_skills for each chosen extension BEFORE writing any code. "
-                        + "This is mandatory, not optional."
-                        + "\n4. Add chosen extensions via quarkus_searchTools query='extension' -> quarkus_callTool."
-                        + "\n5. Use quarkus_searchDocs to look up additional Quarkus APIs and best practices."
-                        + "\n6. Write your code AND tests. Always include tests for every feature."
-                        + "\n7. Run tests with quarkus_callTool: use 'devui-testing_runTests' to run all tests, "
-                        + "'devui-testing_runAffectedTests' to run only tests affected by your changes, "
-                        + "or 'devui-testing_runTest' with arguments {\"className\":\"com.example.MyTest\"} for a specific test."
-                        + "\n8. After code changes, trigger a reload via quarkus_callTool with toolName 'devui-logstream_forceRestart'. Do NOT restart the app manually."
-                        + "\n   IMPORTANT: After pom.xml/build.gradle changes (adding dependencies or extensions), you MUST do a full quarkus_stop + quarkus_start. forceRestart only recompiles source -- it does NOT re-resolve dependencies."
-                        + "\n9. Update README.md with: app description, features, endpoints, how to run, and links to Quarkus guides."
-                        + "\n10. After core features work, suggest to the user: security, observability, health checks, OpenAPI."
-                        + "\n\nWARNING: NEVER run 'mvn clean' or 'gradle clean' while dev mode is running -- it deletes target/test-classes and breaks the test runner. "
-                        + "If the test runner gets stuck returning 'Tests already in progress', do a full quarkus_stop + quarkus_start cycle to reset it.");
+
+                // Block until the app is ready so the agent doesn't need to poll
+                QuarkusInstance instance = processManager.getInstance(projectDir);
+                if (instance != null && instance.getStatus() == QuarkusInstance.Status.STARTING) {
+                    long deadline = System.currentTimeMillis() + 120_000;
+                    while (instance.getStatus() == QuarkusInstance.Status.STARTING
+                            && System.currentTimeMillis() < deadline) {
+                        try {
+                            Thread.sleep(2_000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            break;
+                        }
+                    }
+                }
+
+                StringBuilder response = new StringBuilder();
+                if (instance != null && instance.getStatus() == QuarkusInstance.Status.RUNNING) {
+                    response.append("Quarkus project created and running at: ").append(projectDir)
+                            .append(" (port: ").append(instance.getHttpPort()).append(")");
+                } else {
+                    String portInfo = effectivePort != null ? " (port: " + effectivePort + ")" : "";
+                    response.append("Quarkus project created and starting at: ").append(projectDir).append(portInfo);
+                }
+                response.append(ContainerRuntimeChecker.containerWarning(projectDir));
+
+                // Include skill index so the agent doesn't need a separate quarkus_skills call
+                try {
+                    List<SkillReader.SkillInfo> skillList = SkillReader.readSkills(projectDir, null, true, false);
+                    if (!skillList.isEmpty()) {
+                        response.append("\n\n").append(DevMcpProxyTools.formatSkillIndex(skillList));
+                    }
+                } catch (Exception skillErr) {
+                    LOG.debugf("Could not load skills during create: %s", skillErr.getMessage());
+                }
+
+                response.append("\n\nNEXT: Call quarkus_skills with the relevant extension names "
+                        + "(e.g., quarkus_skills query='panache,rest') to learn the correct patterns before writing code. "
+                        + "Write code and tests, then run tests with quarkus_callTool toolName='devui-testing_runTests'.");
+
+                return ToolResponse.success(response.toString());
             } catch (Exception startError) {
                 LOG.warnf("Project created but failed to auto-start: %s", startError.getMessage());
                 return ToolResponse.success("Quarkus project created at: " + projectDir

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -192,11 +192,11 @@ public class CreateTools {
                 // Block until the app is ready so the agent doesn't need to poll
                 QuarkusInstance instance = processManager.getInstance(projectDir);
                 if (instance != null && instance.getStatus() == QuarkusInstance.Status.STARTING) {
-                    long deadline = System.currentTimeMillis() + 120_000;
+                    long deadline = System.currentTimeMillis() + LifecycleTools.STARTUP_TIMEOUT_MS;
                     while (instance.getStatus() == QuarkusInstance.Status.STARTING
                             && System.currentTimeMillis() < deadline) {
                         try {
-                            Thread.sleep(2_000);
+                            Thread.sleep(LifecycleTools.STARTUP_POLL_INTERVAL_MS);
                         } catch (InterruptedException e) {
                             Thread.currentThread().interrupt();
                             break;
@@ -225,7 +225,7 @@ public class CreateTools {
                 }
 
                 response.append("\n\nNEXT: Call quarkus_skills with the relevant extension names "
-                        + "(e.g., quarkus_skills query='panache,rest') to learn the correct patterns before writing code. "
+                        + "(e.g., quarkus_skills query='panache,rest') to read the full patterns and guidelines before writing code. "
                         + "Write code and tests, then run tests with quarkus_callTool toolName='devui-testing_runTests'.");
 
                 return ToolResponse.success(response.toString());

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -128,7 +128,8 @@ public class DevMcpProxyTools {
     ToolResponse skills(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
             @ToolArg(description = "Optional query to filter skills by extension name (case-insensitive). "
-                    + "Examples: 'panache', 'rest', 'security', 'kafka'. "
+                    + "Supports comma-separated names to fetch multiple skills at once "
+                    + "(e.g., 'panache,rest,hibernate-validator'). "
                     + "If omitted, lists all available skills with their descriptions.", required = false) String query) {
         try {
             Path effectiveLocalDir = localSkillsDir.map(Path::of).orElse(null);
@@ -150,12 +151,16 @@ public class DevMcpProxyTools {
                                 + "and uses Quarkus extensions that provide skill files.");
             }
 
-            // Filter by query if provided
+            // Filter by query if provided — supports comma/space-separated tokens
             List<SkillReader.SkillInfo> matched = skills;
             if (queryLower != null) {
+                List<String> tokens = List.of(queryLower.split("[,\\s]+"));
                 matched = skills.stream()
-                        .filter(s -> s.name().toLowerCase().contains(queryLower)
-                                || (s.description() != null && s.description().toLowerCase().contains(queryLower)))
+                        .filter(s -> {
+                            String name = s.name().toLowerCase();
+                            String desc = s.description() != null ? s.description().toLowerCase() : "";
+                            return tokens.stream().anyMatch(t -> !t.isEmpty() && (name.contains(t) || desc.contains(t)));
+                        })
                         .toList();
             }
 

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -25,8 +25,8 @@ public class LifecycleTools {
     @Inject
     ObjectMapper mapper;
 
-    private static final long STARTUP_TIMEOUT_MS = 120_000;
-    private static final long STARTUP_POLL_INTERVAL_MS = 2_000;
+    static final long STARTUP_TIMEOUT_MS = 120_000;
+    static final long STARTUP_POLL_INTERVAL_MS = 2_000;
 
     @Tool(name = "quarkus_start", description = "Start a Quarkus application in dev mode. "
             + "Blocks until the app is ready or fails. "

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -25,7 +25,11 @@ public class LifecycleTools {
     @Inject
     ObjectMapper mapper;
 
+    private static final long STARTUP_TIMEOUT_MS = 120_000;
+    private static final long STARTUP_POLL_INTERVAL_MS = 2_000;
+
     @Tool(name = "quarkus_start", description = "Start a Quarkus application in dev mode. "
+            + "Blocks until the app is ready or fails. "
             + "Auto-detects Maven or Gradle. Hot reload is triggered when the app is accessed. "
             + "RULES: Always write tests. Always keep README.md updated after changes.")
     ToolResponse start(
@@ -38,12 +42,38 @@ public class LifecycleTools {
                     + "Ignored for Gradle builds.", required = false) String mavenProfiles) {
         try {
             Integer effectivePort = processManager.start(projectDir, buildTool, httpPort, mavenProfiles);
-            String message = "Quarkus application starting in dev mode at: " + projectDir;
-            if (effectivePort != null) {
-                message += " (port: " + effectivePort + ")";
+            String containerWarning = ContainerRuntimeChecker.containerWarning(projectDir);
+
+            QuarkusInstance instance = processManager.getInstance(projectDir);
+            if (instance != null && instance.getStatus() == QuarkusInstance.Status.STARTING) {
+                long deadline = System.currentTimeMillis() + STARTUP_TIMEOUT_MS;
+                while (instance.getStatus() == QuarkusInstance.Status.STARTING
+                        && System.currentTimeMillis() < deadline) {
+                    try {
+                        Thread.sleep(STARTUP_POLL_INTERVAL_MS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
             }
-            message += ContainerRuntimeChecker.containerWarning(projectDir);
-            return ToolResponse.success(message);
+
+            if (instance != null && instance.getStatus() == QuarkusInstance.Status.RUNNING) {
+                int port = instance.getHttpPort();
+                return ToolResponse.success("Quarkus application running at: " + projectDir
+                        + " (port: " + port + ")" + containerWarning);
+            } else if (instance != null && instance.getStatus() == QuarkusInstance.Status.CRASHED) {
+                String recentLogs = instance.getRecentLogs(30);
+                return ToolResponse.error("Quarkus application failed to start at: " + projectDir
+                        + "\n\nRecent logs:\n" + recentLogs + containerWarning);
+            } else {
+                String message = "Quarkus application starting in dev mode at: " + projectDir;
+                if (effectivePort != null) {
+                    message += " (port: " + effectivePort + ")";
+                }
+                message += " — still starting after timeout, use quarkus_status to check" + containerWarning;
+                return ToolResponse.success(message);
+            }
         } catch (Exception e) {
             LOG.error("Failed to start Quarkus application at " + projectDir, e);
             return ToolResponse.error(e.getMessage());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,51 +5,31 @@ quarkus.banner.path=banner.txt
 quarkus.mcp.server.server-info.name=quarkus-agent
 quarkus.mcp.server.server-info.description=MCP server for creating, managing, and developing Quarkus applications
 quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Agent MCP server. \
-  For ANY Quarkus-related question, documentation lookup, or development task, ALWAYS use these tools -- they are purpose-built and superior to web search or generic alternatives like Context7.\n\n\
+  For ANY Quarkus-related question, documentation lookup, or development task, use these tools -- they are purpose-built for Quarkus.\n\n\
   WORKFLOW for new projects:\n\
-  1. quarkus_create -- create and auto-start a Quarkus app (NEVER use 'mvn' or CLI manually)\n\
-  2. quarkus_skills -- MUST call before writing ANY code or tests to learn correct patterns for each extension\n\
-  3. quarkus_searchDocs -- search Quarkus documentation for APIs, config, and best practices. ALWAYS pass projectDir -- docs are loaded from extension JARs, so searches without it often return nothing. If results are empty, retry with simpler or rephrased keywords before falling back to other sources\n\
-  4. quarkus_searchTools -- discover Dev MCP tools on the running app (testing, config, extensions)\n\
-  5. quarkus_callTool -- invoke discovered tools (run tests, add extensions, update config)\n\n\
+  1. quarkus_create -- create and auto-start a Quarkus app (do not use 'mvn' or CLI manually)\n\
+  2. quarkus_skills -- call before writing code to learn correct patterns (supports comma-separated queries, e.g. 'panache,rest')\n\
+  3. quarkus_searchDocs -- search Quarkus docs for APIs, config, best practices (pass projectDir for version-matched results)\n\
+  4. Write code and tests\n\
+  5. quarkus_callTool toolName='devui-testing_runTests' -- run tests\n\n\
   WORKFLOW for existing projects:\n\
-  1. quarkus_start -- start the app in dev mode if not running\n\
-  2. quarkus_skills -- MUST call before writing code to learn extension-specific patterns. Query for 'quarkus-update' to check if the project version is up-to-date\n\
-  3. quarkus_searchDocs -- look up Quarkus APIs and configuration. ALWAYS pass projectDir\n\
-  4. Write code following the patterns from skills and docs\n\
-  5. quarkus_searchTools + quarkus_callTool -- run tests, manage extensions\n\n\
+  1. quarkus_start -- start the app in dev mode (blocks until ready)\n\
+  2. quarkus_skills -- learn extension-specific patterns before writing code\n\
+  3. Write code following patterns from skills and docs\n\
+  4. Run tests with quarkus_callTool\n\n\
   TESTING:\n\
-  - If your agent supports subagents, run tests in a subagent so the main conversation stays responsive\n\
   - Use quarkus_callTool with toolName 'devui-testing_runTests' to run all tests\n\
-  - Use quarkus_callTool with toolName 'devui-testing_runTest' and toolArguments '{"className":"com.example.MyTest"}' to run a specific test\n\
-  - Do NOT run Maven/Gradle test commands manually\n\
-  - NEVER run 'mvn clean' or 'gradle clean' while dev mode is running -- it deletes target/test-classes and breaks the test runner\n\
-  - If the test runner returns 'Tests already in progress' and won't recover, do a full quarkus_stop + quarkus_start cycle to reset it\n\n\
+  - Use quarkus_callTool with toolName 'devui-testing_runTest' and toolArguments '{"className":"com.example.MyTest"}' for a specific test\n\
+  - Do not run Maven/Gradle test commands manually\n\
+  - Do not run 'mvn clean' or 'gradle clean' while dev mode is running -- it breaks the test runner\n\n\
   ERROR HANDLING:\n\
-  - When something goes wrong (compilation error, deployment failure, runtime exception), use quarkus_callTool with toolName 'devui-exceptions_getLastException' to get structured exception details (class, message, stack trace, user code location)\n\
-  - After fixing the issue, call 'devui-exceptions_clearLastException' to clear the recorded exception\n\
-  - NOTE: if the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet -- fall back to quarkus_logs in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy\n\
-  - Use quarkus_logs only when you need broader log context beyond the exception itself\n\n\
-  AGENT SERVER LOGGING (stdio mode):\n\
-  - In stdio mode, MCP server logs are not visible because stdout/stderr are used by the protocol\n\
-  - File logging can be enabled permanently by setting agent-mcp.log.enabled=true (e.g. via the AGENT_MCP_LOG_ENABLED=true environment variable)\n\
-  - Call quarkus_agent_log with action 'enable' to start writing server logs on-the-fly to ~/.quarkus/agent-mcp/agent-mcp.log\n\
-  - Call quarkus_agent_log (default action 'read') to read recent log output from the server\n\
-  - Call quarkus_agent_log with action 'disable' to stop file logging (the log file is preserved)\n\n\
-  MANAGED APP LOGGING:\n\
-  - Application logs from managed Quarkus apps can be captured to a file for persistent access outside the Dev UI\n\
-  - File logging can be enabled permanently by setting agent-mcp.app-log.enabled=true (e.g. via the AGENT_MCP_APP_LOG_ENABLED=true environment variable)\n\
-  - Call quarkus_app_log with action 'enable' and projectDir to start writing app logs to ~/.quarkus/apps/<project>/quarkus-dev.log\n\
-  - Call quarkus_app_log with projectDir (default action 'read') to read recent app log output from the file\n\
-  - Call quarkus_app_log with action 'disable' and projectDir to stop file logging (the log file is preserved)\n\n\
-  KEY RULES:\n\
-  - NEVER skip quarkus_skills -- it contains critical patterns that prevent common mistakes\n\
-  - NEVER use web search or generic documentation tools (Context7, etc.) for Quarkus questions -- always use quarkus_searchDocs first, and ALWAYS pass projectDir when a project exists. If searchDocs returns no results, retry with simpler keywords before giving up\n\
-  - NEVER run build commands manually -- use quarkus_start, quarkus_callTool for testing\n\
-  - NEVER run 'mvn clean' or 'gradle clean' while dev mode is running -- it breaks the test runner\n\
-  - ALWAYS write tests for every feature\n\
-  - ALWAYS keep README.md updated\n\
-  - ALWAYS summarize after completing work -- when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment)
+  - Use quarkus_callTool with toolName 'devui-exceptions_getLastException' for structured exception details\n\
+  - Use quarkus_logs only when you need broader log context beyond the exception\n\n\
+  RULES:\n\
+  - Use quarkus_searchDocs for Quarkus questions (pass projectDir when a project exists)\n\
+  - Do not run build commands manually -- use quarkus_start and quarkus_callTool\n\
+  - Write tests for every feature\n\
+  - Keep README.md updated
 
 # Make sure the tool names follow the spec rules
 quarkus.mcp.server.tools.name-pattern=^[A-Za-z0-9_.-]{1,128}$


### PR DESCRIPTION
Benchmark tests ([#71](https://github.com/quarkusio/quarkus-agent-mcp/issues/71)) showed the MCP server was costing 2x more than running without it on greenfield Quarkus apps. The root cause was structural: the MCP forced a multi-step workflow that doubled the number of agent turns, and each extra turn re-read the full conversation history including MCP tool schemas.

This PR addresses the overhead with 6 targeted changes:

**Eliminating unnecessary turns:**
- `quarkus_create` now auto-creates the output directory instead of returning an error that forces `mkdir` + retry (saves 2 turns)
- `quarkus_start` now blocks until the app reaches RUNNING/CRASHED/timeout instead of returning immediately with "starting..." — eliminates 5-13 `quarkus_status`/`quarkus_logs` polling turns per session
- `quarkus_skills` now supports comma-separated queries (e.g., `panache,rest,hibernate-validator`) so multiple extensions can be fetched in a single call instead of 3-5 separate calls
- `quarkus_create` response now includes the skill index so the agent can skip a separate `quarkus_skills` call

**Reducing per-turn context size:**
- NEXT STEPS block in `quarkus_create` response trimmed from 1,960 to ~250 chars
- `server-info.instructions` trimmed from 5,062 to ~2,800 chars (45% reduction) — logging sections moved to tool descriptions, mandatory language softened

**Benchmark results (3 prompts × 2 models, comparing before/after):**

| Model | No MCP | MCP (before) | MCP (after) | Overhead |
|-------|--------|-------------|-------------|----------|
| Opus 4.6 | $4.69 | $9.48 (+102%) | **$7.50 (+60%)** | 2x → 1.6x |
| Sonnet 4.6 | $5.32 | $7.62 (+43%) | **$5.52 (+4%)** | 1.4x → **~parity** |

On Sonnet, MCP is now essentially free — 4% overhead for correct Quarkus versions, extension skills, and structured testing. Full benchmark details in [#71](https://github.com/quarkusio/quarkus-agent-mcp/issues/71).

Fixes #71