### PR TITLE
Improve dev mode reliability with retry logic and restart readiness

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -35,6 +35,8 @@ public class DevMcpProxyTools {
     private static final Logger LOG = Logger.getLogger(DevMcpProxyTools.class);
 
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+    private static final int MAX_RETRIES = 3;
+    private static final long INITIAL_RETRY_DELAY_MS = 2000;
 
     static final List<String> CATEGORY_ORDER = List.of(
             "web", "data", "security", "core", "messaging", "observability",
@@ -570,40 +572,65 @@ public class DevMcpProxyTools {
     }
 
     private JsonNode callDevMcp(int port, String devMcpPath, String method, Map<String, Object> params) {
+        String jsonRpcRequest;
         try {
-            String jsonRpcRequest = mapper.writeValueAsString(Map.of(
+            jsonRpcRequest = mapper.writeValueAsString(Map.of(
                     "jsonrpc", "2.0",
                     "id", requestId.incrementAndGet(),
                     "method", method,
                     "params", params));
-
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("http://localhost:" + port + devMcpPath))
-                    .header("Content-Type", "application/json")
-                    .header("Accept", "application/json, text/event-stream")
-                    .POST(HttpRequest.BodyPublishers.ofString(jsonRpcRequest))
-                    .timeout(REQUEST_TIMEOUT)
-                    .build();
-
-            HttpResponse<String> response = HttpClientProvider.getHttpClient().send(request,
-                    HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() != 200) {
-                throw new RuntimeException("Dev MCP returned HTTP " + response.statusCode());
-            }
-
-            JsonNode body = mapper.readTree(response.body());
-            if (body.has("result")) {
-                return body.get("result");
-            }
-            if (body.has("error")) {
-                String errorMsg = body.get("error").has("message")
-                        ? body.get("error").get("message").asText()
-                        : body.get("error").toString();
-                throw new RuntimeException("Dev MCP error: " + errorMsg);
-            }
-            return null;
-        } catch (IOException | InterruptedException e) {
-            throw new RuntimeException("Failed to call Dev MCP: " + e.getMessage(), e);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize JSON-RPC request: " + e.getMessage(), e);
         }
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + devMcpPath))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonRpcRequest))
+                .timeout(REQUEST_TIMEOUT)
+                .build();
+
+        IOException lastException = null;
+        for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            if (attempt > 0) {
+                long delay = INITIAL_RETRY_DELAY_MS * (1L << (attempt - 1));
+                LOG.warnf("Dev MCP call failed (attempt %d/%d), retrying in %dms: %s",
+                        attempt, MAX_RETRIES + 1, delay, lastException.getMessage());
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted while retrying Dev MCP call", ie);
+                }
+            }
+
+            try {
+                HttpResponse<String> response = HttpClientProvider.getHttpClient().send(request,
+                        HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() != 200) {
+                    throw new RuntimeException("Dev MCP returned HTTP " + response.statusCode());
+                }
+
+                JsonNode body = mapper.readTree(response.body());
+                if (body.has("result")) {
+                    return body.get("result");
+                }
+                if (body.has("error")) {
+                    String errorMsg = body.get("error").has("message")
+                            ? body.get("error").get("message").asText()
+                            : body.get("error").toString();
+                    throw new RuntimeException("Dev MCP error: " + errorMsg);
+                }
+                return null;
+            } catch (IOException e) {
+                lastException = e;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Failed to call Dev MCP: " + e.getMessage(), e);
+            }
+        }
+        throw new RuntimeException("Failed to call Dev MCP after " + (MAX_RETRIES + 1)
+                + " attempts: " + lastException.getMessage(), lastException);
     }
 }

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -104,12 +104,39 @@ public class LifecycleTools {
     }
 
     @Tool(name = "quarkus_restart", description = "Force restart a Quarkus application. "
+            + "Blocks until the app is ready or fails. "
             + "Only use if the app is unresponsive. Normally hot reload handles changes automatically.")
     ToolResponse restart(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir) {
         try {
             processManager.restart(projectDir);
-            return ToolResponse.success("Quarkus application restart triggered at: " + projectDir);
+
+            QuarkusInstance instance = processManager.getInstance(projectDir);
+            if (instance != null && instance.getStatus() == QuarkusInstance.Status.STARTING) {
+                long deadline = System.currentTimeMillis() + STARTUP_TIMEOUT_MS;
+                while (instance.getStatus() == QuarkusInstance.Status.STARTING
+                        && System.currentTimeMillis() < deadline) {
+                    try {
+                        Thread.sleep(STARTUP_POLL_INTERVAL_MS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            }
+
+            if (instance != null && instance.getStatus() == QuarkusInstance.Status.RUNNING) {
+                int port = instance.getHttpPort();
+                String portInfo = port > 0 ? " (port: " + port + ")" : "";
+                return ToolResponse.success("Quarkus application restarted at: " + projectDir + portInfo);
+            } else if (instance != null && instance.getStatus() == QuarkusInstance.Status.CRASHED) {
+                String recentLogs = instance.getRecentLogs(30);
+                return ToolResponse.error("Quarkus application failed to restart at: " + projectDir
+                        + "\n\nRecent logs:\n" + recentLogs);
+            } else {
+                return ToolResponse.success("Quarkus application restart triggered at: " + projectDir
+                        + " — still starting after timeout, use quarkus_status to check");
+            }
         } catch (Exception e) {
             LOG.error("Failed to restart Quarkus application at " + projectDir, e);
             return ToolResponse.error(e.getMessage());

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -226,8 +226,9 @@ public class QuarkusInstance {
                     "Process is not running. Use quarkus_start to start a new instance.");
         }
         status.set(Status.STARTING);
-        httpPort = -1;
-        devMcpPath = null;
+        // Keep httpPort and devMcpPath: during a live reload the JVM stays alive
+        // and the port doesn't change. The log parser will overwrite these if new
+        // "Listening on:" / "Dev MCP available at:" lines appear.
         sendInput('s');
     }
 

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -222,7 +222,7 @@ class QuarkusInstanceTest {
     }
 
     @Test
-    void restartResetsDevMcpPath() throws Exception {
+    void restartPreservesDevMcpPath() throws Exception {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://localhost:8080' && echo 'Dev MCP available at: /custom/dev-mcp' && cat")
                 .start();
@@ -233,11 +233,11 @@ class QuarkusInstanceTest {
 
         instance.restart();
 
-        assertEquals("/q/dev-mcp", instance.getDevMcpPath());
+        assertEquals("/custom/dev-mcp", instance.getDevMcpPath());
     }
 
     @Test
-    void restartResetsPortAndStatus() throws Exception {
+    void restartPreservesPortAndResetsStatus() throws Exception {
         process = new ProcessBuilder("bash", "-c",
                 "echo 'Listening on: http://localhost:8080' && cat")
                 .start();
@@ -250,7 +250,7 @@ class QuarkusInstanceTest {
         instance.restart();
 
         assertEquals(QuarkusInstance.Status.STARTING, instance.getStatus());
-        assertEquals(-1, instance.getHttpPort());
+        assertEquals(8080, instance.getHttpPort());
     }
 
     @Test


### PR DESCRIPTION
When the LLM edits code, Quarkus hot-reload makes the Dev MCP endpoint briefly unavailable. The agent's single-attempt HTTP call would fail, confusing the LLM into launching rogue restart attempts that cause port conflicts and zombie processes.

Three changes work together to address this:

- **Retry with backoff in `callDevMcp()`** — HTTP calls to the Dev MCP now retry up to 3 times on `IOException` with exponential backoff (2s, 4s, 8s), handling transient unavailability during hot-reload transparently
- **Preserve port/path during live reload** — `QuarkusInstance.restart()` no longer clears `httpPort` and `devMcpPath` since the JVM stays alive and the port doesn't change during a live reload; the log parser overwrites them when new values appear
- **`quarkus_restart` waits for readiness** — now blocks until the app reaches RUNNING (or CRASHED), matching `quarkus_start` behavior, so the LLM doesn't call tools against a not-yet-ready instance

Fixes #211