### PR TITLE
Fix parsePort failing when management interface is enabled

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -117,6 +117,7 @@ public class QuarkusInstance {
                 if (spaceIdx > 0) {
                     url = url.substring(0, spaceIdx);
                 }
+                url = url.replaceAll("[.,;:!?)]+$", "");
                 int port = URI.create(url).getPort();
                 if (port > 0) {
                     httpPort = port;

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -173,6 +173,19 @@ class QuarkusInstanceTest {
     }
 
     @Test
+    void detectsPortFromListeningOnLogWithMgmtInterface() throws Exception {
+        process = new ProcessBuilder("bash", "-c",
+                "echo 'my-app 1.0.0-SNAPSHOT on JVM (powered by Quarkus 3.33.1.1) started in 6.909s. Listening on: http://localhost:8080. Management interface listening on http://localhost:9000.' && sleep 5")
+                .start();
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
+
+        Thread.sleep(500);
+
+        assertEquals(8080, instance.getHttpPort());
+        assertEquals(QuarkusInstance.Status.RUNNING, instance.getStatus());
+    }
+
+    @Test
     void restartResetsPortAndStatus() throws Exception {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://localhost:8080' && cat")


### PR DESCRIPTION
When the management interface is enabled, Quarkus logs both ports in a single sentence ending with periods:

```
Listening on: http://localhost:8080. Management interface listening on http://localhost:9000.
```

The `parsePort` method extracted everything from `http://` to the next space, yielding `http://localhost:8080.` — the trailing dot caused `URI.create` to fail silently.

The fix strips trailing punctuation (`.,;:!?)`) from the extracted URL before parsing.

Fixes #185