### PR TITLE
Ensure agent files exist when starting existing projects

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -178,11 +178,9 @@ public class CreateTools {
             // full restart.
             createSourceDirectories(projectDir);
 
-            // Generate AGENTS.md with Quarkus-specific instructions (and CLAUDE.md pointing to it)
-            generateProjectInstructions(projectDir, extensions);
-
-            // Generate .mcp.json so tools like Claude Code auto-discover quarkus-agent-mcp
-            generateMcpConfig(projectDir);
+            // Generate AGENTS.md, CLAUDE.md, and .mcp.json
+            ProjectFiles.generateProjectInstructions(projectDir);
+            ProjectFiles.generateMcpConfig(projectDir);
 
             // Auto-start the app in dev mode and wait for it to be ready
             try {
@@ -480,117 +478,4 @@ public class CreateTools {
         Files.delete(subDir.toPath());
     }
 
-    private void generateProjectInstructions(String projectDir, String extensions) {
-        try {
-            String agentsMdContent = """
-                    # AGENTS.md -- Quarkus Project Instructions
-
-                    This is a Quarkus application. Follow these rules when working on this project.
-
-                    ## CRITICAL -- Extension-First Rule (NEVER skip this)
-
-                    **STOP before writing ANY code.** For every feature or capability the user requests:
-
-                    1. **Search for Quarkus extensions** that provide the capability using `quarkus_searchDocs` and `quarkus_searchTools query='extension'`.
-                       Do NOT rely on a fixed list of extensions -- always search dynamically, as available extensions change across Quarkus versions and platform BOMs.
-                    2. **Present ALL matching extensions to the user** with a recommended default marked. Wait for the user to choose before proceeding.
-                       Do NOT silently pick an extension when multiple options exist.
-                    3. **Load skills** with `quarkus_skills` for the chosen extension BEFORE writing any code.
-
-                    Skipping any of these steps is a violation. NEVER implement a feature by hand-coding HTML, JavaScript, REST endpoints, or other functionality when a Quarkus extension exists for it.
-
-                    ## Required Workflow
-
-                    1. **Use quarkus_skills BEFORE writing any code or tests** -- it contains extension-specific patterns, testing approaches, and common pitfalls that prevent mistakes. Skills may also list **Available Dev MCP Tools** specific to each extension (e.g. OpenAPI schema retrieval, scheduler job management) -- use these via `quarkus_callTool`. Call this EVERY time you are about to add or modify a feature, not just at project creation. When returning to an existing project, query for the `quarkus-update` skill to check if the Quarkus version is up-to-date.
-                    2. **Use quarkus_searchDocs for Quarkus documentation** -- do NOT use generic documentation tools (Context7, web search). The Quarkus doc search is version-aware and more accurate.
-                    3. **Use quarkus_searchTools to discover Dev MCP tools** on the running app for testing, config changes, and extension management. The tool list is **dynamic** -- it changes when extensions are added or removed. Re-call `quarkus_searchTools` after any extension change to discover newly available tools. Note: some extension-specific tools are also documented in the skills output (see step 1).
-                    4. **Use quarkus_callTool to invoke Dev MCP tools** -- run tests, add extensions, update configuration. Do NOT run Maven/Gradle commands manually.
-                    5. **After code changes, trigger a reload** via `quarkus_callTool` with toolName `devui-logstream_forceRestart`. Do NOT restart the app manually.
-                    6. **After pom.xml / build.gradle changes** (adding dependencies or extensions), you MUST do a full `quarkus_stop` + `quarkus_start` cycle. A `forceRestart` only recompiles source files -- it does NOT re-resolve dependencies.
-
-                    ## Rules
-
-                    - NEVER implement features manually when a Quarkus extension exists -- search for and add the right extension first.
-                    - NEVER silently pick an extension when multiple options exist -- ALWAYS present options to the user and wait for their choice.
-                    - NEVER write code for a feature without first loading its skill via `quarkus_skills`.
-                    - ALWAYS write tests for every feature -- no exceptions.
-                    - ALWAYS keep README.md updated with app description, features, endpoints, and Quarkus guide links.
-                    - ALWAYS summarize after completing work -- when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment).
-                    - Use `@QuarkusTest` for integration tests -- Dev Services auto-starts backing services (databases, messaging, etc.).
-                    - Use `%dev.` and `%test.` profile prefixes for dev/test configuration -- never hardcode connection URLs without a profile prefix.
-
-                    ## Testing
-
-                    If your agent supports subagents, run tests in a **subagent** so the main conversation stays responsive:
-
-                    ```
-                    If supported, use the Agent tool to launch a subagent with this prompt:
-                      "Run the Quarkus tests for project <projectDir> using quarkus_callTool
-                       with toolName 'devui-testing_runTests'. Analyze the results and report
-                       which tests passed, failed, or errored. If tests fail, include the
-                       failure messages and suggest fixes."
-                    ```
-
-                    - Use `devui-testing_runTests` to run all tests.
-                    - Use `devui-testing_runTest` with arguments `{"className":"com.example.MyTest"}` to run a specific test class.
-                    - Do NOT run Maven/Gradle test commands manually -- the Dev MCP test tools handle compilation, hot reload, and result reporting.
-                    - After fixing test failures, re-run tests (via a subagent if supported) to verify the fix.
-                    - **NEVER run `mvn clean` or `gradle clean` while dev mode is running** -- it deletes `target/test-classes` and breaks the test runner with no automatic recovery.
-                    - If the test runner gets stuck returning "Tests already in progress", do a full `quarkus_stop` + `quarkus_start` cycle to reset the test runner state.
-
-                    ## Error Handling
-
-                    When something goes wrong (compilation error, deployment failure, runtime exception):
-
-                    1. Use `quarkus_callTool` with toolName `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location).
-                    2. Fix the issue based on the exception details.
-                    3. Call `devui-exceptions_clearLastException` to clear the recorded exception.
-                    4. Use `quarkus_logs` only when you need broader log context beyond the exception itself.
-
-                    **Note:** If the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet -- fall back to `quarkus_logs` in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy.
-
-                    ## Customizing Skills
-
-                    **Global customizations** (`~/.quarkus/skills/`) apply to all projects. Use `quarkus_updateSkill`
-                    to create or update global customizations. Ask the user whether to ENHANCE (append to the base)
-                    or OVERRIDE (fully replace the base).
-
-                    **Project-level skills** (`.agent/skills/`) are standalone files readable by any agent.
-                    Use `quarkus_saveSkill` to materialize the full composed skill into `.agent/skills/`,
-                    then edit the file directly to customize it for the project.
-                    """;
-            Files.writeString(Path.of(projectDir, "AGENTS.md"), agentsMdContent, StandardCharsets.UTF_8);
-            LOG.debugf("Generated AGENTS.md in %s", projectDir);
-
-            // Generate CLAUDE.md that points to AGENTS.md for Claude Code compatibility
-            String claudeMdContent = """
-                    See [AGENTS.md](AGENTS.md) for project instructions.
-                    """;
-            Files.writeString(Path.of(projectDir, "CLAUDE.md"), claudeMdContent, StandardCharsets.UTF_8);
-            LOG.debugf("Generated CLAUDE.md in %s", projectDir);
-        } catch (IOException e) {
-            LOG.warnf("Failed to generate project instructions in %s: %s", projectDir, e.getMessage());
-        }
-    }
-
-    private void generateMcpConfig(String projectDir) {
-        try {
-            String mcpJson = """
-                    {
-                      "mcpServers": {
-                        "quarkus-agent": {
-                          "command": "jbang",
-                          "args": [
-                            "quarkus-agent-mcp@quarkusio"
-                          ]
-                        }
-                      }
-                    }
-                    """;
-            Files.writeString(Path.of(projectDir, ".mcp.json"), mcpJson, StandardCharsets.UTF_8);
-            LOG.debugf("Generated .mcp.json in %s", projectDir);
-        } catch (IOException e) {
-            LOG.warnf("Failed to generate .mcp.json in %s: %s", projectDir, e.getMessage());
-        }
-    }
 }

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -6,6 +6,7 @@ import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
 import io.quarkiverse.mcp.server.ToolResponse;
 import jakarta.inject.Inject;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.jboss.logging.Logger;
@@ -58,10 +59,14 @@ public class LifecycleTools {
                 }
             }
 
+            List<String> createdFiles = ProjectFiles.ensureAgentFiles(projectDir);
+            String agentFilesNote = createdFiles.isEmpty() ? ""
+                    : "\nGenerated missing agent files: " + String.join(", ", createdFiles);
+
             if (instance != null && instance.getStatus() == QuarkusInstance.Status.RUNNING) {
                 int port = instance.getHttpPort();
                 return ToolResponse.success("Quarkus application running at: " + projectDir
-                        + " (port: " + port + ")" + containerWarning);
+                        + " (port: " + port + ")" + containerWarning + agentFilesNote);
             } else if (instance != null && instance.getStatus() == QuarkusInstance.Status.CRASHED) {
                 String recentLogs = instance.getRecentLogs(30);
                 return ToolResponse.error("Quarkus application failed to start at: " + projectDir
@@ -71,7 +76,8 @@ public class LifecycleTools {
                 if (effectivePort != null) {
                     message += " (port: " + effectivePort + ")";
                 }
-                message += " — still starting after timeout, use quarkus_status to check" + containerWarning;
+                message += " — still starting after timeout, use quarkus_status to check" + containerWarning
+                        + agentFilesNote;
                 return ToolResponse.success(message);
             }
         } catch (Exception e) {

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -70,7 +70,7 @@ public class LifecycleTools {
             } else if (instance != null && instance.getStatus() == QuarkusInstance.Status.CRASHED) {
                 String recentLogs = instance.getRecentLogs(30);
                 return ToolResponse.error("Quarkus application failed to start at: " + projectDir
-                        + "\n\nRecent logs:\n" + recentLogs + containerWarning);
+                        + "\n\nRecent logs:\n" + recentLogs + containerWarning + agentFilesNote);
             } else {
                 String message = "Quarkus application starting in dev mode at: " + projectDir;
                 if (effectivePort != null) {

--- a/src/main/java/io/quarkus/agent/mcp/ProjectFiles.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProjectFiles.java
@@ -1,0 +1,176 @@
+package io.quarkus.agent.mcp;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.logging.Logger;
+
+/**
+ * Generates agent instruction files (AGENTS.md, CLAUDE.md, .mcp.json)
+ * that coding agents rely on when working with a Quarkus project.
+ * Used by {@link CreateTools} (always writes) and {@link LifecycleTools} (writes only if missing).
+ */
+public final class ProjectFiles {
+
+    private static final Logger LOG = Logger.getLogger(ProjectFiles.class);
+
+    private ProjectFiles() {
+    }
+
+    static final String AGENTS_MD = "AGENTS.md";
+    static final String CLAUDE_MD = "CLAUDE.md";
+    static final String MCP_JSON = ".mcp.json";
+
+    /**
+     * Checks for missing agent files and generates any that don't exist.
+     * Never overwrites existing files.
+     *
+     * @return list of filenames that were created (empty if all already existed)
+     */
+    public static List<String> ensureAgentFiles(String projectDir) {
+        List<String> created = new ArrayList<>();
+        Path dir = Path.of(projectDir);
+
+        if (!Files.exists(dir.resolve(AGENTS_MD))) {
+            generateAgentsMd(projectDir);
+            created.add(AGENTS_MD);
+        }
+        if (!Files.exists(dir.resolve(CLAUDE_MD))) {
+            generateClaudeMd(projectDir);
+            created.add(CLAUDE_MD);
+        }
+        if (!Files.exists(dir.resolve(MCP_JSON))) {
+            generateMcpConfig(projectDir);
+            created.add(MCP_JSON);
+        }
+
+        return created;
+    }
+
+    static void generateProjectInstructions(String projectDir) {
+        generateAgentsMd(projectDir);
+        generateClaudeMd(projectDir);
+    }
+
+    private static void generateAgentsMd(String projectDir) {
+        try {
+            String agentsMdContent = """
+                    # AGENTS.md -- Quarkus Project Instructions
+
+                    This is a Quarkus application. Follow these rules when working on this project.
+
+                    ## CRITICAL -- Extension-First Rule (NEVER skip this)
+
+                    **STOP before writing ANY code.** For every feature or capability the user requests:
+
+                    1. **Search for Quarkus extensions** that provide the capability using `quarkus_searchDocs` and `quarkus_searchTools query='extension'`.
+                       Do NOT rely on a fixed list of extensions -- always search dynamically, as available extensions change across Quarkus versions and platform BOMs.
+                    2. **Present ALL matching extensions to the user** with a recommended default marked. Wait for the user to choose before proceeding.
+                       Do NOT silently pick an extension when multiple options exist.
+                    3. **Load skills** with `quarkus_skills` for the chosen extension BEFORE writing any code.
+
+                    Skipping any of these steps is a violation. NEVER implement a feature by hand-coding HTML, JavaScript, REST endpoints, or other functionality when a Quarkus extension exists for it.
+
+                    ## Required Workflow
+
+                    1. **Use quarkus_skills BEFORE writing any code or tests** -- it contains extension-specific patterns, testing approaches, and common pitfalls that prevent mistakes. Skills may also list **Available Dev MCP Tools** specific to each extension (e.g. OpenAPI schema retrieval, scheduler job management) -- use these via `quarkus_callTool`. Call this EVERY time you are about to add or modify a feature, not just at project creation. When returning to an existing project, query for the `quarkus-update` skill to check if the Quarkus version is up-to-date.
+                    2. **Use quarkus_searchDocs for Quarkus documentation** -- do NOT use generic documentation tools (Context7, web search). The Quarkus doc search is version-aware and more accurate.
+                    3. **Use quarkus_searchTools to discover Dev MCP tools** on the running app for testing, config changes, and extension management. The tool list is **dynamic** -- it changes when extensions are added or removed. Re-call `quarkus_searchTools` after any extension change to discover newly available tools. Note: some extension-specific tools are also documented in the skills output (see step 1).
+                    4. **Use quarkus_callTool to invoke Dev MCP tools** -- run tests, add extensions, update configuration. Do NOT run Maven/Gradle commands manually.
+                    5. **After code changes, trigger a reload** via `quarkus_callTool` with toolName `devui-logstream_forceRestart`. Do NOT restart the app manually.
+                    6. **After pom.xml / build.gradle changes** (adding dependencies or extensions), you MUST do a full `quarkus_stop` + `quarkus_start` cycle. A `forceRestart` only recompiles source files -- it does NOT re-resolve dependencies.
+
+                    ## Rules
+
+                    - NEVER implement features manually when a Quarkus extension exists -- search for and add the right extension first.
+                    - NEVER silently pick an extension when multiple options exist -- ALWAYS present options to the user and wait for their choice.
+                    - NEVER write code for a feature without first loading its skill via `quarkus_skills`.
+                    - ALWAYS write tests for every feature -- no exceptions.
+                    - ALWAYS keep README.md updated with app description, features, endpoints, and Quarkus guide links.
+                    - ALWAYS summarize after completing work -- when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment).
+                    - Use `@QuarkusTest` for integration tests -- Dev Services auto-starts backing services (databases, messaging, etc.).
+                    - Use `%dev.` and `%test.` profile prefixes for dev/test configuration -- never hardcode connection URLs without a profile prefix.
+
+                    ## Testing
+
+                    If your agent supports subagents, run tests in a **subagent** so the main conversation stays responsive:
+
+                    ```
+                    If supported, use the Agent tool to launch a subagent with this prompt:
+                      "Run the Quarkus tests for project <projectDir> using quarkus_callTool
+                       with toolName 'devui-testing_runTests'. Analyze the results and report
+                       which tests passed, failed, or errored. If tests fail, include the
+                       failure messages and suggest fixes."
+                    ```
+
+                    - Use `devui-testing_runTests` to run all tests.
+                    - Use `devui-testing_runTest` with arguments `{"className":"com.example.MyTest"}` to run a specific test class.
+                    - Do NOT run Maven/Gradle test commands manually -- the Dev MCP test tools handle compilation, hot reload, and result reporting.
+                    - After fixing test failures, re-run tests (via a subagent if supported) to verify the fix.
+                    - **NEVER run `mvn clean` or `gradle clean` while dev mode is running** -- it deletes `target/test-classes` and breaks the test runner with no automatic recovery.
+                    - If the test runner gets stuck returning "Tests already in progress", do a full `quarkus_stop` + `quarkus_start` cycle to reset the test runner state.
+
+                    ## Error Handling
+
+                    When something goes wrong (compilation error, deployment failure, runtime exception):
+
+                    1. Use `quarkus_callTool` with toolName `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location).
+                    2. Fix the issue based on the exception details.
+                    3. Call `devui-exceptions_clearLastException` to clear the recorded exception.
+                    4. Use `quarkus_logs` only when you need broader log context beyond the exception itself.
+
+                    **Note:** If the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet -- fall back to `quarkus_logs` in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy.
+
+                    ## Customizing Skills
+
+                    **Global customizations** (`~/.quarkus/skills/`) apply to all projects. Use `quarkus_updateSkill`
+                    to create or update global customizations. Ask the user whether to ENHANCE (append to the base)
+                    or OVERRIDE (fully replace the base).
+
+                    **Project-level skills** (`.agent/skills/`) are standalone files readable by any agent.
+                    Use `quarkus_saveSkill` to materialize the full composed skill into `.agent/skills/`,
+                    then edit the file directly to customize it for the project.
+                    """;
+            Files.writeString(Path.of(projectDir, AGENTS_MD), agentsMdContent, StandardCharsets.UTF_8);
+            LOG.debugf("Generated %s in %s", AGENTS_MD, projectDir);
+        } catch (IOException e) {
+            LOG.warnf("Failed to generate %s in %s: %s", AGENTS_MD, projectDir, e.getMessage());
+        }
+    }
+
+    private static void generateClaudeMd(String projectDir) {
+        try {
+            String claudeMdContent = """
+                    See [AGENTS.md](AGENTS.md) for project instructions.
+                    """;
+            Files.writeString(Path.of(projectDir, CLAUDE_MD), claudeMdContent, StandardCharsets.UTF_8);
+            LOG.debugf("Generated %s in %s", CLAUDE_MD, projectDir);
+        } catch (IOException e) {
+            LOG.warnf("Failed to generate %s in %s: %s", CLAUDE_MD, projectDir, e.getMessage());
+        }
+    }
+
+    static void generateMcpConfig(String projectDir) {
+        try {
+            String mcpJson = """
+                    {
+                      "mcpServers": {
+                        "quarkus-agent": {
+                          "command": "jbang",
+                          "args": [
+                            "quarkus-agent-mcp@quarkusio"
+                          ]
+                        }
+                      }
+                    }
+                    """;
+            Files.writeString(Path.of(projectDir, MCP_JSON), mcpJson, StandardCharsets.UTF_8);
+            LOG.debugf("Generated %s in %s", MCP_JSON, projectDir);
+        } catch (IOException e) {
+            LOG.warnf("Failed to generate %s in %s: %s", MCP_JSON, projectDir, e.getMessage());
+        }
+    }
+}

--- a/src/test/java/io/quarkus/agent/mcp/ProjectFilesTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/ProjectFilesTest.java
@@ -1,0 +1,77 @@
+package io.quarkus.agent.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProjectFilesTest {
+
+    @Test
+    void ensureAgentFiles_createsAllInEmptyDir(@TempDir Path tempDir) {
+        List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString());
+
+        assertEquals(List.of("AGENTS.md", "CLAUDE.md", ".mcp.json"), created);
+        assertTrue(Files.exists(tempDir.resolve("AGENTS.md")));
+        assertTrue(Files.exists(tempDir.resolve("CLAUDE.md")));
+        assertTrue(Files.exists(tempDir.resolve(".mcp.json")));
+    }
+
+    @Test
+    void ensureAgentFiles_skipsExistingFiles(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("AGENTS.md"), "custom content");
+        Files.writeString(tempDir.resolve("CLAUDE.md"), "custom claude");
+        Files.writeString(tempDir.resolve(".mcp.json"), "{}");
+
+        List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString());
+
+        assertTrue(created.isEmpty());
+        assertEquals("custom content", Files.readString(tempDir.resolve("AGENTS.md")));
+        assertEquals("custom claude", Files.readString(tempDir.resolve("CLAUDE.md")));
+        assertEquals("{}", Files.readString(tempDir.resolve(".mcp.json")));
+    }
+
+    @Test
+    void ensureAgentFiles_createsOnlyMissing(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("AGENTS.md"), "custom content");
+
+        List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString());
+
+        assertEquals(List.of("CLAUDE.md", ".mcp.json"), created);
+        assertEquals("custom content", Files.readString(tempDir.resolve("AGENTS.md")));
+        assertTrue(Files.exists(tempDir.resolve("CLAUDE.md")));
+        assertTrue(Files.exists(tempDir.resolve(".mcp.json")));
+    }
+
+    @Test
+    void generatedAgentsMd_containsWorkflowInstructions(@TempDir Path tempDir) throws IOException {
+        ProjectFiles.ensureAgentFiles(tempDir.toString());
+
+        String content = Files.readString(tempDir.resolve("AGENTS.md"));
+        assertTrue(content.contains("Extension-First Rule"));
+        assertTrue(content.contains("quarkus_skills"));
+        assertTrue(content.contains("quarkus_searchDocs"));
+    }
+
+    @Test
+    void generatedClaudeMd_pointsToAgentsMd(@TempDir Path tempDir) throws IOException {
+        ProjectFiles.ensureAgentFiles(tempDir.toString());
+
+        String content = Files.readString(tempDir.resolve("CLAUDE.md"));
+        assertTrue(content.contains("AGENTS.md"));
+    }
+
+    @Test
+    void generatedMcpJson_containsServerConfig(@TempDir Path tempDir) throws IOException {
+        ProjectFiles.ensureAgentFiles(tempDir.toString());
+
+        String content = Files.readString(tempDir.resolve(".mcp.json"));
+        assertTrue(content.contains("quarkus-agent"));
+        assertTrue(content.contains("jbang"));
+        assertTrue(content.contains("quarkus-agent-mcp@quarkusio"));
+    }
+}


### PR DESCRIPTION
When users add quarkus-agent-mcp to an existing Quarkus project, the agent instruction files (`AGENTS.md`, `CLAUDE.md`, `.mcp.json`) are missing because they only get generated during `quarkus_create`. Without them, AI assistants skip the quarkus-agent workflow entirely.

This extracts the file generation logic from `CreateTools` into a shared `ProjectFiles` utility and calls `ensureAgentFiles()` from `LifecycleTools.start()` — the natural entry point for existing projects. Missing files are auto-generated; existing files are never overwritten. The start response reports which files were created.

Supersedes #156 with a much smaller change (4 files vs 14, no new tools or aliases needed) that works against current main where `UpdateTools` no longer exists.

Fixes #154