### PR TITLE
Update Quarkus platform from 3.34.2 to 3.36.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,12 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.34.2</quarkus.platform.version>
+        <quarkus.platform.version>3.36.0</quarkus.platform.version>
         <quarkus-mcp-server.version>1.11.0</quarkus-mcp-server.version>
         <langchain4j.version>1.12.2-beta22</langchain4j.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
         <djl.version>0.28.0</djl.version>
-        <testcontainers.version>2.0.5</testcontainers.version>
     </properties>
 
     <dependencyManagement>
@@ -129,12 +128,10 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-postgresql</artifactId>
-            <version>${testcontainers.version}</version>
         </dependency>
         <!-- Required for native image: docker-java's shaded HTTP client references
              BrotliInputStreamFactory at link time -->
@@ -147,7 +144,6 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
-            <version>3.5.3</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Bumps the Quarkus platform BOM from 3.34.2 to 3.36.0. With this version, testcontainers and jandex versions are now managed by the BOM, so their explicit version properties and declarations have been removed.