### PR TITLE
Resolve Maven Command using option property `agent-mcp.process.mvn-cmd`

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
@@ -8,8 +8,11 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 final class ProcessUtils {
@@ -24,12 +27,15 @@ final class ProcessUtils {
     }
 
     static String resolveMavenCommand(File projectDir) {
-        boolean win = OS.WINDOWS.isCurrent();
-        File wrapper = win ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
-        if (wrapper.exists()) {
-            return win ? "mvnw.cmd" : "./mvnw";
-        }
-        return win ? "mvn.cmd" : "mvn";
+        Optional<String> mvnCmd = ConfigProvider.getConfig().getOptionalValue("agent-mcp.process.mvn-cmd", String.class);
+        return mvnCmd.orElseGet(() -> {
+            boolean win = OS.WINDOWS.isCurrent();
+            File wrapper = win ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
+            if (wrapper.exists()) {
+                return win ? "mvnw.cmd" : "./mvnw";
+            }
+            return win ? "mvn.cmd" : "mvn";
+        });
     }
 
     static String resolveGradleCommand(File projectDir) {

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -32,9 +32,6 @@ public class QuarkusProcessManager {
     @Inject
     ManagedExecutor executor;
 
-    @ConfigProperty(name = "agent-mcp.process.mvn-cmd")
-    Optional<String> mvnCmd;
-
     @ConfigProperty(name = "agent-mcp.process.gradle-cmd")
     Optional<String> gradleCmd;
 
@@ -192,8 +189,8 @@ public class QuarkusProcessManager {
     }
 
     private ProcessBuilder createMavenProcessBuilder(File projectDir, String mavenProfiles) {
-        String cmd = mvnCmd.orElseGet(() -> ProcessUtils.resolveMavenCommand(projectDir));
-        var command = new ArrayList<>(List.of(cmd, "quarkus:dev",
+        String mvnCmd = ProcessUtils.resolveMavenCommand(projectDir);
+        var command = new ArrayList<>(List.of(mvnCmd, "quarkus:dev",
                 "-Dquarkus.console.basic=true", "-Dquarkus.dev-mcp.enabled=true"));
         if (mavenProfiles != null && !mavenProfiles.isBlank()) {
             command.add("-P" + mavenProfiles.trim());


### PR DESCRIPTION
Use optional property in `agent-mcp.process.mvn-cmd` in `ProcessUtils.resolveMavenCommand(File)`, before defulting to the other options.
Fixes https://github.com/quarkusio/quarkus-agent-mcp/issues/189

