### PR TITLE
Remove git wrapper verification and use SmallRye Common in ProcessUtils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,10 @@
             <artifactId>jandex</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-process</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>

--- a/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
@@ -1,10 +1,13 @@
 package io.quarkus.agent.mcp;
 
+import io.smallrye.common.os.OS;
+import io.smallrye.common.process.ProcessUtil;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.jboss.logging.Logger;
@@ -17,69 +20,25 @@ final class ProcessUtils {
     }
 
     static boolean isCommandAvailable(String command) {
-        String checker = isWindows() ? "where" : "which";
-        Process p = null;
-        try {
-            p = new ProcessBuilder(checker, command)
-                    .redirectErrorStream(true)
-                    .start();
-            p.getInputStream().transferTo(java.io.OutputStream.nullOutputStream());
-            return p.waitFor() == 0;
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return false;
-        } catch (Exception e) {
-            return false;
-        } finally {
-            if (p != null) {
-                p.destroyForcibly();
-            }
-        }
-    }
-
-    static boolean isWindows() {
-        return System.getProperty("os.name", "").toLowerCase().contains("win");
+        return ProcessUtil.pathOfCommand(Path.of(command)).isPresent();
     }
 
     static String resolveMavenCommand(File projectDir) {
-        boolean win = isWindows();
+        boolean win = OS.WINDOWS.isCurrent();
         File wrapper = win ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
-        if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
+        if (wrapper.exists()) {
             return win ? "mvnw.cmd" : "./mvnw";
         }
         return win ? "mvn.cmd" : "mvn";
     }
 
     static String resolveGradleCommand(File projectDir) {
-        boolean win = isWindows();
+        boolean win = OS.WINDOWS.isCurrent();
         File wrapper = win ? new File(projectDir, "gradlew.bat") : new File(projectDir, "gradlew");
-        if (wrapper.exists() && verifyTrustedWrapper(wrapper)) {
+        if (wrapper.exists()) {
             return win ? "gradlew.bat" : "./gradlew";
         }
         return win ? "gradle.bat" : "gradle";
-    }
-
-    static boolean verifyTrustedWrapper(File wrapper) {
-        try {
-            Process p = new ProcessBuilder("git", "ls-files", "--error-unmatch", wrapper.getName())
-                    .directory(wrapper.getParentFile())
-                    .redirectErrorStream(true)
-                    .start();
-            p.getInputStream().transferTo(java.io.OutputStream.nullOutputStream());
-            int exit = p.waitFor();
-            if (exit != 0) {
-                throw new IllegalStateException(
-                        "Wrapper script '" + wrapper.getAbsolutePath() + "' is NOT tracked by git. "
-                                + "It could be malicious. Add it to git or use the system-installed build tool.");
-            }
-            return true;
-        } catch (IllegalStateException e) {
-            throw e;
-        } catch (Exception e) {
-            LOG.warnf("Could not verify wrapper script '%s' against git: %s. "
-                    + "Falling back to system build tool.", wrapper.getAbsolutePath(), e.getMessage());
-            return false;
-        }
     }
 
     static String runAndCapture(ProcessBuilder pb, long timeout, TimeUnit unit) {


### PR DESCRIPTION
The `verifyTrustedWrapper` method checked whether Maven/Gradle wrapper scripts were tracked by git before allowing their use, throwing an `IllegalStateException` if not. This broke project creation flows — freshly generated wrappers aren't in git yet — and assumed all projects use git, which isn't always the case.

This removes the git verification entirely (if a wrapper exists, just use it) and replaces the hand-rolled `isWindows()` and `isCommandAvailable()` implementations with `OS.WINDOWS.isCurrent()` and `ProcessUtil.pathOfCommand()` from SmallRye Common, as suggested by @gsmet.

Fixes #184