### PR TITLE
Support module files in skills and resolve latest Quarkus version

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -141,11 +141,13 @@ public class DevMcpProxyTools {
         try {
             Path effectiveLocalDir = localSkillsDir.map(Path::of).orElse(null);
             String queryLower = (query != null && !query.isBlank()) ? query.toLowerCase() : null;
-            boolean needsContent = queryLower != null;
+            boolean needsModuleOnly = module != null && !module.isBlank();
+            boolean needsContent = queryLower != null && !needsModuleOnly;
 
-            // When a query is provided we need full content; otherwise read metadata only
-            List<SkillReader.SkillInfo> skills = SkillReader.readSkills(projectDir, effectiveLocalDir, !needsContent,
-                    includeTransitiveDeps);
+            // When a query is provided we need full content; module-only requests skip body but load modules
+            List<SkillReader.SkillInfo> skills = SkillReader.readSkills(projectDir, effectiveLocalDir,
+                    !needsContent && !needsModuleOnly, includeTransitiveDeps,
+                    needsContent || needsModuleOnly);
 
             // If no skills found, check if the app is still building and wait for it
             if (skills.isEmpty()) {

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -120,6 +120,8 @@ public class DevMcpProxyTools {
             + "If the app is still building (just created), this will wait for the build to complete. "
             + "Skills may include an 'Available Dev MCP Tools' section listing extension-specific Dev MCP tools "
             + "that can be invoked via quarkus_callTool (e.g. OpenAPI schema retrieval, scheduler job management). "
+            + "Some skills include module files (e.g., code patterns, reference tables) that can be loaded individually "
+            + "using the 'module' parameter. The skill content lists available modules at the bottom. "
             + "Skills can be customized globally using quarkus_updateSkill (writes to ~/.quarkus/skills/). "
             + "Project-level skills in .agent/skills/ are standalone files readable by any agent -- "
             + "use quarkus_saveSkill to materialize a fully composed skill there, then edit directly.",
@@ -131,7 +133,11 @@ public class DevMcpProxyTools {
             @ToolArg(description = "Optional query to filter skills by extension name (case-insensitive). "
                     + "Supports comma-separated names to fetch multiple skills at once "
                     + "(e.g., 'panache,rest,hibernate-validator'). "
-                    + "If omitted, lists all available skills with their descriptions.", required = false) String query) {
+                    + "If omitted, lists all available skills with their descriptions.", required = false) String query,
+            @ToolArg(description = "Optional module path to load from a skill "
+                    + "(e.g., 'modules/build.md', 'references/dependency-map.md'). "
+                    + "Requires 'query' to identify which skill the module belongs to. "
+                    + "Available module paths are listed in the skill's output.", required = false) String module) {
         try {
             Path effectiveLocalDir = localSkillsDir.map(Path::of).orElse(null);
             String queryLower = (query != null && !query.isBlank()) ? query.toLowerCase() : null;
@@ -169,6 +175,23 @@ public class DevMcpProxyTools {
                 return ToolResponse.success("No skills found matching: " + query);
             }
 
+            // Module loading: return a specific module file from a skill
+            if (module != null && !module.isBlank()) {
+                if (matched.size() != 1) {
+                    return ToolResponse.error("Specify a single skill name in 'query' when loading a module. "
+                            + "Matched: " + matched.stream().map(SkillReader.SkillInfo::name).toList());
+                }
+                SkillReader.SkillInfo skill = matched.get(0);
+                if (skill.modules() == null || !skill.modules().containsKey(module)) {
+                    String available = skill.modules() != null
+                            ? String.join(", ", skill.modules().keySet())
+                            : "none";
+                    return ToolResponse.error("Module '" + module + "' not found in skill '" + skill.name()
+                            + "'. Available modules: " + available);
+                }
+                return ToolResponse.success(skill.modules().get(module));
+            }
+
             // Multiple skills and no query — return categorized index
             if (queryLower == null && matched.size() > 1) {
                 return ToolResponse.success(formatSkillIndex(matched));
@@ -180,14 +203,30 @@ public class DevMcpProxyTools {
                 matched = skills;
             }
 
+            // Resolve latest Quarkus version for context
+            String latestVersion = LatestQuarkusVersionResolver.resolve(projectDir);
+
             // Return full content for matched skills
             StringBuilder sb = new StringBuilder();
+            if (latestVersion != null) {
+                sb.append("> **Latest Quarkus release:** ").append(latestVersion).append("\n\n");
+            }
+            boolean first = true;
             for (SkillReader.SkillInfo skill : matched) {
-                if (!sb.isEmpty()) {
+                if (!first) {
                     sb.append("\n---\n\n");
                 }
+                first = false;
                 sb.append("# ").append(skill.name()).append("\n\n");
                 sb.append(skill.content());
+                if (skill.modules() != null && !skill.modules().isEmpty()) {
+                    sb.append("\n\n---\n\n### Available Modules\n\n");
+                    sb.append("Load a module with `quarkus_skills query='").append(skill.name())
+                            .append("' module='<path>'`:\n\n");
+                    for (String modulePath : skill.modules().keySet()) {
+                        sb.append("- `").append(modulePath).append("`\n");
+                    }
+                }
             }
             return ToolResponse.success(sb.toString());
         } catch (Exception e) {

--- a/src/main/java/io/quarkus/agent/mcp/LatestQuarkusVersionResolver.java
+++ b/src/main/java/io/quarkus/agent/mcp/LatestQuarkusVersionResolver.java
@@ -1,0 +1,76 @@
+package io.quarkus.agent.mcp;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jboss.logging.Logger;
+
+/**
+ * Resolves the latest released Quarkus version from Maven Central (or a configured mirror).
+ * Results are cached with a 1-hour TTL to avoid repeated HTTP calls.
+ */
+public final class LatestQuarkusVersionResolver {
+
+    private static final Logger LOG = Logger.getLogger(LatestQuarkusVersionResolver.class);
+    private static final long CACHE_TTL_MS = 3_600_000;
+    private static final Pattern RELEASE_PATTERN = Pattern.compile("<release>([^<]+)</release>");
+
+    private static volatile String cachedVersion;
+    private static volatile long cacheTimestamp;
+
+    private LatestQuarkusVersionResolver() {
+    }
+
+    public static String resolve(String projectDir) {
+        if (cachedVersion != null && System.currentTimeMillis() - cacheTimestamp < CACHE_TTL_MS) {
+            return cachedVersion;
+        }
+        return doResolve(projectDir);
+    }
+
+    private static synchronized String doResolve(String projectDir) {
+        if (cachedVersion != null && System.currentTimeMillis() - cacheTimestamp < CACHE_TTL_MS) {
+            return cachedVersion;
+        }
+
+        String baseUrl = SkillReader.resolveMavenRepoBaseUrl(projectDir);
+        String metadataUrl = baseUrl + "/io/quarkus/quarkus-bom/maven-metadata.xml";
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(metadataUrl))
+                    .timeout(Duration.ofSeconds(10))
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = HttpClientProvider.getHttpClient()
+                    .send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                String version = parseRelease(response.body());
+                if (version != null) {
+                    cachedVersion = version;
+                    cacheTimestamp = System.currentTimeMillis();
+                    LOG.debugf("Resolved latest Quarkus version: %s", version);
+                    return version;
+                }
+            }
+        } catch (Exception e) {
+            LOG.debugf("Failed to resolve latest Quarkus version from %s: %s", metadataUrl, e.getMessage());
+        }
+        return cachedVersion;
+    }
+
+    static String parseRelease(String xml) {
+        Matcher m = RELEASE_PATTERN.matcher(xml);
+        return m.find() ? m.group(1).trim() : null;
+    }
+
+    static void invalidateCache() {
+        cachedVersion = null;
+        cacheTimestamp = 0;
+    }
+}

--- a/src/main/java/io/quarkus/agent/mcp/LatestQuarkusVersionResolver.java
+++ b/src/main/java/io/quarkus/agent/mcp/LatestQuarkusVersionResolver.java
@@ -4,13 +4,16 @@ import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jboss.logging.Logger;
 
 /**
  * Resolves the latest released Quarkus version from Maven Central (or a configured mirror).
- * Results are cached with a 1-hour TTL to avoid repeated HTTP calls.
+ * Results are cached with a 1-hour TTL. Resolution is non-blocking: returns the cached value
+ * immediately and triggers an async refresh when stale, so skill responses are never delayed
+ * by network timeouts.
  */
 public final class LatestQuarkusVersionResolver {
 
@@ -20,20 +23,37 @@ public final class LatestQuarkusVersionResolver {
 
     private static volatile String cachedVersion;
     private static volatile long cacheTimestamp;
+    private static volatile boolean refreshing;
 
     private LatestQuarkusVersionResolver() {
     }
 
     public static String resolve(String projectDir) {
-        if (cachedVersion != null && System.currentTimeMillis() - cacheTimestamp < CACHE_TTL_MS) {
-            return cachedVersion;
+        String current = cachedVersion;
+        if (current != null && System.currentTimeMillis() - cacheTimestamp < CACHE_TTL_MS) {
+            return current;
         }
-        return doResolve(projectDir);
+        triggerAsyncRefresh(projectDir);
+        return current;
     }
 
-    private static synchronized String doResolve(String projectDir) {
+    private static void triggerAsyncRefresh(String projectDir) {
+        if (refreshing) {
+            return;
+        }
+        refreshing = true;
+        CompletableFuture.runAsync(() -> {
+            try {
+                doResolve(projectDir);
+            } finally {
+                refreshing = false;
+            }
+        });
+    }
+
+    private static synchronized void doResolve(String projectDir) {
         if (cachedVersion != null && System.currentTimeMillis() - cacheTimestamp < CACHE_TTL_MS) {
-            return cachedVersion;
+            return;
         }
 
         String baseUrl = SkillReader.resolveMavenRepoBaseUrl(projectDir);
@@ -55,13 +75,11 @@ public final class LatestQuarkusVersionResolver {
                     cachedVersion = version;
                     cacheTimestamp = System.currentTimeMillis();
                     LOG.debugf("Resolved latest Quarkus version: %s", version);
-                    return version;
                 }
             }
         } catch (Exception e) {
             LOG.debugf("Failed to resolve latest Quarkus version from %s: %s", metadataUrl, e.getMessage());
         }
-        return cachedVersion;
     }
 
     static String parseRelease(String xml) {

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -126,7 +126,12 @@ public final class SkillReader {
         }
     }
 
-    public record SkillInfo(String name, String description, String content, SkillMode mode, List<String> categories) {
+    public record SkillInfo(String name, String description, String content, SkillMode mode, List<String> categories,
+            Map<String, String> modules) {
+
+        SkillInfo(String name, String description, String content, SkillMode mode, List<String> categories) {
+            this(name, description, content, mode, categories, null);
+        }
     }
 
     private SkillReader() {
@@ -256,7 +261,9 @@ public final class SkillReader {
                     List<String> cats = skill.categories() != null && !skill.categories().isEmpty()
                             ? skill.categories()
                             : base.categories();
-                    target.put(skill.name(), new SkillInfo(skill.name(), desc, mergedContent, SkillMode.ENHANCE, cats));
+                    Map<String, String> mergedModules = mergeModules(base.modules(), skill.modules());
+                    target.put(skill.name(),
+                            new SkillInfo(skill.name(), desc, mergedContent, SkillMode.ENHANCE, cats, mergedModules));
                     LOG.infof("Skill '%s' enhanced by %s", skill.name(), source);
                 } else {
                     target.put(skill.name(), skill);
@@ -285,6 +292,21 @@ public final class SkillReader {
             return base;
         }
         return base + "\n\n---\n\n" + overlay;
+    }
+
+    private static Map<String, String> mergeModules(Map<String, String> base, Map<String, String> overlay) {
+        if (base == null && overlay == null) {
+            return null;
+        }
+        if (base == null) {
+            return overlay;
+        }
+        if (overlay == null) {
+            return base;
+        }
+        Map<String, String> merged = new LinkedHashMap<>(base);
+        merged.putAll(overlay);
+        return merged;
     }
 
     /**
@@ -358,28 +380,74 @@ public final class SkillReader {
     }
 
     /**
-     * Reads SKILL.md files from a single JAR.
+     * Reads SKILL.md files (and their module/reference files) from a single JAR.
      *
-     * @param metadataOnly if true, only extract frontmatter — content will be null
+     * @param metadataOnly if true, only extract frontmatter — content and modules will be null
      */
     static List<SkillInfo> readSkillsFromJar(Path jarPath, boolean metadataOnly) throws IOException {
-        List<SkillInfo> skills = new ArrayList<>();
+        Map<String, List<JarEntry>> entriesBySkill = new LinkedHashMap<>();
         try (JarFile jar = new JarFile(jarPath.toFile())) {
             Enumeration<JarEntry> entries = jar.entries();
             while (entries.hasMoreElements()) {
                 JarEntry entry = entries.nextElement();
                 String entryName = entry.getName();
-                if (entryName.startsWith(SKILLS_PATH_PREFIX)
-                        && entryName.endsWith(SKILL_FILE_NAME)
-                        && !entry.isDirectory()) {
-                    try (InputStream is = jar.getInputStream(entry)) {
-                        String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-                        skills.add(parseFrontmatter(content, metadataOnly));
+                if (!entryName.startsWith(SKILLS_PATH_PREFIX) || entry.isDirectory()
+                        || !entryName.endsWith(".md")) {
+                    continue;
+                }
+                String relative = entryName.substring(SKILLS_PATH_PREFIX.length());
+                int slash = relative.indexOf('/');
+                if (slash < 0) {
+                    continue;
+                }
+                String skillDirName = relative.substring(0, slash);
+                entriesBySkill.computeIfAbsent(skillDirName, k -> new ArrayList<>()).add(entry);
+            }
+
+            List<SkillInfo> skills = new ArrayList<>();
+            for (var group : entriesBySkill.entrySet()) {
+                String skillDir = group.getKey();
+                String skillMdPath = SKILLS_PATH_PREFIX + skillDir + "/" + SKILL_FILE_NAME;
+
+                JarEntry skillEntry = null;
+                for (JarEntry e : group.getValue()) {
+                    if (e.getName().equals(skillMdPath)) {
+                        skillEntry = e;
+                        break;
                     }
                 }
+                if (skillEntry == null) {
+                    continue;
+                }
+
+                String content;
+                try (InputStream is = jar.getInputStream(skillEntry)) {
+                    content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                }
+                SkillInfo baseInfo = parseFrontmatter(content, metadataOnly);
+
+                Map<String, String> modules = null;
+                if (!metadataOnly) {
+                    String prefix = SKILLS_PATH_PREFIX + skillDir + "/";
+                    for (JarEntry moduleEntry : group.getValue()) {
+                        if (moduleEntry.getName().equals(skillMdPath)) {
+                            continue;
+                        }
+                        String modulePath = moduleEntry.getName().substring(prefix.length());
+                        try (InputStream is = jar.getInputStream(moduleEntry)) {
+                            if (modules == null) {
+                                modules = new LinkedHashMap<>();
+                            }
+                            modules.put(modulePath, new String(is.readAllBytes(), StandardCharsets.UTF_8));
+                        }
+                    }
+                }
+
+                skills.add(new SkillInfo(baseInfo.name(), baseInfo.description(),
+                        baseInfo.content(), baseInfo.mode(), baseInfo.categories(), modules));
             }
+            return skills;
         }
-        return skills;
     }
 
     /**
@@ -396,10 +464,10 @@ public final class SkillReader {
     }
 
     /**
-     * Reads SKILL.md files from a local directory.
+     * Reads SKILL.md files (and their module/reference files) from a local directory.
      *
      * @param skillsDir    the directory to scan for SKILL.md files
-     * @param metadataOnly if true, only extract frontmatter — content will be null
+     * @param metadataOnly if true, only extract frontmatter — content and modules will be null
      * @return list of locally found skills, never null
      */
     static List<SkillInfo> readLocalSkills(Path skillsDir, boolean metadataOnly) {
@@ -408,27 +476,58 @@ public final class SkillReader {
         }
 
         List<SkillInfo> skills = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(skillsDir, Files::isDirectory)) {
+            for (Path skillDir : stream) {
+                Path skillFile = skillDir.resolve(SKILL_FILE_NAME);
+                if (!Files.isRegularFile(skillFile)) {
+                    continue;
+                }
+                try {
+                    String content = Files.readString(skillFile, StandardCharsets.UTF_8);
+                    SkillInfo baseInfo = parseFrontmatter(content, metadataOnly);
+
+                    Map<String, String> modules = null;
+                    if (!metadataOnly) {
+                        modules = readModuleFiles(skillDir);
+                    }
+
+                    SkillInfo skill = new SkillInfo(baseInfo.name(), baseInfo.description(),
+                            baseInfo.content(), baseInfo.mode(), baseInfo.categories(), modules);
+                    skills.add(skill);
+                    LOG.debugf("Found local skill '%s' at %s", skill.name(), skillFile);
+                } catch (IOException e) {
+                    LOG.debugf("Failed to read local skill %s: %s", skillFile, e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            LOG.debugf("Failed to scan local skills directory %s: %s", skillsDir, e.getMessage());
+        }
+        return skills;
+    }
+
+    private static Map<String, String> readModuleFiles(Path skillDir) {
+        Map<String, String> modules = new LinkedHashMap<>();
         try {
-            Files.walkFileTree(skillsDir, Collections.emptySet(), 3, new SimpleFileVisitor<>() {
+            Files.walkFileTree(skillDir, Collections.emptySet(), 5, new SimpleFileVisitor<>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    if (file.getFileName().toString().equals(SKILL_FILE_NAME)) {
+                    String fileName = file.getFileName().toString();
+                    if (fileName.endsWith(".md") && !fileName.equals(SKILL_FILE_NAME)) {
+                        String relativePath = skillDir.relativize(file).toString()
+                                .replace('\\', '/');
                         try {
-                            String content = Files.readString(file, StandardCharsets.UTF_8);
-                            SkillInfo skill = parseFrontmatter(content, metadataOnly);
-                            skills.add(skill);
-                            LOG.debugf("Found local skill '%s' at %s", skill.name(), file);
+                            modules.put(relativePath, Files.readString(file, StandardCharsets.UTF_8));
                         } catch (IOException e) {
-                            LOG.debugf("Failed to read local skill %s: %s", file, e.getMessage());
+                            LOG.debugf("Failed to read module %s: %s", file, e.getMessage());
                         }
                     }
                     return FileVisitResult.CONTINUE;
                 }
             });
         } catch (IOException e) {
-            LOG.debugf("Failed to scan local skills directory %s: %s", skillsDir, e.getMessage());
+            LOG.debugf("Failed to scan module files in %s: %s", skillDir, e.getMessage());
         }
-        return skills;
+        return modules.isEmpty() ? null : modules;
     }
 
     /**

--- a/src/main/java/io/quarkus/agent/mcp/SkillReader.java
+++ b/src/main/java/io/quarkus/agent/mcp/SkillReader.java
@@ -128,10 +128,6 @@ public final class SkillReader {
 
     public record SkillInfo(String name, String description, String content, SkillMode mode, List<String> categories,
             Map<String, String> modules) {
-
-        SkillInfo(String name, String description, String content, SkillMode mode, List<String> categories) {
-            this(name, description, content, mode, categories, null);
-        }
     }
 
     private SkillReader() {
@@ -188,6 +184,21 @@ public final class SkillReader {
      */
     public static List<SkillInfo> readSkills(String projectDir, Path localSkillsDir, boolean metadataOnly,
             boolean includeTransitive) {
+        return readSkills(projectDir, localSkillsDir, metadataOnly, includeTransitive, !metadataOnly);
+    }
+
+    /**
+     * Reads available skills with independent control over content and module loading.
+     *
+     * @param projectDir        the absolute path to the Quarkus project
+     * @param localSkillsDir    optional user-level directory to scan for SKILL.md files, or null for the default
+     * @param metadataOnly      if true, only extract frontmatter (name, description, mode) — content will be null
+     * @param includeTransitive if true, include skills from transitive dependencies; if false, only direct dependencies
+     * @param loadModules       if true, read module/reference .md files alongside SKILL.md
+     * @return list of available skills, never null
+     */
+    public static List<SkillInfo> readSkills(String projectDir, Path localSkillsDir, boolean metadataOnly,
+            boolean includeTransitive, boolean loadModules) {
         // Use a map keyed by skill name so each layer can override the previous
         Map<String, SkillInfo> skillsByName = new LinkedHashMap<>();
 
@@ -218,7 +229,7 @@ public final class SkillReader {
 
                 if (jarPath != null) {
                     try {
-                        for (SkillInfo skill : readSkillsFromJar(jarPath, metadataOnly)) {
+                        for (SkillInfo skill : readSkillsFromJar(jarPath, metadataOnly, loadModules)) {
                             skillsByName.put(skill.name(), skill);
                         }
                     } catch (IOException e) {
@@ -231,16 +242,17 @@ public final class SkillReader {
         }
 
         // Layer 1.5: Bundled community skills (from classpath JAR)
-        overlaySkills(skillsByName, readBundledSkills(metadataOnly), "bundled (classpath)");
+        overlaySkills(skillsByName, readBundledSkills(metadataOnly, loadModules), "bundled (classpath)");
 
         // Layer 2: Overlay user-level skills (~/.quarkus/skills/ or configured dir)
         Path effectiveLocalDir = localSkillsDir != null ? localSkillsDir : DEFAULT_LOCAL_SKILLS_DIR;
-        overlaySkills(skillsByName, readLocalSkills(effectiveLocalDir, metadataOnly), effectiveLocalDir.toString());
+        overlaySkills(skillsByName, readLocalSkills(effectiveLocalDir, metadataOnly, loadModules),
+                effectiveLocalDir.toString());
 
         // Layer 3: Project-level skills (.agent/skills/) — standalone, no composition
         if (projectDir != null) {
             Path projectSkillsDir = Path.of(projectDir, ".agent", "skills");
-            for (SkillInfo skill : readLocalSkills(projectSkillsDir, metadataOnly)) {
+            for (SkillInfo skill : readLocalSkills(projectSkillsDir, metadataOnly, loadModules)) {
                 skillsByName.put(skill.name(), skill);
                 LOG.infof("Skill '%s' loaded from project %s", skill.name(), projectSkillsDir);
             }
@@ -358,7 +370,7 @@ public final class SkillReader {
             }
         }
 
-        return new SkillInfo(name, description, body, mode, categories);
+        return new SkillInfo(name, description, body, mode, categories, null);
     }
 
     static List<String> parseCategories(String value) {
@@ -385,6 +397,17 @@ public final class SkillReader {
      * @param metadataOnly if true, only extract frontmatter — content and modules will be null
      */
     static List<SkillInfo> readSkillsFromJar(Path jarPath, boolean metadataOnly) throws IOException {
+        return readSkillsFromJar(jarPath, metadataOnly, !metadataOnly);
+    }
+
+    /**
+     * Reads SKILL.md files from a single JAR with independent control over content and module loading.
+     *
+     * @param metadataOnly if true, only extract frontmatter — content will be null
+     * @param loadModules  if true, read module/reference .md files alongside SKILL.md
+     */
+    static List<SkillInfo> readSkillsFromJar(Path jarPath, boolean metadataOnly, boolean loadModules)
+            throws IOException {
         Map<String, List<JarEntry>> entriesBySkill = new LinkedHashMap<>();
         try (JarFile jar = new JarFile(jarPath.toFile())) {
             Enumeration<JarEntry> entries = jar.entries();
@@ -427,7 +450,7 @@ public final class SkillReader {
                 SkillInfo baseInfo = parseFrontmatter(content, metadataOnly);
 
                 Map<String, String> modules = null;
-                if (!metadataOnly) {
+                if (loadModules) {
                     String prefix = SKILLS_PATH_PREFIX + skillDir + "/";
                     for (JarEntry moduleEntry : group.getValue()) {
                         if (moduleEntry.getName().equals(skillMdPath)) {
@@ -471,6 +494,18 @@ public final class SkillReader {
      * @return list of locally found skills, never null
      */
     static List<SkillInfo> readLocalSkills(Path skillsDir, boolean metadataOnly) {
+        return readLocalSkills(skillsDir, metadataOnly, !metadataOnly);
+    }
+
+    /**
+     * Reads SKILL.md files from a local directory with independent control over content and module loading.
+     *
+     * @param skillsDir    the directory to scan for SKILL.md files
+     * @param metadataOnly if true, only extract frontmatter — content will be null
+     * @param loadModules  if true, read module/reference .md files alongside SKILL.md
+     * @return list of locally found skills, never null
+     */
+    static List<SkillInfo> readLocalSkills(Path skillsDir, boolean metadataOnly, boolean loadModules) {
         if (!Files.isDirectory(skillsDir)) {
             return List.of();
         }
@@ -487,7 +522,7 @@ public final class SkillReader {
                     SkillInfo baseInfo = parseFrontmatter(content, metadataOnly);
 
                     Map<String, String> modules = null;
-                    if (!metadataOnly) {
+                    if (loadModules) {
                         modules = readModuleFiles(skillDir);
                     }
 
@@ -535,6 +570,10 @@ public final class SkillReader {
      * Scans for {@code META-INF/skills/<name>/SKILL.md} entries.
      */
     static List<SkillInfo> readBundledSkills(boolean metadataOnly) {
+        return readBundledSkills(metadataOnly, !metadataOnly);
+    }
+
+    static List<SkillInfo> readBundledSkills(boolean metadataOnly, boolean loadModules) {
         List<SkillInfo> skills = new ArrayList<>();
         try {
             Enumeration<URL> resources = Thread.currentThread().getContextClassLoader()
@@ -552,13 +591,13 @@ public final class SkillReader {
                         }
                         Path jar = Path.of(filePath);
                         if (Files.isRegularFile(jar)) {
-                            skills.addAll(readSkillsFromJar(jar, metadataOnly));
+                            skills.addAll(readSkillsFromJar(jar, metadataOnly, loadModules));
                         }
                     }
                 } else if ("file".equals(protocol)) {
                     Path dir = Path.of(url.toURI());
                     if (Files.isDirectory(dir)) {
-                        skills.addAll(readLocalSkills(dir.getParent(), metadataOnly));
+                        skills.addAll(readLocalSkills(dir.getParent(), metadataOnly, loadModules));
                     }
                 }
             }
@@ -708,7 +747,7 @@ public final class SkillReader {
             List<String> categories = meta != null ? meta.categories : null;
 
             if (metadataOnly) {
-                return new SkillInfo(skillName, description, null, SkillMode.ENHANCE, categories);
+                return new SkillInfo(skillName, description, null, SkillMode.ENHANCE, categories, null);
             }
 
             String rawSkill;
@@ -718,7 +757,7 @@ public final class SkillReader {
 
             List<McpToolInfo> tools = discoverMcpTools(depJar, runtimeJar, devJar);
             String content = composeContent(rawSkill, meta, tools, skillName);
-            return new SkillInfo(skillName, description, content, SkillMode.ENHANCE, categories);
+            return new SkillInfo(skillName, description, content, SkillMode.ENHANCE, categories, null);
         } catch (IOException e) {
             LOG.debugf("Failed to compose skill from %s: %s", deploymentJar, e.getMessage());
             return null;

--- a/src/test/java/io/quarkus/agent/mcp/DevMcpProxyToolsTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/DevMcpProxyToolsTest.java
@@ -11,11 +11,11 @@ class DevMcpProxyToolsTest {
     void formatSkillIndexGroupsByCategory() {
         List<SkillReader.SkillInfo> skills = List.of(
                 new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE,
-                        List.of("web")),
+                        List.of("web"), null),
                 new SkillReader.SkillInfo("quarkus-hibernate-orm", "ORM extension", null, SkillReader.SkillMode.ENHANCE,
-                        List.of("data")),
+                        List.of("data"), null),
                 new SkillReader.SkillInfo("quarkus-rest-client", "REST client", null, SkillReader.SkillMode.ENHANCE,
-                        List.of("web")));
+                        List.of("web"), null));
 
         String index = DevMcpProxyTools.formatSkillIndex(skills);
 
@@ -30,9 +30,9 @@ class DevMcpProxyToolsTest {
     @Test
     void formatSkillIndexUsesDefaultCategoriesForUncategorizedSkills() {
         List<SkillReader.SkillInfo> skills = List.of(
-                new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE, null),
+                new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE, null, null),
                 new SkillReader.SkillInfo("quarkus-security", "Security framework", null,
-                        SkillReader.SkillMode.ENHANCE, null));
+                        SkillReader.SkillMode.ENHANCE, null, null));
 
         String index = DevMcpProxyTools.formatSkillIndex(skills);
 
@@ -44,9 +44,9 @@ class DevMcpProxyToolsTest {
     void formatSkillIndexPutsUnknownSkillsInMiscellaneous() {
         List<SkillReader.SkillInfo> skills = List.of(
                 new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE,
-                        List.of("web")),
+                        List.of("web"), null),
                 new SkillReader.SkillInfo("quarkus-custom", "Custom extension", null, SkillReader.SkillMode.ENHANCE,
-                        null));
+                        null, null));
 
         String index = DevMcpProxyTools.formatSkillIndex(skills);
 
@@ -58,10 +58,10 @@ class DevMcpProxyToolsTest {
     @Test
     void formatSkillIndexOrdersCategoriesCorrectly() {
         List<SkillReader.SkillInfo> skills = List.of(
-                new SkillReader.SkillInfo("s1", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("security")),
-                new SkillReader.SkillInfo("s2", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("core")),
-                new SkillReader.SkillInfo("s3", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("web")),
-                new SkillReader.SkillInfo("s4", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("data")));
+                new SkillReader.SkillInfo("s1", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("security"), null),
+                new SkillReader.SkillInfo("s2", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("core"), null),
+                new SkillReader.SkillInfo("s3", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("web"), null),
+                new SkillReader.SkillInfo("s4", "desc", null, SkillReader.SkillMode.ENHANCE, List.of("data"), null));
 
         String index = DevMcpProxyTools.formatSkillIndex(skills);
 
@@ -78,7 +78,7 @@ class DevMcpProxyToolsTest {
     void formatSkillIndexFrontmatterCategoryOverridesDefault() {
         List<SkillReader.SkillInfo> skills = List.of(
                 new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE,
-                        List.of("messaging")));
+                        List.of("messaging"), null));
 
         String index = DevMcpProxyTools.formatSkillIndex(skills);
 
@@ -90,7 +90,7 @@ class DevMcpProxyToolsTest {
     void formatSkillIndexListsSkillUnderAllCategories() {
         List<SkillReader.SkillInfo> skills = List.of(
                 new SkillReader.SkillInfo("quarkus-rest", "REST extension", null, SkillReader.SkillMode.ENHANCE,
-                        List.of("web", "reactive")));
+                        List.of("web", "reactive"), null));
 
         String index = DevMcpProxyTools.formatSkillIndex(skills);
 
@@ -108,9 +108,9 @@ class DevMcpProxyToolsTest {
     void formatSkillIndexMultiCategoryPreservesOrder() {
         List<SkillReader.SkillInfo> skills = List.of(
                 new SkillReader.SkillInfo("quarkus-reactive-rest", "Reactive REST", null,
-                        SkillReader.SkillMode.ENHANCE, List.of("reactive", "web")),
+                        SkillReader.SkillMode.ENHANCE, List.of("reactive", "web"), null),
                 new SkillReader.SkillInfo("quarkus-hibernate-orm", "ORM", null,
-                        SkillReader.SkillMode.ENHANCE, List.of("data")));
+                        SkillReader.SkillMode.ENHANCE, List.of("data"), null));
 
         String index = DevMcpProxyTools.formatSkillIndex(skills);
 
@@ -124,9 +124,10 @@ class DevMcpProxyToolsTest {
     @Test
     void formatSkillIndexOmitsDescriptionWhenNull() {
         List<SkillReader.SkillInfo> skills = List.of(
-                new SkillReader.SkillInfo("quarkus-rest", null, null, SkillReader.SkillMode.ENHANCE, List.of("web")),
+                new SkillReader.SkillInfo("quarkus-rest", null, null, SkillReader.SkillMode.ENHANCE, List.of("web"),
+                        null),
                 new SkillReader.SkillInfo("quarkus-arc", "CDI framework", null, SkillReader.SkillMode.ENHANCE,
-                        List.of("core")));
+                        List.of("core"), null));
 
         String index = DevMcpProxyTools.formatSkillIndex(skills);
 
@@ -138,7 +139,7 @@ class DevMcpProxyToolsTest {
     @Test
     void resolveCategoriesReturnsAllExplicitCategories() {
         SkillReader.SkillInfo skill = new SkillReader.SkillInfo("quarkus-rest", "REST", null,
-                SkillReader.SkillMode.ENHANCE, List.of("web", "reactive"));
+                SkillReader.SkillMode.ENHANCE, List.of("web", "reactive"), null);
 
         assertEquals(List.of("web", "reactive"), DevMcpProxyTools.resolveCategories(skill));
     }
@@ -146,7 +147,7 @@ class DevMcpProxyToolsTest {
     @Test
     void resolveCategoriesFallsBackToDefaultMap() {
         SkillReader.SkillInfo skill = new SkillReader.SkillInfo("quarkus-rest", "REST", null,
-                SkillReader.SkillMode.ENHANCE, null);
+                SkillReader.SkillMode.ENHANCE, null, null);
 
         assertEquals(List.of("web"), DevMcpProxyTools.resolveCategories(skill));
     }
@@ -154,7 +155,7 @@ class DevMcpProxyToolsTest {
     @Test
     void resolveCategoriesReturnsMiscellaneousForUnknownSkill() {
         SkillReader.SkillInfo skill = new SkillReader.SkillInfo("quarkus-custom", "Custom", null,
-                SkillReader.SkillMode.ENHANCE, null);
+                SkillReader.SkillMode.ENHANCE, null, null);
 
         assertEquals(List.of("miscellaneous"), DevMcpProxyTools.resolveCategories(skill));
     }

--- a/src/test/java/io/quarkus/agent/mcp/LatestQuarkusVersionResolverTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/LatestQuarkusVersionResolverTest.java
@@ -1,0 +1,59 @@
+package io.quarkus.agent.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class LatestQuarkusVersionResolverTest {
+
+    @Test
+    void parseReleaseExtractsVersion() {
+        String xml = """
+                <metadata>
+                  <groupId>io.quarkus</groupId>
+                  <artifactId>quarkus-bom</artifactId>
+                  <versioning>
+                    <latest>3.36.3</latest>
+                    <release>3.36.3</release>
+                    <versions>
+                      <version>3.35.0</version>
+                      <version>3.36.0</version>
+                      <version>3.36.3</version>
+                    </versions>
+                  </versioning>
+                </metadata>
+                """;
+
+        assertEquals("3.36.3", LatestQuarkusVersionResolver.parseRelease(xml));
+    }
+
+    @Test
+    void parseReleaseReturnsNullForMissingTag() {
+        String xml = """
+                <metadata>
+                  <groupId>io.quarkus</groupId>
+                  <versioning>
+                    <latest>3.36.3</latest>
+                  </versioning>
+                </metadata>
+                """;
+
+        assertNull(LatestQuarkusVersionResolver.parseRelease(xml));
+    }
+
+    @Test
+    void parseReleaseReturnsNullForEmptyXml() {
+        assertNull(LatestQuarkusVersionResolver.parseRelease(""));
+    }
+
+    @Test
+    void parseReleaseHandlesMalformedXml() {
+        assertNull(LatestQuarkusVersionResolver.parseRelease("this is not xml"));
+    }
+
+    @Test
+    void parseReleaseTrimsWhitespace() {
+        String xml = "<metadata><versioning><release>  3.36.3  </release></versioning></metadata>";
+        assertEquals("3.36.3", LatestQuarkusVersionResolver.parseRelease(xml));
+    }
+}

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -283,7 +283,7 @@ class SkillReaderTest {
         // Base skill simulating JAR layer
         SkillReader.SkillInfo base = new SkillReader.SkillInfo(
                 "quarkus-rest", "Base REST skill", "### Base REST patterns\nUse @GET for endpoints.",
-                SkillReader.SkillMode.ENHANCE, List.of("web"));
+                SkillReader.SkillMode.ENHANCE, List.of("web"), null);
 
         // Project-level skill in .agent/skills/ with ENHANCE mode
         Path projectSkillsDir = tempDir.resolve(".agent/skills/quarkus-rest");

--- a/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/SkillReaderTest.java
@@ -1864,4 +1864,214 @@ class SkillReaderTest {
             assertNull(skill.content(), "Content should be null in metadata-only mode");
         }
     }
+
+    // --- Module loading tests ---
+
+    @Test
+    void readSkillsFromJarReadsModuleFiles() throws Exception {
+        Path jarPath = tempDir.resolve("skills-with-modules.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/my-skill/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: my-skill
+                    description: "Skill with modules"
+                    ---
+
+                    ### Main content
+                    See [modules/build.md](modules/build.md).
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+
+            jos.putNextEntry(new JarEntry("META-INF/skills/my-skill/modules/build.md"));
+            jos.write("# Build Module\nBuild instructions here.".getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+
+            jos.putNextEntry(new JarEntry("META-INF/skills/my-skill/references/dep-map.md"));
+            jos.write("# Dependency Map\n| Spring | Quarkus |".getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readSkillsFromJar(jarPath);
+
+        assertEquals(1, skills.size());
+        SkillReader.SkillInfo skill = skills.get(0);
+        assertEquals("my-skill", skill.name());
+        assertNotNull(skill.modules());
+        assertEquals(2, skill.modules().size());
+        assertTrue(skill.modules().containsKey("modules/build.md"));
+        assertTrue(skill.modules().containsKey("references/dep-map.md"));
+        assertTrue(skill.modules().get("modules/build.md").contains("Build instructions"));
+        assertTrue(skill.modules().get("references/dep-map.md").contains("Dependency Map"));
+    }
+
+    @Test
+    void readSkillsFromJarMetadataOnlySkipsModules() throws Exception {
+        Path jarPath = tempDir.resolve("skills-with-modules.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/my-skill/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: my-skill
+                    ---
+
+                    ### Content
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+
+            jos.putNextEntry(new JarEntry("META-INF/skills/my-skill/modules/build.md"));
+            jos.write("# Build Module".getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readSkillsFromJar(jarPath, true);
+
+        assertEquals(1, skills.size());
+        assertNull(skills.get(0).modules());
+        assertNull(skills.get(0).content());
+    }
+
+    @Test
+    void readSkillsFromJarSkillWithoutModulesHasNullModules() throws Exception {
+        Path jarPath = tempDir.resolve("no-modules.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/simple/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: simple
+                    ---
+
+                    ### Simple skill
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readSkillsFromJar(jarPath);
+
+        assertEquals(1, skills.size());
+        assertNull(skills.get(0).modules());
+    }
+
+    @Test
+    void readLocalSkillsReadsModuleFiles() throws Exception {
+        Path skillsDir = tempDir.resolve("skills");
+        Path skillDir = skillsDir.resolve("my-skill");
+        Path modulesDir = skillDir.resolve("modules");
+        Path refsDir = skillDir.resolve("references");
+        Files.createDirectories(modulesDir);
+        Files.createDirectories(refsDir);
+
+        Files.writeString(skillDir.resolve("SKILL.md"), """
+                ---
+                name: my-skill
+                description: "Local skill with modules"
+                ---
+
+                ### Main content
+                """);
+        Files.writeString(modulesDir.resolve("build.md"), "# Build Module\nLocal build content.");
+        Files.writeString(refsDir.resolve("config-map.md"), "# Config Map\n| Spring | Quarkus |");
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readLocalSkills(skillsDir);
+
+        assertEquals(1, skills.size());
+        SkillReader.SkillInfo skill = skills.get(0);
+        assertNotNull(skill.modules());
+        assertEquals(2, skill.modules().size());
+        assertTrue(skill.modules().containsKey("modules/build.md"));
+        assertTrue(skill.modules().containsKey("references/config-map.md"));
+    }
+
+    @Test
+    void readLocalSkillsMetadataOnlySkipsModules() throws Exception {
+        Path skillsDir = tempDir.resolve("skills");
+        Path skillDir = skillsDir.resolve("my-skill");
+        Path modulesDir = skillDir.resolve("modules");
+        Files.createDirectories(modulesDir);
+
+        Files.writeString(skillDir.resolve("SKILL.md"), """
+                ---
+                name: my-skill
+                ---
+
+                ### Content
+                """);
+        Files.writeString(modulesDir.resolve("build.md"), "# Build Module");
+
+        List<SkillReader.SkillInfo> skills = SkillReader.readLocalSkills(skillsDir, true);
+
+        assertEquals(1, skills.size());
+        assertNull(skills.get(0).modules());
+    }
+
+    @Test
+    void enhanceModeOverlayMergesModules() throws Exception {
+        Path jarPath = tempDir.resolve("skills.jar");
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            jos.putNextEntry(new JarEntry("META-INF/skills/my-skill/SKILL.md"));
+            jos.write("""
+                    ---
+                    name: my-skill
+                    ---
+
+                    ### Base
+                    """.getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+
+            jos.putNextEntry(new JarEntry("META-INF/skills/my-skill/modules/build.md"));
+            jos.write("Base build content".getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+
+            jos.putNextEntry(new JarEntry("META-INF/skills/my-skill/modules/code.md"));
+            jos.write("Base code content".getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+        }
+
+        Path localDir = tempDir.resolve("local/my-skill");
+        Path localModulesDir = localDir.resolve("modules");
+        Files.createDirectories(localModulesDir);
+        Files.writeString(localDir.resolve("SKILL.md"), """
+                ---
+                name: my-skill
+                mode: enhance
+                ---
+
+                ### Enhanced
+                """);
+        Files.writeString(localModulesDir.resolve("build.md"), "Enhanced build content");
+        Files.writeString(localModulesDir.resolve("testing.md"), "New testing module");
+
+        List<SkillReader.SkillInfo> base = SkillReader.readSkillsFromJar(jarPath);
+        Map<String, SkillReader.SkillInfo> skillMap = new LinkedHashMap<>();
+        for (SkillReader.SkillInfo s : base) {
+            skillMap.put(s.name(), s);
+        }
+
+        List<SkillReader.SkillInfo> local = SkillReader.readLocalSkills(tempDir.resolve("local"));
+        SkillReader.overlaySkills(skillMap, local, "local");
+
+        SkillReader.SkillInfo result = skillMap.get("my-skill");
+        assertNotNull(result.modules());
+        assertEquals(3, result.modules().size());
+        assertEquals("Enhanced build content", result.modules().get("modules/build.md"));
+        assertEquals("Base code content", result.modules().get("modules/code.md"));
+        assertEquals("New testing module", result.modules().get("modules/testing.md"));
+    }
+
+    @Test
+    void readBundledSkillsLoadsModules() {
+        List<SkillReader.SkillInfo> skills = SkillReader.readBundledSkills(false);
+        SkillReader.SkillInfo migrationSkill = skills.stream()
+                .filter(s -> s.name().contains("migrate"))
+                .findFirst()
+                .orElse(null);
+
+        if (migrationSkill != null) {
+            assertNotNull(migrationSkill.modules(), "Migration skill should have module files");
+            assertTrue(migrationSkill.modules().containsKey("modules/build.md"),
+                    "Should contain modules/build.md");
+            assertTrue(migrationSkill.modules().containsKey("references/dependency-map.md"),
+                    "Should contain references/dependency-map.md");
+        }
+    }
 }


### PR DESCRIPTION
Skills like `migrate-spring-to-quarkus` ship with module and reference files alongside `SKILL.md` (e.g. `modules/build.md`, `references/dependency-map.md`). These were not being loaded because `readSkillsFromJar` only read `SKILL.md` entries — the AI agent could see the relative links in the skill content but had no way to access the referenced files.

Additionally, skills that instruct the agent to "use the latest Quarkus release" had no way to communicate what that version actually is, causing the agent to fall back to stale training data (e.g. 3.21.3 instead of 3.36.3).

This adds module file support to the skill loading pipeline and resolves the latest Quarkus version from Maven Central metadata:

- `SkillInfo` now carries a `Map<String, String> modules` field for sub-files
- `readSkillsFromJar` and `readLocalSkills` read all `.md` files from skill directories, not just `SKILL.md`
- The `quarkus_skills` tool gains a `module` parameter for loading individual module files on demand
- Skill output appends an "Available Modules" section listing loadable paths
- `LatestQuarkusVersionResolver` fetches and caches (1h TTL) the latest release from Maven Central's `maven-metadata.xml`
- Skill responses are prepended with `> **Latest Quarkus release:** X.Y.Z`