### PR TITLE
Pass Maven server credentials when downloading artifacts from authenticated repositories

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -211,20 +211,26 @@ public class RagSqlLoader {
             return null;
         }
 
-        String baseUrl = SkillReader.resolveMavenRepoBaseUrl(null);
+        SkillReader.MavenRepoInfo repoInfo = SkillReader.resolveMavenRepoInfo(null);
         String artifactPath = "/" + AGGREGATED_GROUP_PATH + "/" + AGGREGATED_ARTIFACT_ID
                 + "/" + version
                 + "/" + AGGREGATED_ARTIFACT_ID + "-" + version + ".jar";
-        String url = baseUrl + artifactPath;
+        String url = repoInfo.url() + artifactPath;
 
         LOG.infof("RAG SQL not found locally, downloading from %s...", url);
 
         try {
-            HttpRequest request = HttpRequest.newBuilder()
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .timeout(Duration.ofSeconds(60))
-                    .GET()
-                    .build();
+                    .GET();
+
+            SkillReader.ServerCredentials credentials = SkillReader.resolveServerCredentials(null, repoInfo.serverId());
+            if (credentials != null) {
+                requestBuilder.header("Authorization", SkillReader.buildAuthHeader(credentials));
+            }
+
+            HttpRequest request = requestBuilder.build();
 
             HttpResponse<InputStream> response = HttpClientProvider.getHttpClient().send(request,
                     HttpResponse.BodyHandlers.ofInputStream());

--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -225,13 +225,7 @@ public class RagSqlLoader {
                     .timeout(Duration.ofSeconds(60))
                     .GET();
 
-            SkillReader.ServerCredentials credentials = repoInfo.credentials();
-            if (credentials == null) {
-                credentials = SkillReader.resolveServerCredentials(null, repoInfo.serverId());
-            }
-            if (credentials != null) {
-                requestBuilder.header("Authorization", SkillReader.buildAuthHeader(credentials));
-            }
+            SkillReader.addAuthHeader(requestBuilder, repoInfo, null);
 
             HttpRequest request = requestBuilder.build();
 

--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -225,7 +225,10 @@ public class RagSqlLoader {
                     .timeout(Duration.ofSeconds(60))
                     .GET();
 
-            SkillReader.ServerCredentials credentials = SkillReader.resolveServerCredentials(null, repoInfo.serverId());
+            SkillReader.ServerCredentials credentials = repoInfo.credentials();
+            if (credentials == null) {
+                credentials = SkillReader.resolveServerCredentials(null, repoInfo.serverId());
+            }
             if (credentials != null) {
                 requestBuilder.header("Authorization", SkillReader.buildAuthHeader(credentials));
             }

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -76,10 +76,14 @@ public final class SkillReader {
     private static final String DEV_SUFFIX = "-dev";
     private static final String MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2";
 
-    record MavenRepoInfo(String url, String serverId) {
+    record MavenRepoInfo(String url, String serverId, ServerCredentials credentials) {
     }
 
     record ServerCredentials(String username, String password) {
+        @Override
+        public String toString() {
+            return "ServerCredentials[username=" + username + ", password=***]";
+        }
     }
 
     // Jandex annotation names for MCP tool discovery
@@ -1035,7 +1039,10 @@ public final class SkillReader {
                     .timeout(Duration.ofSeconds(30))
                     .GET();
 
-            ServerCredentials credentials = resolveServerCredentials(projectDir, repoInfo.serverId());
+            ServerCredentials credentials = repoInfo.credentials();
+            if (credentials == null) {
+                credentials = resolveServerCredentials(projectDir, repoInfo.serverId());
+            }
             if (credentials != null) {
                 requestBuilder.header("Authorization", buildAuthHeader(credentials));
             }
@@ -1085,7 +1092,7 @@ public final class SkillReader {
 
     static MavenRepoInfo resolveMavenRepoInfo(String projectDir) {
         MavenRepoInfo info = findInSettingsFiles(projectDir, "mirror", SkillReader::parseMirrorInfo);
-        return info != null ? info : new MavenRepoInfo(MAVEN_CENTRAL_BASE, null);
+        return info != null ? info : new MavenRepoInfo(MAVEN_CENTRAL_BASE, null, null);
     }
 
     /**
@@ -1222,7 +1229,8 @@ public final class SkillReader {
                 if (mirrorOf != null && url != null && mirrorOfMatchesCentral(mirrorOf)) {
                     String cleanUrl = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
                     String id = getChildText(mirror, "id");
-                    return new MavenRepoInfo(cleanUrl, id);
+                    ServerCredentials credentials = id != null ? findServerInDocument(doc, id) : null;
+                    return new MavenRepoInfo(cleanUrl, id, credentials);
                 }
             }
         } catch (Exception e) {
@@ -1244,26 +1252,34 @@ public final class SkillReader {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             Document doc = factory.newDocumentBuilder().parse(settingsFile.toFile());
-
-            NodeList servers = doc.getElementsByTagName("server");
-            for (int i = 0; i < servers.getLength(); i++) {
-                Element server = (Element) servers.item(i);
-                String id = getChildText(server, "id");
-                if (serverId.equals(id)) {
-                    String username = getChildText(server, "username");
-                    String password = getChildText(server, "password");
-                    if (username != null && password != null) {
-                        return new ServerCredentials(username, password);
-                    }
-                }
-            }
+            return findServerInDocument(doc, serverId);
         } catch (Exception e) {
             LOG.warnf("Failed to parse server credentials from %s: %s", settingsFile, e.getMessage());
         }
         return null;
     }
 
+    private static ServerCredentials findServerInDocument(Document doc, String serverId) {
+        NodeList servers = doc.getElementsByTagName("server");
+        for (int i = 0; i < servers.getLength(); i++) {
+            Element server = (Element) servers.item(i);
+            String id = getChildText(server, "id");
+            if (serverId.equals(id)) {
+                String username = getChildText(server, "username");
+                String password = getChildText(server, "password");
+                if (username != null && password != null) {
+                    return new ServerCredentials(username, password);
+                }
+            }
+        }
+        return null;
+    }
+
     static String buildAuthHeader(ServerCredentials credentials) {
+        if (credentials.password().startsWith("{") && credentials.password().endsWith("}")) {
+            LOG.warnf("Password for user '%s' appears to be Maven-encrypted; encrypted passwords are not supported",
+                    credentials.username());
+        }
         String value = credentials.username() + ":" + credentials.password();
         return "Basic " + Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -1039,13 +1039,7 @@ public final class SkillReader {
                     .timeout(Duration.ofSeconds(30))
                     .GET();
 
-            ServerCredentials credentials = repoInfo.credentials();
-            if (credentials == null) {
-                credentials = resolveServerCredentials(projectDir, repoInfo.serverId());
-            }
-            if (credentials != null) {
-                requestBuilder.header("Authorization", buildAuthHeader(credentials));
-            }
+            addAuthHeader(requestBuilder, repoInfo, projectDir);
 
             HttpRequest request = requestBuilder.build();
 
@@ -1273,6 +1267,16 @@ public final class SkillReader {
             }
         }
         return null;
+    }
+
+    static void addAuthHeader(HttpRequest.Builder builder, MavenRepoInfo repoInfo, String projectDir) {
+        ServerCredentials credentials = repoInfo.credentials();
+        if (credentials == null) {
+            credentials = resolveServerCredentials(projectDir, repoInfo.serverId());
+        }
+        if (credentials != null) {
+            builder.header("Authorization", buildAuthHeader(credentials));
+        }
     }
 
     static String buildAuthHeader(ServerCredentials credentials) {

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -11,6 +11,7 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -74,6 +75,12 @@ public final class SkillReader {
     private static final String DEPLOYMENT_SUFFIX = "-deployment";
     private static final String DEV_SUFFIX = "-dev";
     private static final String MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2";
+
+    record MavenRepoInfo(String url, String serverId) {
+    }
+
+    record ServerCredentials(String username, String password) {
+    }
 
     // Jandex annotation names for MCP tool discovery
     private static final DotName JSON_RPC_DESCRIPTION = DotName
@@ -1014,20 +1021,26 @@ public final class SkillReader {
             return null;
         }
 
-        String baseUrl = resolveMavenRepoBaseUrl(projectDir);
+        MavenRepoInfo repoInfo = resolveMavenRepoInfo(projectDir);
         String artifactPath = "/io/quarkus/" + SKILLS_ARTIFACT_ID
                 + "/" + version
                 + "/" + SKILLS_ARTIFACT_ID + "-" + version + ".jar";
-        String url = baseUrl + artifactPath;
+        String url = repoInfo.url() + artifactPath;
 
         LOG.debugf("Downloading skills JAR from %s", url);
 
         try {
-            HttpRequest request = HttpRequest.newBuilder()
+            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .timeout(Duration.ofSeconds(30))
-                    .GET()
-                    .build();
+                    .GET();
+
+            ServerCredentials credentials = resolveServerCredentials(projectDir, repoInfo.serverId());
+            if (credentials != null) {
+                requestBuilder.header("Authorization", buildAuthHeader(credentials));
+            }
+
+            HttpRequest request = requestBuilder.build();
 
             HttpResponse<InputStream> response = HttpClientProvider.getHttpClient().send(request,
                     HttpResponse.BodyHandlers.ofInputStream());
@@ -1067,8 +1080,12 @@ public final class SkillReader {
      * @param projectDir the project directory (may be null)
      */
     static String resolveMavenRepoBaseUrl(String projectDir) {
-        String url = findInSettingsFiles(projectDir, "mirror", SkillReader::parseMirrorUrl);
-        return url != null ? url : MAVEN_CENTRAL_BASE;
+        return resolveMavenRepoInfo(projectDir).url();
+    }
+
+    static MavenRepoInfo resolveMavenRepoInfo(String projectDir) {
+        MavenRepoInfo info = findInSettingsFiles(projectDir, "mirror", SkillReader::parseMirrorInfo);
+        return info != null ? info : new MavenRepoInfo(MAVEN_CENTRAL_BASE, null);
     }
 
     /**
@@ -1186,9 +1203,13 @@ public final class SkillReader {
      * Returns the mirror URL (without trailing slash), or null if none found.
      */
     static String parseMirrorUrl(Path settingsFile) {
+        MavenRepoInfo info = parseMirrorInfo(settingsFile);
+        return info != null ? info.url() : null;
+    }
+
+    static MavenRepoInfo parseMirrorInfo(Path settingsFile) {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            // Disable external entities for security
             factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             Document doc = factory.newDocumentBuilder().parse(settingsFile.toFile());
 
@@ -1199,14 +1220,52 @@ public final class SkillReader {
                 String url = getChildText(mirror, "url");
 
                 if (mirrorOf != null && url != null && mirrorOfMatchesCentral(mirrorOf)) {
-                    // Strip trailing slash for consistent path joining
-                    return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+                    String cleanUrl = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+                    String id = getChildText(mirror, "id");
+                    return new MavenRepoInfo(cleanUrl, id);
                 }
             }
         } catch (Exception e) {
             LOG.warnf("Failed to parse settings.xml at %s: %s", settingsFile, e.getMessage());
         }
         return null;
+    }
+
+    static ServerCredentials resolveServerCredentials(String projectDir, String serverId) {
+        if (serverId == null) {
+            return null;
+        }
+        return findInSettingsFiles(projectDir, "server credentials",
+                path -> parseServerCredentials(path, serverId));
+    }
+
+    static ServerCredentials parseServerCredentials(Path settingsFile, String serverId) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            Document doc = factory.newDocumentBuilder().parse(settingsFile.toFile());
+
+            NodeList servers = doc.getElementsByTagName("server");
+            for (int i = 0; i < servers.getLength(); i++) {
+                Element server = (Element) servers.item(i);
+                String id = getChildText(server, "id");
+                if (serverId.equals(id)) {
+                    String username = getChildText(server, "username");
+                    String password = getChildText(server, "password");
+                    if (username != null && password != null) {
+                        return new ServerCredentials(username, password);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.warnf("Failed to parse server credentials from %s: %s", settingsFile, e.getMessage());
+        }
+        return null;
+    }
+
+    static String buildAuthHeader(ServerCredentials credentials) {
+        String value = credentials.username() + ":" + credentials.password();
+        return "Basic " + Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -396,6 +396,39 @@ class SkillReaderTest {
         assertNotNull(info);
         assertEquals("https://artifactory.company.com/maven-central", info.url());
         assertEquals("company-mirror", info.serverId());
+        assertNull(info.credentials());
+    }
+
+    @Test
+    void parseMirrorInfoExtractsCredentialsFromSameFile() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <mirrors>
+                        <mirror>
+                            <id>company-mirror</id>
+                            <url>https://artifactory.company.com/maven-central/</url>
+                            <mirrorOf>*</mirrorOf>
+                        </mirror>
+                    </mirrors>
+                    <servers>
+                        <server>
+                            <id>company-mirror</id>
+                            <username>myuser</username>
+                            <password>mypassword</password>
+                        </server>
+                    </servers>
+                </settings>
+                """);
+
+        SkillReader.MavenRepoInfo info = SkillReader.parseMirrorInfo(settingsFile);
+
+        assertNotNull(info);
+        assertEquals("https://artifactory.company.com/maven-central", info.url());
+        assertEquals("company-mirror", info.serverId());
+        assertNotNull(info.credentials());
+        assertEquals("myuser", info.credentials().username());
+        assertEquals("mypassword", info.credentials().password());
     }
 
     @Test
@@ -408,6 +441,18 @@ class SkillReaderTest {
                 """);
 
         assertNull(SkillReader.parseMirrorInfo(settingsFile));
+    }
+
+    // --- resolveMavenRepoInfo tests ---
+
+    @Test
+    void resolveMavenRepoInfoDefaultsToMavenCentral() {
+        SkillReader.MavenRepoInfo info = SkillReader.resolveMavenRepoInfo("/nonexistent/project");
+
+        assertNotNull(info);
+        assertEquals("https://repo1.maven.org/maven2", info.url());
+        assertNull(info.serverId());
+        assertNull(info.credentials());
     }
 
     // --- parseServerCredentials tests ---
@@ -497,6 +542,14 @@ class SkillReaderTest {
         SkillReader.ServerCredentials creds = new SkillReader.ServerCredentials("user", "pass");
         String header = SkillReader.buildAuthHeader(creds);
         assertEquals("Basic dXNlcjpwYXNz", header);
+    }
+
+    @Test
+    void buildAuthHeaderStillWorksWithEncryptedPassword() {
+        SkillReader.ServerCredentials creds = new SkillReader.ServerCredentials("user", "{encryptedValue}");
+        String header = SkillReader.buildAuthHeader(creds);
+        assertNotNull(header);
+        assertTrue(header.startsWith("Basic "));
     }
 
     // --- parseLocalRepository tests ---

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -374,6 +374,131 @@ class SkillReaderTest {
         assertNull(url);
     }
 
+    // --- parseMirrorInfo tests ---
+
+    @Test
+    void parseMirrorInfoReturnsBothUrlAndId() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <mirrors>
+                        <mirror>
+                            <id>company-mirror</id>
+                            <url>https://artifactory.company.com/maven-central/</url>
+                            <mirrorOf>*</mirrorOf>
+                        </mirror>
+                    </mirrors>
+                </settings>
+                """);
+
+        SkillReader.MavenRepoInfo info = SkillReader.parseMirrorInfo(settingsFile);
+
+        assertNotNull(info);
+        assertEquals("https://artifactory.company.com/maven-central", info.url());
+        assertEquals("company-mirror", info.serverId());
+    }
+
+    @Test
+    void parseMirrorInfoReturnsNullWhenNoMirror() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <profiles><profile><id>x</id></profile></profiles>
+                </settings>
+                """);
+
+        assertNull(SkillReader.parseMirrorInfo(settingsFile));
+    }
+
+    // --- parseServerCredentials tests ---
+
+    @Test
+    void parseServerCredentialsFindsMatchingServer() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <servers>
+                        <server>
+                            <id>other-repo</id>
+                            <username>other</username>
+                            <password>other-pass</password>
+                        </server>
+                        <server>
+                            <id>company-mirror</id>
+                            <username>myuser</username>
+                            <password>mypassword</password>
+                        </server>
+                    </servers>
+                </settings>
+                """);
+
+        SkillReader.ServerCredentials creds = SkillReader.parseServerCredentials(settingsFile, "company-mirror");
+
+        assertNotNull(creds);
+        assertEquals("myuser", creds.username());
+        assertEquals("mypassword", creds.password());
+    }
+
+    @Test
+    void parseServerCredentialsReturnsNullWhenNoMatch() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <servers>
+                        <server>
+                            <id>other-repo</id>
+                            <username>other</username>
+                            <password>other-pass</password>
+                        </server>
+                    </servers>
+                </settings>
+                """);
+
+        assertNull(SkillReader.parseServerCredentials(settingsFile, "company-mirror"));
+    }
+
+    @Test
+    void parseServerCredentialsReturnsNullWhenNoServersSection() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <mirrors>
+                        <mirror>
+                            <id>company-mirror</id>
+                            <url>https://mirror.example.com/maven/</url>
+                            <mirrorOf>*</mirrorOf>
+                        </mirror>
+                    </mirrors>
+                </settings>
+                """);
+
+        assertNull(SkillReader.parseServerCredentials(settingsFile, "company-mirror"));
+    }
+
+    @Test
+    void parseServerCredentialsReturnsNullWhenPasswordMissing() throws Exception {
+        Path settingsFile = tempDir.resolve("settings.xml");
+        Files.writeString(settingsFile, """
+                <settings>
+                    <servers>
+                        <server>
+                            <id>company-mirror</id>
+                            <username>myuser</username>
+                        </server>
+                    </servers>
+                </settings>
+                """);
+
+        assertNull(SkillReader.parseServerCredentials(settingsFile, "company-mirror"));
+    }
+
+    @Test
+    void buildAuthHeaderEncodesCredentials() {
+        SkillReader.ServerCredentials creds = new SkillReader.ServerCredentials("user", "pass");
+        String header = SkillReader.buildAuthHeader(creds);
+        assertEquals("Basic dXNlcjpwYXNz", header);
+    }
+
     // --- parseLocalRepository tests ---
 
     @Test


### PR DESCRIPTION
When the Maven repository is an authenticated mirror (e.g. corporate Artifactory), downloading the `quarkus-documentation-core-rag` and `quarkus-extension-skills` JARs fails with HTTP 401 because no credentials are sent with the request.

The code already resolves mirror URLs from `settings.xml`, but never reads `<server>` credentials. This change reads the mirror's `<id>`, matches it against `<server>` entries in `settings.xml`, and adds a `Basic` auth header to artifact download requests when credentials are found.

Reported by @vsevel

Fixes #206