### PR TITLE
Fix SQL statement splitter mishandling escaped single quotes

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -416,7 +416,13 @@ public class RagSqlLoader {
                 continue;
             }
 
-            if (c == '\'' && !isEscaped(sql, i)) {
+            if (c == '\'') {
+                if (inSingleQuote && i + 1 < sql.length() && sql.charAt(i + 1) == '\'') {
+                    current.append('\'');
+                    current.append('\'');
+                    i++;
+                    continue;
+                }
                 inSingleQuote = !inSingleQuote;
             }
 
@@ -437,10 +443,6 @@ public class RagSqlLoader {
         }
 
         return statements;
-    }
-
-    private static boolean isEscaped(String sql, int pos) {
-        return pos > 0 && sql.charAt(pos - 1) == '\'';
     }
 
     private String detectLatestInstalledVersion() {

--- a/src/test/java/io/quarkus/agent/mcp/RagSqlLoaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/RagSqlLoaderTest.java
@@ -53,6 +53,28 @@ class RagSqlLoaderTest {
     }
 
     @Test
+    void splitSqlStatementsHandlesEscapedQuotes() {
+        String sql = "INSERT INTO t VALUES ('it''s a test; with semicolons');\n"
+                + "INSERT INTO t VALUES ('import java.util.UUID;');";
+        List<String> stmts = RagSqlLoader.splitSqlStatements(sql);
+
+        assertEquals(2, stmts.size());
+        assertTrue(stmts.get(0).contains("it''s a test; with semicolons"));
+        assertTrue(stmts.get(1).contains("import java.util.UUID;"));
+    }
+
+    @Test
+    void splitSqlStatementsHandlesMultipleEscapedQuotes() {
+        String sql = "INSERT INTO t VALUES ('don''t stop; can''t stop');\n"
+                + "DELETE FROM t WHERE x = 'y';";
+        List<String> stmts = RagSqlLoader.splitSqlStatements(sql);
+
+        assertEquals(2, stmts.size());
+        assertTrue(stmts.get(0).contains("don''t stop; can''t stop"));
+        assertTrue(stmts.get(1).startsWith("DELETE"));
+    }
+
+    @Test
     void splitSqlStatementsSkipsComments() {
         String sql = "-- this is a comment\nINSERT INTO t VALUES (1);";
         List<String> stmts = RagSqlLoader.splitSqlStatements(sql);


### PR DESCRIPTION
The `splitSqlStatements` parser used a lookback (`isEscaped`) to detect `''` inside quoted strings. This caused the parser to exit the string at the first quote of a `''` pair, so any semicolons later in the text (e.g. Java `import` statements in documentation code examples) were treated as statement delimiters.

On the 3.36.1 aggregated RAG SQL file (3,671 escaped quotes across 197 documentation sources), this produced 11,083 broken fragments instead of the correct 7,908 statements — meaning most INSERT statements would be truncated and fail when executed against PostgreSQL.

The fix replaces the lookback with forward-looking `''` detection: when inside a quoted string and the next character is also a quote, consume both and stay in the string.