### PR TITLE
Support classifier in maven dependency; be defensive when resolving local artifacts files

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DependencyResolver.java
+++ b/src/main/java/io/quarkus/agent/mcp/DependencyResolver.java
@@ -43,7 +43,7 @@ public final class DependencyResolver {
     // ("   groupId:artifactId:type:version:scope").
     // May be suffixed with ANSI codes and module info.
     private static final Pattern MAVEN_DEP_LINE = Pattern.compile(
-            "^(?:\\[INFO\\])?\\s+(\\S+):(\\S+):\\S+:(\\S+):\\S+.*$");
+            "^(?:\\[INFO\\])?\\s+([^\\s:]+):([^\\s:]+):jar(?::[^\\s:]+)?:([^\\s:]+):(?:compile|provided|runtime|test|system|import).*$");
 
     // Gradle dependency: "+--- group:artifact:version" or "\--- group:artifact:version"
     // Also handles transitive deps with leading pipes/spaces: "|    +---" or "     +---"

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -6,13 +6,7 @@ import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
+import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -501,19 +495,26 @@ public final class SkillReader {
                 continue;
             }
             String groupPath = dep.groupId().replace('.', '/');
-            Path deploymentJar = m2Repo.resolve(groupPath)
-                    .resolve(dep.artifactId() + DEPLOYMENT_SUFFIX)
-                    .resolve(dep.version())
-                    .resolve(dep.artifactId() + DEPLOYMENT_SUFFIX + "-" + dep.version() + ".jar");
-            Path runtimeJar = m2Repo.resolve(groupPath)
-                    .resolve(dep.artifactId())
-                    .resolve(dep.version())
-                    .resolve(dep.artifactId() + "-" + dep.version() + ".jar");
-            Path devJar = m2Repo.resolve(groupPath)
-                    .resolve(dep.artifactId() + DEV_SUFFIX)
-                    .resolve(dep.version())
-                    .resolve(dep.artifactId() + DEV_SUFFIX + "-" + dep.version() + ".jar");
-
+            Path deploymentJar;
+            Path runtimeJar;
+            Path devJar;
+            try {
+                deploymentJar = m2Repo.resolve(groupPath)
+                        .resolve(dep.artifactId() + DEPLOYMENT_SUFFIX)
+                        .resolve(dep.version())
+                        .resolve(dep.artifactId() + DEPLOYMENT_SUFFIX + "-" + dep.version() + ".jar");
+                runtimeJar = m2Repo.resolve(groupPath)
+                        .resolve(dep.artifactId())
+                        .resolve(dep.version())
+                        .resolve(dep.artifactId() + "-" + dep.version() + ".jar");
+                devJar = m2Repo.resolve(groupPath)
+                        .resolve(dep.artifactId() + DEV_SUFFIX)
+                        .resolve(dep.version())
+                        .resolve(dep.artifactId() + DEV_SUFFIX + "-" + dep.version() + ".jar");
+            } catch (InvalidPathException e) {
+                LOG.warnf("Unable to resolve jars for dependency %s", dep);
+                continue;
+            }
             SkillInfo skill = composeSkillFromExtension(deploymentJar, runtimeJar, devJar,
                     dep.artifactId(), metadataOnly);
             if (skill != null) {


### PR DESCRIPTION
Fixes https://github.com/quarkusio/quarkus-agent-mcp/issues/168
because the classifier is optional I had to be more precise for the packaging and the scope
I assume we are not interested in non jars (e.g. war)?