### PR TITLE
Stop using management port for Dev MCP endpoint

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -418,10 +418,6 @@ public class DevMcpProxyTools {
     }
 
     private int getDevMcpPort(QuarkusInstance instance) {
-        int mgmtPort = instance.getManagementPort();
-        if (mgmtPort > 0) {
-            return mgmtPort;
-        }
         int port = instance.getHttpPort();
         if (port < 0) {
             throw new IllegalStateException("Could not detect HTTP port for the running Quarkus application.");

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -51,7 +51,6 @@ public class QuarkusInstance {
     private final LinkedList<String> logBuffer = new LinkedList<>();
     private final AtomicReference<Status> status = new AtomicReference<>(Status.STARTING);
     private volatile int httpPort = -1;
-    private volatile int managementPort = -1;
     private volatile String devMcpPath;
     private volatile PrintWriter logWriter;
     private volatile Path logFile;
@@ -78,9 +77,6 @@ public class QuarkusInstance {
 
                 if (line.contains("Listening on:")) {
                     parsePort(line);
-                }
-                if (line.contains("Management interface listening on")) {
-                    parseManagementPort(line);
                 }
                 if (line.contains("Dev MCP available at:")) {
                     parseDevMcpPath(line);
@@ -116,17 +112,6 @@ public class QuarkusInstance {
         int port = parsePortFromLine(line);
         if (port > 0) {
             httpPort = port;
-        }
-    }
-
-    private void parseManagementPort(String line) {
-        String clean = ANSI.matcher(line).replaceAll("");
-        int marker = clean.indexOf("Management interface listening on");
-        if (marker >= 0) {
-            int port = parsePortFromLine(clean.substring(marker));
-            if (port > 0) {
-                managementPort = port;
-            }
         }
     }
 
@@ -240,7 +225,6 @@ public class QuarkusInstance {
         }
         status.set(Status.STARTING);
         httpPort = -1;
-        managementPort = -1;
         devMcpPath = null;
         sendInput('s');
     }
@@ -271,10 +255,6 @@ public class QuarkusInstance {
 
     public int getHttpPort() {
         return httpPort;
-    }
-
-    public int getManagementPort() {
-        return managementPort;
     }
 
     public String getDevMcpPath() {

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -182,21 +182,7 @@ class QuarkusInstanceTest {
         Thread.sleep(500);
 
         assertEquals(8080, instance.getHttpPort());
-        assertEquals(9000, instance.getManagementPort());
         assertEquals(QuarkusInstance.Status.RUNNING, instance.getStatus());
-    }
-
-    @Test
-    void managementPortDefaultsToNegativeOne() throws Exception {
-        process = new ProcessBuilder("bash", "-c",
-                "echo 'Listening on: http://localhost:8080' && sleep 5")
-                .start();
-        QuarkusInstance instance = new QuarkusInstance("/test/project", "maven", null, null, process, executor);
-
-        Thread.sleep(500);
-
-        assertEquals(8080, instance.getHttpPort());
-        assertEquals(-1, instance.getManagementPort());
     }
 
     @Test


### PR DESCRIPTION
Dev UI and Dev MCP always run on the main HTTP port, never on the management interface — the route registration in Quarkus core (`MCPProcessor.java`, `DevUIProcessor.java`) never calls `.management()` on the route builder and there is no config property to change this (unlike e.g. SmallRye OpenAPI which has `quarkus.smallrye-openapi.management.enabled`).

The management port preference introduced in #195 causes 404 errors for users with `quarkus.management.enabled=true`, as reported by @vsevel in https://github.com/quarkusio/quarkus-agent-mcp/pull/195#issuecomment-4719275516.

This removes the management port tracking from `QuarkusInstance` entirely since it was only added for this incorrect use case and has no other consumers.

Fixes the remaining issue from #194.