### PR TITLE
Discover Dev MCP endpoint path from managed app startup log

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -78,9 +78,6 @@ public class DevMcpProxyTools {
     @ConfigProperty(name = "agent-mcp.skills.include-transitive", defaultValue = "false")
     boolean includeTransitiveDeps;
 
-    @ConfigProperty(name = "quarkus.http.non-application-root-path", defaultValue = "/q")
-    String nonApplicationRootPath;
-
     @Tool(name = "quarkus_searchTools", description = "Discover available tools on the running Quarkus app's Dev MCP server. "
             + "Use this before interacting with the running app -- for testing, config, extensions, "
             + "endpoints, dev services, etc. Then use quarkus_callTool to invoke the discovered tool. "
@@ -95,8 +92,9 @@ public class DevMcpProxyTools {
                     + "Examples: 'test' for testing tools, 'config' for configuration, "
                     + "'extension' for extension management. If omitted, returns all tools.", required = false) String query) {
         try {
-            int port = resolveDevMcpPort(projectDir);
-            JsonNode tools = fetchDevMcpTools(port);
+            QuarkusInstance instance = resolveInstance(projectDir);
+            int port = getDevMcpPort(instance);
+            JsonNode tools = fetchDevMcpTools(port, instance.getDevMcpPath());
             if (tools == null || !tools.isArray()) {
                 return ToolResponse.success("No tools available from Dev MCP");
             }
@@ -452,7 +450,8 @@ public class DevMcpProxyTools {
             @ToolArg(description = "Arguments to pass to the tool as a JSON string (matching the tool's inputSchema). "
                     + "Omit if the tool takes no arguments.", required = false) String toolArguments) {
         try {
-            int port = resolveDevMcpPort(projectDir);
+            QuarkusInstance instance = resolveInstance(projectDir);
+            int port = getDevMcpPort(instance);
 
             Map<String, Object> params = new LinkedHashMap<>();
             params.put("name", toolName);
@@ -462,7 +461,7 @@ public class DevMcpProxyTools {
                 params.put("arguments", Map.of());
             }
 
-            JsonNode response = callDevMcp(port, "tools/call", params);
+            JsonNode response = callDevMcp(port, instance.getDevMcpPath(), "tools/call", params);
             ToolResponse result = extractToolResult(response);
 
             // Invalidate dependency cache and remind agent after structural changes
@@ -495,8 +494,7 @@ public class DevMcpProxyTools {
         }
     }
 
-    private int resolveDevMcpPort(String projectDir) {
-        QuarkusInstance instance = resolveInstance(projectDir);
+    private int getDevMcpPort(QuarkusInstance instance) {
         int mgmtPort = instance.getManagementPort();
         if (mgmtPort > 0) {
             return mgmtPort;
@@ -603,15 +601,15 @@ public class DevMcpProxyTools {
         return "";
     }
 
-    private JsonNode fetchDevMcpTools(int port) {
-        JsonNode result = callDevMcp(port, "tools/list", Map.of());
+    private JsonNode fetchDevMcpTools(int port, String devMcpPath) {
+        JsonNode result = callDevMcp(port, devMcpPath, "tools/list", Map.of());
         if (result != null && result.has("tools")) {
             return result.get("tools");
         }
         return null;
     }
 
-    private JsonNode callDevMcp(int port, String method, Map<String, Object> params) {
+    private JsonNode callDevMcp(int port, String devMcpPath, String method, Map<String, Object> params) {
         try {
             String jsonRpcRequest = mapper.writeValueAsString(Map.of(
                     "jsonrpc", "2.0",
@@ -620,7 +618,7 @@ public class DevMcpProxyTools {
                     "params", params));
 
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("http://localhost:" + port + nonApplicationRootPath + "/dev-mcp"))
+                    .uri(URI.create("http://localhost:" + port + devMcpPath))
                     .header("Content-Type", "application/json")
                     .header("Accept", "application/json, text/event-stream")
                     .POST(HttpRequest.BodyPublishers.ofString(jsonRpcRequest))

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -52,6 +52,7 @@ public class QuarkusInstance {
     private final AtomicReference<Status> status = new AtomicReference<>(Status.STARTING);
     private volatile int httpPort = -1;
     private volatile int managementPort = -1;
+    private volatile String devMcpPath;
     private volatile PrintWriter logWriter;
     private volatile Path logFile;
 
@@ -80,6 +81,9 @@ public class QuarkusInstance {
                 }
                 if (line.contains("Management interface listening on")) {
                     parseManagementPort(line);
+                }
+                if (line.contains("Dev MCP available at:")) {
+                    parseDevMcpPath(line);
                 }
                 if (status.get() == Status.STARTING && isStartedLine(line)) {
                     status.compareAndSet(Status.STARTING, Status.RUNNING);
@@ -122,6 +126,18 @@ public class QuarkusInstance {
             int port = parsePortFromLine(clean.substring(marker));
             if (port > 0) {
                 managementPort = port;
+            }
+        }
+    }
+
+    private void parseDevMcpPath(String line) {
+        String clean = ANSI.matcher(line).replaceAll("");
+        String marker = "Dev MCP available at:";
+        int idx = clean.indexOf(marker);
+        if (idx >= 0) {
+            String path = clean.substring(idx + marker.length()).trim();
+            if (!path.isEmpty()) {
+                devMcpPath = path;
             }
         }
     }
@@ -225,6 +241,7 @@ public class QuarkusInstance {
         status.set(Status.STARTING);
         httpPort = -1;
         managementPort = -1;
+        devMcpPath = null;
         sendInput('s');
     }
 
@@ -258,6 +275,11 @@ public class QuarkusInstance {
 
     public int getManagementPort() {
         return managementPort;
+    }
+
+    public String getDevMcpPath() {
+        String path = devMcpPath;
+        return path != null ? path : "/q/dev-mcp";
     }
 
     public String getBuildTool() {

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -200,6 +200,57 @@ class QuarkusInstanceTest {
     }
 
     @Test
+    void detectsDevMcpPathFromLog() throws Exception {
+        process = new ProcessBuilder("bash", "-c",
+                "echo 'Listening on: http://localhost:8080' && echo 'Dev MCP available at: /custom/dev-mcp' && sleep 5")
+                .start();
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
+
+        Thread.sleep(500);
+
+        assertEquals("/custom/dev-mcp", instance.getDevMcpPath());
+    }
+
+    @Test
+    void devMcpPathDefaultsWhenLogLineAbsent() throws Exception {
+        process = new ProcessBuilder("bash", "-c",
+                "echo 'Listening on: http://localhost:8080' && sleep 5")
+                .start();
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
+
+        Thread.sleep(500);
+
+        assertEquals("/q/dev-mcp", instance.getDevMcpPath());
+    }
+
+    @Test
+    void detectsDevMcpPathWithAnsiCodes() throws Exception {
+        process = new ProcessBuilder("bash", "-c",
+                "printf 'Listening on: http://localhost:8080\\n' && printf '\\033[32mDev MCP available at: /my-root/dev-mcp\\033[0m\\n' && sleep 5")
+                .start();
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
+
+        Thread.sleep(500);
+
+        assertEquals("/my-root/dev-mcp", instance.getDevMcpPath());
+    }
+
+    @Test
+    void restartResetsDevMcpPath() throws Exception {
+        process = new ProcessBuilder("bash", "-c",
+                "echo 'Listening on: http://localhost:8080' && echo 'Dev MCP available at: /custom/dev-mcp' && cat")
+                .start();
+        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
+
+        Thread.sleep(500);
+        assertEquals("/custom/dev-mcp", instance.getDevMcpPath());
+
+        instance.restart();
+
+        assertEquals("/q/dev-mcp", instance.getDevMcpPath());
+    }
+
+    @Test
     void restartResetsPortAndStatus() throws Exception {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://localhost:8080' && cat")


### PR DESCRIPTION
The previous fix for #194 read `quarkus.http.non-application-root-path` from the agent's own config, which doesn't help when the *managed* application configures a different value.

This reverts that approach and instead parses the `Dev MCP available at:` log line that Quarkus now emits at startup (quarkusio/quarkus#54829) to discover the actual endpoint path at runtime. For older Quarkus versions that don't emit the line, the path falls back to `/q/dev-mcp`.

Fixes #194