### PR TITLE
Fix post-release workflow runner jar upload

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -60,8 +60,15 @@ jobs:
           jq --arg v "$RELEASE_VERSION" '.plugins[0].version = $v' .claude-plugin/marketplace.json > tmp.json && mv tmp.json .claude-plugin/marketplace.json
 
       - name: Commit updated plugin files
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "chore: update plugin version to ${RELEASE_VERSION}"
-          file_pattern: .claude-plugin/*.json
-          branch: main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/*.json
+
+          if git diff --staged --quiet; then
+            echo "No plugin file changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore: update plugin version to ${RELEASE_VERSION}"
+          git push origin main


### PR DESCRIPTION
Fixes #181 by removing the disallowed `stefanzweifel/git-auto-commit-action@v5` from the post-release workflow and replacing it with equivalent inline git commands.