### PR TITLE
Add migration workflow to server instructions

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,6 +17,10 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   2. quarkus_skills -- learn extension-specific patterns before writing code\n\
   3. Write code following patterns from skills and docs\n\
   4. Run tests with quarkus_callTool\n\n\
+  WORKFLOW for migrating Spring Boot to Quarkus:\n\
+  1. quarkus_skills -- call with the Spring project's directory to discover the migration skill (migrate-spring-to-quarkus)\n\
+  2. Read and follow the migration skill instructions -- it provides a complete modular, gate-driven migration process\n\
+  3. Do NOT plan your own migration approach -- the skill handles strategy selection, module execution, and verification\n\n\
   TESTING:\n\
   - Use quarkus_callTool with toolName 'devui-testing_runTests' to run all tests\n\
   - Use quarkus_callTool with toolName 'devui-testing_runTest' and toolArguments '{"className":"com.example.MyTest"}' for a specific test\n\


### PR DESCRIPTION
When a user asks an AI agent to migrate a Spring Boot application to Quarkus, the agent currently has no indication that a dedicated migration skill (`migrate-spring-to-quarkus`) exists. The MCP server instructions define workflows for "new projects" and "existing projects", but nothing for migration — so the agent improvises its own approach from scratch, missing the structured, gate-driven process the skill provides.

This adds a "WORKFLOW for migrating Spring Boot to Quarkus" section to the server instructions that directs the agent to call `quarkus_skills` first and follow the migration skill rather than planning independently.