### PR TITLE
Use quarkus.http.non-application-root-path for Dev MCP endpoint URL

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -78,6 +78,9 @@ public class DevMcpProxyTools {
     @ConfigProperty(name = "agent-mcp.skills.include-transitive", defaultValue = "false")
     boolean includeTransitiveDeps;
 
+    @ConfigProperty(name = "quarkus.http.non-application-root-path", defaultValue = "/q")
+    String nonApplicationRootPath;
+
     @Tool(name = "quarkus_searchTools", description = "Discover available tools on the running Quarkus app's Dev MCP server. "
             + "Use this before interacting with the running app -- for testing, config, extensions, "
             + "endpoints, dev services, etc. Then use quarkus_callTool to invoke the discovered tool. "
@@ -610,7 +613,7 @@ public class DevMcpProxyTools {
                     "params", params));
 
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("http://localhost:" + port + "/q/dev-mcp"))
+                    .uri(URI.create("http://localhost:" + port + nonApplicationRootPath + "/dev-mcp"))
                     .header("Content-Type", "application/json")
                     .header("Accept", "application/json, text/event-stream")
                     .POST(HttpRequest.BodyPublishers.ofString(jsonRpcRequest))

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -95,7 +95,7 @@ public class DevMcpProxyTools {
                     + "Examples: 'test' for testing tools, 'config' for configuration, "
                     + "'extension' for extension management. If omitted, returns all tools.", required = false) String query) {
         try {
-            int port = resolvePort(projectDir);
+            int port = resolveDevMcpPort(projectDir);
             JsonNode tools = fetchDevMcpTools(port);
             if (tools == null || !tools.isArray()) {
                 return ToolResponse.success("No tools available from Dev MCP");
@@ -452,7 +452,7 @@ public class DevMcpProxyTools {
             @ToolArg(description = "Arguments to pass to the tool as a JSON string (matching the tool's inputSchema). "
                     + "Omit if the tool takes no arguments.", required = false) String toolArguments) {
         try {
-            int port = resolvePort(projectDir);
+            int port = resolveDevMcpPort(projectDir);
 
             Map<String, Object> params = new LinkedHashMap<>();
             params.put("name", toolName);
@@ -495,14 +495,26 @@ public class DevMcpProxyTools {
         }
     }
 
-    private int resolvePort(String projectDir) {
+    private int resolveDevMcpPort(String projectDir) {
+        QuarkusInstance instance = resolveInstance(projectDir);
+        int mgmtPort = instance.getManagementPort();
+        if (mgmtPort > 0) {
+            return mgmtPort;
+        }
+        int port = instance.getHttpPort();
+        if (port < 0) {
+            throw new IllegalStateException("Could not detect HTTP port for the running Quarkus application.");
+        }
+        return port;
+    }
+
+    private QuarkusInstance resolveInstance(String projectDir) {
         QuarkusInstance instance = processManager.getInstance(projectDir);
         if (instance == null) {
             throw new IllegalStateException(
                     "Quarkus application is not running at: " + projectDir + ". Start it first with quarkus_start.");
         }
 
-        // If the app is still starting, wait for it to become ready
         if (instance.getStatus() == QuarkusInstance.Status.STARTING) {
             QuarkusInstance.Status status = awaitStartup(instance, STARTUP_WAIT_SECONDS * 1000L, POLL_INTERVAL_MS);
             if (status == null) {
@@ -515,12 +527,7 @@ public class DevMcpProxyTools {
                     "Quarkus application is not running at: " + projectDir
                             + " (status: " + instance.getStatus() + "). Start it first with quarkus_start.");
         }
-
-        int port = instance.getHttpPort();
-        if (port < 0) {
-            throw new IllegalStateException("Could not detect HTTP port for the running Quarkus application.");
-        }
-        return port;
+        return instance;
     }
 
     /**

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -51,6 +51,7 @@ public class QuarkusInstance {
     private final LinkedList<String> logBuffer = new LinkedList<>();
     private final AtomicReference<Status> status = new AtomicReference<>(Status.STARTING);
     private volatile int httpPort = -1;
+    private volatile int managementPort = -1;
     private volatile PrintWriter logWriter;
     private volatile Path logFile;
 
@@ -76,6 +77,9 @@ public class QuarkusInstance {
 
                 if (line.contains("Listening on:")) {
                     parsePort(line);
+                }
+                if (line.contains("Management interface listening on")) {
+                    parseManagementPort(line);
                 }
                 if (status.get() == Status.STARTING && isStartedLine(line)) {
                     status.compareAndSet(Status.STARTING, Status.RUNNING);
@@ -105,6 +109,24 @@ public class QuarkusInstance {
     }
 
     private void parsePort(String line) {
+        int port = parsePortFromLine(line);
+        if (port > 0) {
+            httpPort = port;
+        }
+    }
+
+    private void parseManagementPort(String line) {
+        String clean = ANSI.matcher(line).replaceAll("");
+        int marker = clean.indexOf("Management interface listening on");
+        if (marker >= 0) {
+            int port = parsePortFromLine(clean.substring(marker));
+            if (port > 0) {
+                managementPort = port;
+            }
+        }
+    }
+
+    private int parsePortFromLine(String line) {
         String clean = ANSI.matcher(line).replaceAll("");
         int idx = clean.indexOf("http://");
         if (idx < 0) {
@@ -118,14 +140,12 @@ public class QuarkusInstance {
                     url = url.substring(0, spaceIdx);
                 }
                 url = url.replaceAll("[.,;:!?)]+$", "");
-                int port = URI.create(url).getPort();
-                if (port > 0) {
-                    httpPort = port;
-                }
+                return URI.create(url).getPort();
             } catch (IllegalArgumentException e) {
                 LOG.warnf("Failed to parse URL from log line: %s", line);
             }
         }
+        return -1;
     }
 
     private synchronized void appendLog(String line) {
@@ -204,6 +224,7 @@ public class QuarkusInstance {
         }
         status.set(Status.STARTING);
         httpPort = -1;
+        managementPort = -1;
         sendInput('s');
     }
 
@@ -233,6 +254,10 @@ public class QuarkusInstance {
 
     public int getHttpPort() {
         return httpPort;
+    }
+
+    public int getManagementPort() {
+        return managementPort;
     }
 
     public String getBuildTool() {

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -182,7 +182,21 @@ class QuarkusInstanceTest {
         Thread.sleep(500);
 
         assertEquals(8080, instance.getHttpPort());
+        assertEquals(9000, instance.getManagementPort());
         assertEquals(QuarkusInstance.Status.RUNNING, instance.getStatus());
+    }
+
+    @Test
+    void managementPortDefaultsToNegativeOne() throws Exception {
+        process = new ProcessBuilder("bash", "-c",
+                "echo 'Listening on: http://localhost:8080' && sleep 5")
+                .start();
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
+
+        Thread.sleep(500);
+
+        assertEquals(8080, instance.getHttpPort());
+        assertEquals(-1, instance.getManagementPort());
     }
 
     @Test


### PR DESCRIPTION
`DevMcpProxyTools.callDevMcp()` had `/q` hardcoded as the non-application root path, and always used the main HTTP port. This breaks two configurations:

1. **Custom non-application root path** — when `quarkus.http.non-application-root-path` is set to something other than `/q`, the Dev MCP endpoint URL was wrong.

2. **Management interface enabled** — when `quarkus.management.enabled=true`, non-application endpoints are served on a separate management port (default 9000), not the main HTTP port.

This PR injects the `quarkus.http.non-application-root-path` config property to build the URL dynamically, and teaches `QuarkusInstance` to parse the management port from the startup log so `DevMcpProxyTools` can use it when available.

Fixes #194