### PR TITLE
Support dev/test/prod mode with agent-mcp.mode config

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -185,7 +185,7 @@ public class CreateTools {
             createSourceDirectories(projectDir);
 
             // Generate AGENTS.md, CLAUDE.md, and .mcp.json
-            ProjectFiles.generateProjectInstructions(projectDir);
+            ProjectFiles.generateProjectInstructions(projectDir, processManager.isDevMode());
             ProjectFiles.generateMcpConfig(projectDir);
 
             // Auto-start the app in dev mode and wait for it to be ready
@@ -230,7 +230,12 @@ public class CreateTools {
 
                 response.append("\n\nNEXT: Call quarkus_skills with the relevant extension names "
                         + "(e.g., quarkus_skills query='panache,rest') to read the full patterns and guidelines before writing code. "
-                        + "Write code and tests, then run tests with quarkus_callTool toolName='devui-testing_runTests'.");
+                        + "Write code and tests, then run tests");
+                if (processManager.isDevMode()) {
+                    response.append(" with quarkus_callTool toolName='devui-testing_runTests'.");
+                } else {
+                    response.append(" with mvn test (or gradle test).");
+                }
 
                 return ToolResponse.success(response.toString());
             } catch (Exception startError) {

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -76,7 +76,7 @@ public class LifecycleTools {
                 return ToolResponse.error("Quarkus application failed to start at: " + projectDir
                         + "\n\nRecent logs:\n" + recentLogs + containerWarning + agentFilesNote);
             } else {
-                String message = "Quarkus application starting in dev mode at: " + projectDir;
+                String message = "Quarkus application starting at: " + projectDir;
                 if (effectivePort != null) {
                     message += " (port: " + effectivePort + ")";
                 }

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -29,9 +29,9 @@ public class LifecycleTools {
     static final long STARTUP_TIMEOUT_MS = 120_000;
     static final long STARTUP_POLL_INTERVAL_MS = 2_000;
 
-    @Tool(name = "quarkus_start", description = "Start a Quarkus application in dev mode. "
+    @Tool(name = "quarkus_start", description = "Start a Quarkus application. "
             + "Blocks until the app is ready or fails. "
-            + "Auto-detects Maven or Gradle. Hot reload is triggered when the app is accessed. "
+            + "Auto-detects Maven or Gradle. "
             + "RULES: Always write tests. Always keep README.md updated after changes.")
     ToolResponse start(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
@@ -104,8 +104,7 @@ public class LifecycleTools {
     }
 
     @Tool(name = "quarkus_restart", description = "Force restart a Quarkus application. "
-            + "Blocks until the app is ready or fails. "
-            + "Only use if the app is unresponsive. Normally hot reload handles changes automatically.")
+            + "Blocks until the app is ready or fails.")
     ToolResponse restart(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir) {
         try {
@@ -205,9 +204,7 @@ public class LifecycleTools {
         }
     }
 
-    @Tool(name = "quarkus_logs", description = "Get recent log output from a managed Quarkus application. "
-            + "For structured exception details (class, message, stack trace, user code location), "
-            + "prefer quarkus_callTool with toolName 'devui-exceptions_getLastException' instead.",
+    @Tool(name = "quarkus_logs", description = "Get recent log output from a managed Quarkus application.",
             // title set as workaround: the framework serializes "title":null when unset, which violates the MCP schema
             // see https://github.com/quarkiverse/quarkus-mcp-server/issues/748
             annotations = @Tool.Annotations(title = "quarkus_logs", readOnlyHint = true, destructiveHint = false, openWorldHint = false))

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -63,7 +63,7 @@ public class LifecycleTools {
                 }
             }
 
-            List<String> createdFiles = ProjectFiles.ensureAgentFiles(projectDir);
+            List<String> createdFiles = ProjectFiles.ensureAgentFiles(projectDir, processManager.isDevMode());
             String agentFilesNote = createdFiles.isEmpty() ? ""
                     : "\nGenerated missing agent files: " + String.join(", ", createdFiles);
 

--- a/src/main/java/io/quarkus/agent/mcp/ProjectFiles.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProjectFiles.java
@@ -30,12 +30,12 @@ public final class ProjectFiles {
      *
      * @return list of filenames that were created (empty if all already existed)
      */
-    public static List<String> ensureAgentFiles(String projectDir) {
+    public static List<String> ensureAgentFiles(String projectDir, boolean devMode) {
         List<String> created = new ArrayList<>();
         Path dir = Path.of(projectDir);
 
         if (!Files.exists(dir.resolve(AGENTS_MD))) {
-            generateAgentsMd(projectDir);
+            generateAgentsMd(projectDir, devMode);
             created.add(AGENTS_MD);
         }
         if (!Files.exists(dir.resolve(CLAUDE_MD))) {
@@ -50,95 +50,163 @@ public final class ProjectFiles {
         return created;
     }
 
-    static void generateProjectInstructions(String projectDir) {
-        generateAgentsMd(projectDir);
+    static void generateProjectInstructions(String projectDir, boolean devMode) {
+        generateAgentsMd(projectDir, devMode);
         generateClaudeMd(projectDir);
     }
 
-    private static void generateAgentsMd(String projectDir) {
+    private static void generateAgentsMd(String projectDir, boolean devMode) {
         try {
-            String agentsMdContent = """
-                    # AGENTS.md -- Quarkus Project Instructions
-
-                    This is a Quarkus application. Follow these rules when working on this project.
-
-                    ## CRITICAL -- Extension-First Rule (NEVER skip this)
-
-                    **STOP before writing ANY code.** For every feature or capability the user requests:
-
-                    1. **Search for Quarkus extensions** that provide the capability using `quarkus_searchDocs` and `quarkus_searchTools query='extension'`.
-                       Do NOT rely on a fixed list of extensions -- always search dynamically, as available extensions change across Quarkus versions and platform BOMs.
-                    2. **Present ALL matching extensions to the user** with a recommended default marked. Wait for the user to choose before proceeding.
-                       Do NOT silently pick an extension when multiple options exist.
-                    3. **Load skills** with `quarkus_skills` for the chosen extension BEFORE writing any code.
-
-                    Skipping any of these steps is a violation. NEVER implement a feature by hand-coding HTML, JavaScript, REST endpoints, or other functionality when a Quarkus extension exists for it.
-
-                    ## Required Workflow
-
-                    1. **Use quarkus_skills BEFORE writing any code or tests** -- it contains extension-specific patterns, testing approaches, and common pitfalls that prevent mistakes. Skills may also list **Available Dev MCP Tools** specific to each extension (e.g. OpenAPI schema retrieval, scheduler job management) -- use these via `quarkus_callTool`. Call this EVERY time you are about to add or modify a feature, not just at project creation. When returning to an existing project, query for the `quarkus-update` skill to check if the Quarkus version is up-to-date.
-                    2. **Use quarkus_searchDocs for Quarkus documentation** -- do NOT use generic documentation tools (Context7, web search). The Quarkus doc search is version-aware and more accurate.
-                    3. **Use quarkus_searchTools to discover Dev MCP tools** on the running app for testing, config changes, and extension management. The tool list is **dynamic** -- it changes when extensions are added or removed. Re-call `quarkus_searchTools` after any extension change to discover newly available tools. Note: some extension-specific tools are also documented in the skills output (see step 1).
-                    4. **Use quarkus_callTool to invoke Dev MCP tools** -- run tests, add extensions, update configuration. Do NOT run Maven/Gradle commands manually.
-                    5. **After code changes, trigger a reload** via `quarkus_callTool` with toolName `devui-logstream_forceRestart`. Do NOT restart the app manually.
-                    6. **After pom.xml / build.gradle changes** (adding dependencies or extensions), you MUST do a full `quarkus_stop` + `quarkus_start` cycle. A `forceRestart` only recompiles source files -- it does NOT re-resolve dependencies.
-
-                    ## Rules
-
-                    - NEVER implement features manually when a Quarkus extension exists -- search for and add the right extension first.
-                    - NEVER silently pick an extension when multiple options exist -- ALWAYS present options to the user and wait for their choice.
-                    - NEVER write code for a feature without first loading its skill via `quarkus_skills`.
-                    - ALWAYS write tests for every feature -- no exceptions.
-                    - ALWAYS keep README.md updated with app description, features, endpoints, and Quarkus guide links.
-                    - ALWAYS summarize after completing work -- when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment).
-                    - Use `@QuarkusTest` for integration tests -- Dev Services auto-starts backing services (databases, messaging, etc.).
-                    - Use `%dev.` and `%test.` profile prefixes for dev/test configuration -- never hardcode connection URLs without a profile prefix.
-
-                    ## Testing
-
-                    If your agent supports subagents, run tests in a **subagent** so the main conversation stays responsive:
-
-                    ```
-                    If supported, use the Agent tool to launch a subagent with this prompt:
-                      "Run the Quarkus tests for project <projectDir> using quarkus_callTool
-                       with toolName 'devui-testing_runTests'. Analyze the results and report
-                       which tests passed, failed, or errored. If tests fail, include the
-                       failure messages and suggest fixes."
-                    ```
-
-                    - Use `devui-testing_runTests` to run all tests.
-                    - Use `devui-testing_runTest` with arguments `{"className":"com.example.MyTest"}` to run a specific test class.
-                    - Do NOT run Maven/Gradle test commands manually -- the Dev MCP test tools handle compilation, hot reload, and result reporting.
-                    - After fixing test failures, re-run tests (via a subagent if supported) to verify the fix.
-                    - **NEVER run `mvn clean` or `gradle clean` while dev mode is running** -- it deletes `target/test-classes` and breaks the test runner with no automatic recovery.
-                    - If the test runner gets stuck returning "Tests already in progress", do a full `quarkus_stop` + `quarkus_start` cycle to reset the test runner state.
-
-                    ## Error Handling
-
-                    When something goes wrong (compilation error, deployment failure, runtime exception):
-
-                    1. Use `quarkus_callTool` with toolName `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location).
-                    2. Fix the issue based on the exception details.
-                    3. Call `devui-exceptions_clearLastException` to clear the recorded exception.
-                    4. Use `quarkus_logs` only when you need broader log context beyond the exception itself.
-
-                    **Note:** If the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet -- fall back to `quarkus_logs` in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy.
-
-                    ## Customizing Skills
-
-                    **Global customizations** (`~/.quarkus/skills/`) apply to all projects. Use `quarkus_updateSkill`
-                    to create or update global customizations. Ask the user whether to ENHANCE (append to the base)
-                    or OVERRIDE (fully replace the base).
-
-                    **Project-level skills** (`.agent/skills/`) are standalone files readable by any agent.
-                    Use `quarkus_saveSkill` to materialize the full composed skill into `.agent/skills/`,
-                    then edit the file directly to customize it for the project.
-                    """;
-            Files.writeString(Path.of(projectDir, AGENTS_MD), agentsMdContent, StandardCharsets.UTF_8);
+            String content = devMode ? devModeAgentsMd() : nonDevModeAgentsMd();
+            Files.writeString(Path.of(projectDir, AGENTS_MD), content, StandardCharsets.UTF_8);
             LOG.debugf("Generated %s in %s", AGENTS_MD, projectDir);
         } catch (IOException e) {
             LOG.warnf("Failed to generate %s in %s: %s", AGENTS_MD, projectDir, e.getMessage());
         }
+    }
+
+    private static String devModeAgentsMd() {
+        return """
+                # AGENTS.md -- Quarkus Project Instructions
+
+                This is a Quarkus application. Follow these rules when working on this project.
+
+                ## CRITICAL -- Extension-First Rule (NEVER skip this)
+
+                **STOP before writing ANY code.** For every feature or capability the user requests:
+
+                1. **Search for Quarkus extensions** that provide the capability using `quarkus_searchDocs` and `quarkus_searchTools query='extension'`.
+                   Do NOT rely on a fixed list of extensions -- always search dynamically, as available extensions change across Quarkus versions and platform BOMs.
+                2. **Present ALL matching extensions to the user** with a recommended default marked. Wait for the user to choose before proceeding.
+                   Do NOT silently pick an extension when multiple options exist.
+                3. **Load skills** with `quarkus_skills` for the chosen extension BEFORE writing any code.
+
+                Skipping any of these steps is a violation. NEVER implement a feature by hand-coding HTML, JavaScript, REST endpoints, or other functionality when a Quarkus extension exists for it.
+
+                ## Required Workflow
+
+                1. **Use quarkus_skills BEFORE writing any code or tests** -- it contains extension-specific patterns, testing approaches, and common pitfalls that prevent mistakes. Skills may also list **Available Dev MCP Tools** specific to each extension (e.g. OpenAPI schema retrieval, scheduler job management) -- use these via `quarkus_callTool`. Call this EVERY time you are about to add or modify a feature, not just at project creation. When returning to an existing project, query for the `quarkus-update` skill to check if the Quarkus version is up-to-date.
+                2. **Use quarkus_searchDocs for Quarkus documentation** -- do NOT use generic documentation tools (Context7, web search). The Quarkus doc search is version-aware and more accurate.
+                3. **Use quarkus_searchTools to discover Dev MCP tools** on the running app for testing, config changes, and extension management. The tool list is **dynamic** -- it changes when extensions are added or removed. Re-call `quarkus_searchTools` after any extension change to discover newly available tools. Note: some extension-specific tools are also documented in the skills output (see step 1).
+                4. **Use quarkus_callTool to invoke Dev MCP tools** -- run tests, add extensions, update configuration. Do NOT run Maven/Gradle commands manually.
+                5. **After code changes, trigger a reload** via `quarkus_callTool` with toolName `devui-logstream_forceRestart`. Do NOT restart the app manually.
+                6. **After pom.xml / build.gradle changes** (adding dependencies or extensions), you MUST do a full `quarkus_stop` + `quarkus_start` cycle. A `forceRestart` only recompiles source files -- it does NOT re-resolve dependencies.
+
+                ## Rules
+
+                - NEVER implement features manually when a Quarkus extension exists -- search for and add the right extension first.
+                - NEVER silently pick an extension when multiple options exist -- ALWAYS present options to the user and wait for their choice.
+                - NEVER write code for a feature without first loading its skill via `quarkus_skills`.
+                - ALWAYS write tests for every feature -- no exceptions.
+                - ALWAYS keep README.md updated with app description, features, endpoints, and Quarkus guide links.
+                - ALWAYS summarize after completing work -- when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment).
+                - Use `@QuarkusTest` for integration tests -- Dev Services auto-starts backing services (databases, messaging, etc.).
+                - Use `%dev.` and `%test.` profile prefixes for dev/test configuration -- never hardcode connection URLs without a profile prefix.
+
+                ## Testing
+
+                If your agent supports subagents, run tests in a **subagent** so the main conversation stays responsive:
+
+                ```
+                If supported, use the Agent tool to launch a subagent with this prompt:
+                  "Run the Quarkus tests for project <projectDir> using quarkus_callTool
+                   with toolName 'devui-testing_runTests'. Analyze the results and report
+                   which tests passed, failed, or errored. If tests fail, include the
+                   failure messages and suggest fixes."
+                ```
+
+                - Use `devui-testing_runTests` to run all tests.
+                - Use `devui-testing_runTest` with arguments `{"className":"com.example.MyTest"}` to run a specific test class.
+                - Do NOT run Maven/Gradle test commands manually -- the Dev MCP test tools handle compilation, hot reload, and result reporting.
+                - After fixing test failures, re-run tests (via a subagent if supported) to verify the fix.
+                - **NEVER run `mvn clean` or `gradle clean` while dev mode is running** -- it deletes `target/test-classes` and breaks the test runner with no automatic recovery.
+                - If the test runner gets stuck returning "Tests already in progress", do a full `quarkus_stop` + `quarkus_start` cycle to reset the test runner state.
+
+                ## Error Handling
+
+                When something goes wrong (compilation error, deployment failure, runtime exception):
+
+                1. Use `quarkus_callTool` with toolName `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location).
+                2. Fix the issue based on the exception details.
+                3. Call `devui-exceptions_clearLastException` to clear the recorded exception.
+                4. Use `quarkus_logs` only when you need broader log context beyond the exception itself.
+
+                **Note:** If the app fails on its very first deploy (before the Dev MCP handler is registered), the exception endpoint won't exist yet -- fall back to `quarkus_logs` in that case. For hot-reload failures (the common case), the endpoint is always available from the prior successful deploy.
+
+                ## Customizing Skills
+
+                **Global customizations** (`~/.quarkus/skills/`) apply to all projects. Use `quarkus_updateSkill`
+                to create or update global customizations. Ask the user whether to ENHANCE (append to the base)
+                or OVERRIDE (fully replace the base).
+
+                **Project-level skills** (`.agent/skills/`) are standalone files readable by any agent.
+                Use `quarkus_saveSkill` to materialize the full composed skill into `.agent/skills/`,
+                then edit the file directly to customize it for the project.
+                """;
+    }
+
+    private static String nonDevModeAgentsMd() {
+        return """
+                # AGENTS.md -- Quarkus Project Instructions
+
+                This is a Quarkus application. Follow these rules when working on this project.
+
+                ## CRITICAL -- Extension-First Rule (NEVER skip this)
+
+                **STOP before writing ANY code.** For every feature or capability the user requests:
+
+                1. **Search for Quarkus extensions** that provide the capability using `quarkus_searchDocs`.
+                   Do NOT rely on a fixed list of extensions -- always search dynamically, as available extensions change across Quarkus versions and platform BOMs.
+                2. **Present ALL matching extensions to the user** with a recommended default marked. Wait for the user to choose before proceeding.
+                   Do NOT silently pick an extension when multiple options exist.
+                3. **Load skills** with `quarkus_skills` for the chosen extension BEFORE writing any code.
+
+                Skipping any of these steps is a violation. NEVER implement a feature by hand-coding HTML, JavaScript, REST endpoints, or other functionality when a Quarkus extension exists for it.
+
+                ## Required Workflow
+
+                1. **Use quarkus_skills BEFORE writing any code or tests** -- it contains extension-specific patterns, testing approaches, and common pitfalls that prevent mistakes. Call this EVERY time you are about to add or modify a feature, not just at project creation. When returning to an existing project, query for the `quarkus-update` skill to check if the Quarkus version is up-to-date.
+                2. **Use quarkus_searchDocs for Quarkus documentation** -- do NOT use generic documentation tools (Context7, web search). The Quarkus doc search is version-aware and more accurate.
+                3. **After code changes, use `quarkus_restart`** to rebuild and restart the application. This performs a full stop, rebuild, and start cycle.
+                4. **After pom.xml / build.gradle changes** (adding dependencies or extensions), you MUST do a full `quarkus_stop` + `quarkus_start` cycle to re-resolve dependencies.
+
+                ## Rules
+
+                - NEVER implement features manually when a Quarkus extension exists -- search for and add the right extension first.
+                - NEVER silently pick an extension when multiple options exist -- ALWAYS present options to the user and wait for their choice.
+                - NEVER write code for a feature without first loading its skill via `quarkus_skills`.
+                - ALWAYS write tests for every feature -- no exceptions.
+                - ALWAYS keep README.md updated with app description, features, endpoints, and Quarkus guide links.
+                - ALWAYS summarize after completing work -- when you finish building an app, adding a feature, or completing a task, provide a clear summary of what was done (files created/modified, endpoints added, extensions used, etc.) and suggest logical next steps the user might want to take (e.g. adding security, observability, persistence, testing improvements, deployment).
+                - Use `@QuarkusTest` for integration tests -- Dev Services auto-starts backing services (databases, messaging, etc.).
+                - Use `%dev.` and `%test.` profile prefixes for dev/test configuration -- never hardcode connection URLs without a profile prefix.
+
+                ## Testing
+
+                Run tests using Maven or Gradle directly:
+
+                - `mvn test` to run all tests, or `mvn test -Dtest=com.example.MyTest` for a specific test class.
+                - For Gradle projects: `gradle test` or `gradle test --tests com.example.MyTest`.
+                - After fixing test failures, re-run tests to verify the fix.
+
+                ## Error Handling
+
+                When something goes wrong (compilation error, deployment failure, runtime exception):
+
+                1. Use `quarkus_logs` to get recent log output and identify the error.
+                2. Fix the issue based on the log details.
+                3. Use `quarkus_restart` to rebuild and verify the fix.
+
+                ## Customizing Skills
+
+                **Global customizations** (`~/.quarkus/skills/`) apply to all projects. Use `quarkus_updateSkill`
+                to create or update global customizations. Ask the user whether to ENHANCE (append to the base)
+                or OVERRIDE (fully replace the base).
+
+                **Project-level skills** (`.agent/skills/`) are standalone files readable by any agent.
+                Use `quarkus_saveSkill` to materialize the full composed skill into `.agent/skills/`,
+                then edit the file directly to customize it for the project.
+                """;
     }
 
     private static void generateClaudeMd(String projectDir) {

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -32,8 +32,8 @@ public class QuarkusProcessManager {
     @Inject
     ManagedExecutor executor;
 
-    @ConfigProperty(name = "agent-mcp.dev-mode", defaultValue = "true")
-    boolean devMode;
+    @ConfigProperty(name = "agent-mcp.mode", defaultValue = "dev")
+    String mode;
 
     @ConfigProperty(name = "agent-mcp.process.gradle-cmd")
     Optional<String> gradleCmd;
@@ -41,8 +41,12 @@ public class QuarkusProcessManager {
     @ConfigProperty(name = "agent-mcp.app-log.enabled")
     Optional<Boolean> appLogEnabled;
 
+    public String getMode() {
+        return mode;
+    }
+
     public boolean isDevMode() {
-        return devMode;
+        return "dev".equals(mode);
     }
 
     private static final Set<String> VALID_BUILD_TOOLS = Set.of("maven", "gradle");
@@ -90,10 +94,8 @@ public class QuarkusProcessManager {
             if (appLogEnabled.orElse(false)) {
                 instance.enableFileLogging(computeLogFile(normalizedDir));
             }
-            String mode = devMode ? "dev" : "prod";
             LOG.infof("Started Quarkus %s mode at: %s (build tool: %s)", mode, normalizedDir, detectedBuildTool);
         } catch (IOException e) {
-            String mode = devMode ? "dev" : "prod";
             throw new RuntimeException("Failed to start Quarkus " + mode + " mode: " + e.getMessage(), e);
         }
         return effectivePort;
@@ -118,7 +120,7 @@ public class QuarkusProcessManager {
                     "No Quarkus instance found at: " + normalizedDir + ". Use quarkus_start first.");
         }
 
-        if (devMode && instance.isAlive()) {
+        if (isDevMode() && instance.isAlive()) {
             instance.restart();
             LOG.infof("Live reload triggered at: %s", normalizedDir);
         } else {
@@ -215,11 +217,14 @@ public class QuarkusProcessManager {
         String mvnCmd = ProcessUtils.resolveMavenCommand(projectDir);
         var command = new ArrayList<String>();
         command.add(mvnCmd);
-        if (devMode) {
+        if (isDevMode()) {
             command.addAll(List.of("quarkus:dev",
                     "-Dquarkus.console.basic=true", "-Dquarkus.dev-mcp.enabled=true"));
         } else {
             command.add("quarkus:run");
+            if ("test".equals(mode)) {
+                command.add("-Dquarkus.profile=test");
+            }
         }
         if (mavenProfiles != null && !mavenProfiles.isBlank()) {
             command.add("-P" + mavenProfiles.trim());
@@ -229,11 +234,15 @@ public class QuarkusProcessManager {
 
     private ProcessBuilder createGradleProcessBuilder(File projectDir) {
         String cmd = gradleCmd.orElseGet(() -> ProcessUtils.resolveGradleCommand(projectDir));
-        if (devMode) {
+        if (isDevMode()) {
             return new ProcessBuilder(cmd, "quarkusDev",
                     "-Dquarkus.console.basic=true", "-Dquarkus.dev-mcp.enabled=true");
         }
-        return new ProcessBuilder(cmd, "quarkusRun");
+        var command = new ArrayList<>(List.of(cmd, "quarkusRun"));
+        if ("test".equals(mode)) {
+            command.add("-Dquarkus.profile=test");
+        }
+        return new ProcessBuilder(command);
     }
 
     static boolean isPortAvailable(int port) {

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -1,5 +1,6 @@
 package io.quarkus.agent.mcp;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -49,6 +50,15 @@ public class QuarkusProcessManager {
         return "dev".equals(mode);
     }
 
+    @PostConstruct
+    void validateMode() {
+        if (!VALID_MODES.contains(mode)) {
+            throw new IllegalStateException(
+                    "Invalid agent-mcp.mode: '" + mode + "'. Must be one of: " + VALID_MODES);
+        }
+    }
+
+    private static final Set<String> VALID_MODES = Set.of("dev", "test", "prod");
     private static final Set<String> VALID_BUILD_TOOLS = Set.of("maven", "gradle");
     static final int DEFAULT_HTTP_PORT = 8080;
     private static final int MAX_PORT_SCAN = 100;

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -93,7 +93,8 @@ public class QuarkusProcessManager {
             String mode = devMode ? "dev" : "prod";
             LOG.infof("Started Quarkus %s mode at: %s (build tool: %s)", mode, normalizedDir, detectedBuildTool);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to start Quarkus dev mode: " + e.getMessage(), e);
+            String mode = devMode ? "dev" : "prod";
+            throw new RuntimeException("Failed to start Quarkus " + mode + " mode: " + e.getMessage(), e);
         }
         return effectivePort;
     }

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -32,11 +32,18 @@ public class QuarkusProcessManager {
     @Inject
     ManagedExecutor executor;
 
+    @ConfigProperty(name = "agent-mcp.dev-mode", defaultValue = "true")
+    boolean devMode;
+
     @ConfigProperty(name = "agent-mcp.process.gradle-cmd")
     Optional<String> gradleCmd;
 
     @ConfigProperty(name = "agent-mcp.app-log.enabled")
     Optional<Boolean> appLogEnabled;
+
+    public boolean isDevMode() {
+        return devMode;
+    }
 
     private static final Set<String> VALID_BUILD_TOOLS = Set.of("maven", "gradle");
     static final int DEFAULT_HTTP_PORT = 8080;
@@ -83,7 +90,8 @@ public class QuarkusProcessManager {
             if (appLogEnabled.orElse(false)) {
                 instance.enableFileLogging(computeLogFile(normalizedDir));
             }
-            LOG.infof("Started Quarkus dev mode at: %s (build tool: %s)", normalizedDir, detectedBuildTool);
+            String mode = devMode ? "dev" : "prod";
+            LOG.infof("Started Quarkus %s mode at: %s (build tool: %s)", mode, normalizedDir, detectedBuildTool);
         } catch (IOException e) {
             throw new RuntimeException("Failed to start Quarkus dev mode: " + e.getMessage(), e);
         }
@@ -109,17 +117,20 @@ public class QuarkusProcessManager {
                     "No Quarkus instance found at: " + normalizedDir + ". Use quarkus_start first.");
         }
 
-        if (!instance.isAlive()) {
+        if (devMode && instance.isAlive()) {
+            instance.restart();
+            LOG.infof("Live reload triggered at: %s", normalizedDir);
+        } else {
             String savedBuildTool = instance.getBuildTool();
             Integer savedHttpPort = instance.getRequestedHttpPort();
             String savedMavenProfiles = instance.getMavenProfiles();
             String savedExtraArgs = instance.getExtraArgs();
+            if (instance.isAlive()) {
+                instance.stop();
+            }
             instances.remove(normalizedDir);
             start(normalizedDir, savedBuildTool, savedHttpPort, savedMavenProfiles, savedExtraArgs);
-            LOG.infof("Re-started dead Quarkus instance at: %s", normalizedDir);
-        } else {
-            instance.restart();
-            LOG.infof("Restart triggered at: %s", normalizedDir);
+            LOG.infof("Full restart at: %s", normalizedDir);
         }
     }
 
@@ -201,8 +212,14 @@ public class QuarkusProcessManager {
 
     private ProcessBuilder createMavenProcessBuilder(File projectDir, String mavenProfiles) {
         String mvnCmd = ProcessUtils.resolveMavenCommand(projectDir);
-        var command = new ArrayList<>(List.of(mvnCmd, "quarkus:dev",
-                "-Dquarkus.console.basic=true", "-Dquarkus.dev-mcp.enabled=true"));
+        var command = new ArrayList<String>();
+        command.add(mvnCmd);
+        if (devMode) {
+            command.addAll(List.of("quarkus:dev",
+                    "-Dquarkus.console.basic=true", "-Dquarkus.dev-mcp.enabled=true"));
+        } else {
+            command.add("quarkus:run");
+        }
         if (mavenProfiles != null && !mavenProfiles.isBlank()) {
             command.add("-P" + mavenProfiles.trim());
         }
@@ -211,8 +228,11 @@ public class QuarkusProcessManager {
 
     private ProcessBuilder createGradleProcessBuilder(File projectDir) {
         String cmd = gradleCmd.orElseGet(() -> ProcessUtils.resolveGradleCommand(projectDir));
-        return new ProcessBuilder(cmd, "quarkusDev", "-Dquarkus.console.basic=true",
-                "-Dquarkus.dev-mcp.enabled=true");
+        if (devMode) {
+            return new ProcessBuilder(cmd, "quarkusDev",
+                    "-Dquarkus.console.basic=true", "-Dquarkus.dev-mcp.enabled=true");
+        }
+        return new ProcessBuilder(cmd, "quarkusRun");
     }
 
     static boolean isPortAvailable(int port) {

--- a/src/main/java/io/quarkus/agent/mcp/StartupObserver.java
+++ b/src/main/java/io/quarkus/agent/mcp/StartupObserver.java
@@ -6,7 +6,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import java.util.List;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -23,15 +22,15 @@ public class StartupObserver {
     @Inject
     ToolManager toolManager;
 
-    @ConfigProperty(name = "agent-mcp.mode", defaultValue = "dev")
-    String mode;
+    @Inject
+    QuarkusProcessManager processManager;
 
     void onStart(@Observes StartupEvent event) {
         LOG.infof("Quarkus Agent MCP running on Java %s (%s) — %s mode",
-                Runtime.version(), System.getProperty("java.vm.name"), mode);
+                Runtime.version(), System.getProperty("java.vm.name"), processManager.getMode());
         containerManager.warmUpDefaultAsync();
 
-        if (!"dev".equals(mode)) {
+        if (!processManager.isDevMode()) {
             for (String toolName : DEV_MODE_ONLY_TOOLS) {
                 if (toolManager.removeTool(toolName) != null) {
                     LOG.infof("Removed dev-mode-only tool: %s", toolName);

--- a/src/main/java/io/quarkus/agent/mcp/StartupObserver.java
+++ b/src/main/java/io/quarkus/agent/mcp/StartupObserver.java
@@ -23,16 +23,15 @@ public class StartupObserver {
     @Inject
     ToolManager toolManager;
 
-    @ConfigProperty(name = "agent-mcp.dev-mode", defaultValue = "true")
-    boolean devMode;
+    @ConfigProperty(name = "agent-mcp.mode", defaultValue = "dev")
+    String mode;
 
     void onStart(@Observes StartupEvent event) {
         LOG.infof("Quarkus Agent MCP running on Java %s (%s) — %s mode",
-                Runtime.version(), System.getProperty("java.vm.name"),
-                devMode ? "dev" : "prod");
+                Runtime.version(), System.getProperty("java.vm.name"), mode);
         containerManager.warmUpDefaultAsync();
 
-        if (!devMode) {
+        if (!"dev".equals(mode)) {
             for (String toolName : DEV_MODE_ONLY_TOOLS) {
                 if (toolManager.removeTool(toolName) != null) {
                     LOG.infof("Removed dev-mode-only tool: %s", toolName);

--- a/src/main/java/io/quarkus/agent/mcp/StartupObserver.java
+++ b/src/main/java/io/quarkus/agent/mcp/StartupObserver.java
@@ -1,9 +1,12 @@
 package io.quarkus.agent.mcp;
 
+import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import java.util.List;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 @ApplicationScoped
@@ -11,12 +14,30 @@ public class StartupObserver {
 
     private static final Logger LOG = Logger.getLogger(StartupObserver.class);
 
+    private static final List<String> DEV_MODE_ONLY_TOOLS = List.of(
+            "quarkus_searchTools", "quarkus_callTool", "quarkus_browser");
+
     @Inject
     ContainerManager containerManager;
 
+    @Inject
+    ToolManager toolManager;
+
+    @ConfigProperty(name = "agent-mcp.dev-mode", defaultValue = "true")
+    boolean devMode;
+
     void onStart(@Observes StartupEvent event) {
-        LOG.infof("Quarkus Agent MCP running on Java %s (%s)",
-                Runtime.version(), System.getProperty("java.vm.name"));
+        LOG.infof("Quarkus Agent MCP running on Java %s (%s) — %s mode",
+                Runtime.version(), System.getProperty("java.vm.name"),
+                devMode ? "dev" : "prod");
         containerManager.warmUpDefaultAsync();
+
+        if (!devMode) {
+            for (String toolName : DEV_MODE_ONLY_TOOLS) {
+                if (toolManager.removeTool(toolName) != null) {
+                    LOG.infof("Removed dev-mode-only tool: %s", toolName);
+                }
+            }
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,29 +11,22 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   2. quarkus_skills -- call before writing code to learn correct patterns (supports comma-separated queries, e.g. 'panache,rest')\n\
   3. quarkus_searchDocs -- search Quarkus docs for APIs, config, best practices (pass projectDir for version-matched results)\n\
   4. Write code and tests\n\
-  5. quarkus_callTool toolName='devui-testing_runTests' -- run tests\n\n\
+  5. Run tests -- see AGENTS.md in your project for mode-specific instructions\n\n\
   WORKFLOW for existing projects:\n\
-  1. quarkus_start -- start the app in dev mode (blocks until ready)\n\
+  1. quarkus_start -- start the app (blocks until ready)\n\
   2. quarkus_skills -- learn extension-specific patterns before writing code\n\
   3. Write code following patterns from skills and docs\n\
-  4. Run tests with quarkus_callTool\n\n\
+  4. Run tests -- see AGENTS.md in your project for mode-specific instructions\n\n\
   WORKFLOW for migrating Spring Boot to Quarkus:\n\
   1. quarkus_skills -- call with the Spring project's directory to discover the migration skill (migrate-spring-to-quarkus)\n\
   2. Read and follow the migration skill instructions -- it provides a complete modular, gate-driven migration process\n\
   3. Do NOT plan your own migration approach -- the skill handles strategy selection, module execution, and verification\n\n\
-  TESTING:\n\
-  - Use quarkus_callTool with toolName 'devui-testing_runTests' to run all tests\n\
-  - Use quarkus_callTool with toolName 'devui-testing_runTest' and toolArguments '{"className":"com.example.MyTest"}' for a specific test\n\
-  - Do not run Maven/Gradle test commands manually\n\
-  - Do not run 'mvn clean' or 'gradle clean' while dev mode is running -- it breaks the test runner\n\n\
-  ERROR HANDLING:\n\
-  - Use quarkus_callTool with toolName 'devui-exceptions_getLastException' for structured exception details\n\
-  - Use quarkus_logs only when you need broader log context beyond the exception\n\n\
   RULES:\n\
   - Use quarkus_searchDocs for Quarkus questions (pass projectDir when a project exists)\n\
-  - Do not run build commands manually -- use quarkus_start and quarkus_callTool\n\
+  - Use quarkus_logs when you need log context for debugging\n\
   - Write tests for every feature\n\
-  - Keep README.md updated
+  - Keep README.md updated\n\
+  - Follow the AGENTS.md instructions generated in each project for testing, error handling, and reload workflows
 
 # Make sure the tool names follow the spec rules
 quarkus.mcp.server.tools.name-pattern=^[A-Za-z0-9_.-]{1,128}$

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,6 +42,12 @@ quarkus.mcp.server.tools.name-pattern=^[A-Za-z0-9_.-]{1,128}$
 # Uncomment for local testing against a SNAPSHOT build:
 # agent-mcp.default-quarkus-version=999-SNAPSHOT
 
+# Dev mode (default: true)
+# When true, applications are started with quarkus:dev / quarkusDev (hot reload, Dev MCP, Dev UI).
+# When false, applications are started with quarkus:run / quarkusRun (prod mode) and
+# dev-mode-only tools (quarkus_searchTools, quarkus_callTool, quarkus_browser) are removed.
+agent-mcp.dev-mode=true
+
 # Include transitive dependencies when scanning for extension skills
 # Default is false (only direct dependencies) for backward compatibility
 # Set to true to discover skills from indirect dependencies as well

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,11 +42,11 @@ quarkus.mcp.server.tools.name-pattern=^[A-Za-z0-9_.-]{1,128}$
 # Uncomment for local testing against a SNAPSHOT build:
 # agent-mcp.default-quarkus-version=999-SNAPSHOT
 
-# Dev mode (default: true)
-# When true, applications are started with quarkus:dev / quarkusDev (hot reload, Dev MCP, Dev UI).
-# When false, applications are started with quarkus:run / quarkusRun (prod mode) and
-# dev-mode-only tools (quarkus_searchTools, quarkus_callTool, quarkus_browser) are removed.
-agent-mcp.dev-mode=true
+# Application mode: dev (default), test, or prod
+# dev  — quarkus:dev / quarkusDev (hot reload, Dev MCP, Dev UI, all tools)
+# test — quarkus:run / quarkusRun with -Dquarkus.profile=test (dev-only tools removed)
+# prod — quarkus:run / quarkusRun (dev-only tools removed)
+agent-mcp.mode=dev
 
 # Include transitive dependencies when scanning for extension skills
 # Default is false (only direct dependencies) for backward compatibility

--- a/src/test/java/io/quarkus/agent/mcp/ProjectFilesTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/ProjectFilesTest.java
@@ -13,7 +13,7 @@ class ProjectFilesTest {
 
     @Test
     void ensureAgentFiles_createsAllInEmptyDir(@TempDir Path tempDir) {
-        List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString());
+        List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
 
         assertEquals(List.of("AGENTS.md", "CLAUDE.md", ".mcp.json"), created);
         assertTrue(Files.exists(tempDir.resolve("AGENTS.md")));
@@ -27,7 +27,7 @@ class ProjectFilesTest {
         Files.writeString(tempDir.resolve("CLAUDE.md"), "custom claude");
         Files.writeString(tempDir.resolve(".mcp.json"), "{}");
 
-        List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString());
+        List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
 
         assertTrue(created.isEmpty());
         assertEquals("custom content", Files.readString(tempDir.resolve("AGENTS.md")));
@@ -39,7 +39,7 @@ class ProjectFilesTest {
     void ensureAgentFiles_createsOnlyMissing(@TempDir Path tempDir) throws IOException {
         Files.writeString(tempDir.resolve("AGENTS.md"), "custom content");
 
-        List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString());
+        List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
 
         assertEquals(List.of("CLAUDE.md", ".mcp.json"), created);
         assertEquals("custom content", Files.readString(tempDir.resolve("AGENTS.md")));
@@ -49,7 +49,7 @@ class ProjectFilesTest {
 
     @Test
     void generatedAgentsMd_containsWorkflowInstructions(@TempDir Path tempDir) throws IOException {
-        ProjectFiles.ensureAgentFiles(tempDir.toString());
+        ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
 
         String content = Files.readString(tempDir.resolve("AGENTS.md"));
         assertTrue(content.contains("Extension-First Rule"));
@@ -59,7 +59,7 @@ class ProjectFilesTest {
 
     @Test
     void generatedClaudeMd_pointsToAgentsMd(@TempDir Path tempDir) throws IOException {
-        ProjectFiles.ensureAgentFiles(tempDir.toString());
+        ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
 
         String content = Files.readString(tempDir.resolve("CLAUDE.md"));
         assertTrue(content.contains("AGENTS.md"));
@@ -67,11 +67,38 @@ class ProjectFilesTest {
 
     @Test
     void generatedMcpJson_containsServerConfig(@TempDir Path tempDir) throws IOException {
-        ProjectFiles.ensureAgentFiles(tempDir.toString());
+        ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
 
         String content = Files.readString(tempDir.resolve(".mcp.json"));
         assertTrue(content.contains("quarkus-agent"));
         assertTrue(content.contains("jbang"));
         assertTrue(content.contains("quarkus-agent-mcp@quarkusio"));
+    }
+
+    @Test
+    void devModeAgentsMd_containsDevTools(@TempDir Path tempDir) throws IOException {
+        ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
+
+        String content = Files.readString(tempDir.resolve("AGENTS.md"));
+        assertTrue(content.contains("quarkus_searchTools"));
+        assertTrue(content.contains("quarkus_callTool"));
+        assertTrue(content.contains("devui-testing_runTests"));
+        assertTrue(content.contains("devui-exceptions_getLastException"));
+        assertTrue(content.contains("devui-logstream_forceRestart"));
+    }
+
+    @Test
+    void nonDevModeAgentsMd_omitsDevTools(@TempDir Path tempDir) throws IOException {
+        ProjectFiles.ensureAgentFiles(tempDir.toString(), false);
+
+        String content = Files.readString(tempDir.resolve("AGENTS.md"));
+        assertFalse(content.contains("quarkus_searchTools"));
+        assertFalse(content.contains("quarkus_callTool"));
+        assertFalse(content.contains("devui-testing_runTests"));
+        assertFalse(content.contains("devui-exceptions_getLastException"));
+        assertFalse(content.contains("devui-logstream_forceRestart"));
+        assertTrue(content.contains("quarkus_restart"));
+        assertTrue(content.contains("quarkus_logs"));
+        assertTrue(content.contains("mvn test"));
     }
 }

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -175,18 +175,18 @@ class QuarkusProcessManagerTest {
     }
 
     private void initOptionalFields() throws Exception {
-        initOptionalFields(true);
+        initOptionalFields("dev");
     }
 
-    private void initOptionalFields(boolean devMode) throws Exception {
+    private void initOptionalFields(String mode) throws Exception {
         for (String fieldName : new String[] { "gradleCmd", "appLogEnabled" }) {
             Field f = QuarkusProcessManager.class.getDeclaredField(fieldName);
             f.setAccessible(true);
             f.set(manager, Optional.empty());
         }
-        Field devModeField = QuarkusProcessManager.class.getDeclaredField("devMode");
-        devModeField.setAccessible(true);
-        devModeField.setBoolean(manager, devMode);
+        Field modeField = QuarkusProcessManager.class.getDeclaredField("mode");
+        modeField.setAccessible(true);
+        modeField.set(manager, mode);
     }
 
     @Test
@@ -290,14 +290,27 @@ class QuarkusProcessManagerTest {
     }
 
     @Test
-    void devModeDefaultIsTrue() {
-        // CDI injects defaultValue = "true"; verify getter reflects that when set
+    void modeDefaultIsDev() {
         QuarkusProcessManager pm = new QuarkusProcessManager();
         try {
-            Field f = QuarkusProcessManager.class.getDeclaredField("devMode");
+            Field f = QuarkusProcessManager.class.getDeclaredField("mode");
             f.setAccessible(true);
-            f.setBoolean(pm, true);
+            f.set(pm, "dev");
+            assertEquals("dev", pm.getMode());
             assertTrue(pm.isDevMode());
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void isDevModeReturnsFalseForProd() {
+        QuarkusProcessManager pm = new QuarkusProcessManager();
+        try {
+            Field f = QuarkusProcessManager.class.getDeclaredField("mode");
+            f.setAccessible(true);
+            f.set(pm, "prod");
+            assertFalse(pm.isDevMode());
         } catch (Exception e) {
             fail(e);
         }
@@ -306,7 +319,7 @@ class QuarkusProcessManagerTest {
     @Test
     void processBuilderUsesMavenDevModeByDefault() throws Exception {
         Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
-        initOptionalFields(true);
+        initOptionalFields("dev");
         Method m = QuarkusProcessManager.class.getDeclaredMethod(
                 "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
         m.setAccessible(true);
@@ -319,7 +332,7 @@ class QuarkusProcessManagerTest {
     @Test
     void processBuilderUsesMavenProdMode() throws Exception {
         Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
-        initOptionalFields(false);
+        initOptionalFields("prod");
         Method m = QuarkusProcessManager.class.getDeclaredMethod(
                 "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
         m.setAccessible(true);
@@ -328,26 +341,52 @@ class QuarkusProcessManagerTest {
         assertFalse(pb.command().contains("quarkus:dev"));
         assertFalse(pb.command().contains("-Dquarkus.dev-mcp.enabled=true"));
         assertFalse(pb.command().contains("-Dquarkus.console.basic=true"));
+        assertFalse(pb.command().contains("-Dquarkus.profile=test"));
+    }
+
+    @Test
+    void processBuilderUsesMavenTestMode() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields("test");
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, (String) null, (String) null);
+        assertTrue(pb.command().contains("quarkus:run"));
+        assertTrue(pb.command().contains("-Dquarkus.profile=test"));
+        assertFalse(pb.command().contains("quarkus:dev"));
     }
 
     @Test
     void processBuilderUsesGradleProdMode() throws Exception {
         Files.writeString(tempDir.resolve("build.gradle"), "// gradle");
-        initOptionalFields(false);
+        initOptionalFields("prod");
         Method m = QuarkusProcessManager.class.getDeclaredMethod(
                 "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
         m.setAccessible(true);
         ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "gradle", (Integer) null, (String) null, (String) null);
         assertTrue(pb.command().contains("quarkusRun"));
         assertFalse(pb.command().contains("quarkusDev"));
-        assertFalse(pb.command().contains("-Dquarkus.dev-mcp.enabled=true"));
-        assertFalse(pb.command().contains("-Dquarkus.console.basic=true"));
+        assertFalse(pb.command().contains("-Dquarkus.profile=test"));
+    }
+
+    @Test
+    void processBuilderUsesGradleTestMode() throws Exception {
+        Files.writeString(tempDir.resolve("build.gradle"), "// gradle");
+        initOptionalFields("test");
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "gradle", (Integer) null, (String) null, (String) null);
+        assertTrue(pb.command().contains("quarkusRun"));
+        assertTrue(pb.command().contains("-Dquarkus.profile=test"));
+        assertFalse(pb.command().contains("quarkusDev"));
     }
 
     @Test
     void processBuilderProdModeIncludesPortArgs() throws Exception {
         Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
-        initOptionalFields(false);
+        initOptionalFields("prod");
         Method m = QuarkusProcessManager.class.getDeclaredMethod(
                 "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
         m.setAccessible(true);
@@ -359,7 +398,7 @@ class QuarkusProcessManagerTest {
     @Test
     void processBuilderProdModeIncludesMavenProfile() throws Exception {
         Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
-        initOptionalFields(false);
+        initOptionalFields("prod");
         Method m = QuarkusProcessManager.class.getDeclaredMethod(
                 "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
         m.setAccessible(true);

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -175,11 +175,18 @@ class QuarkusProcessManagerTest {
     }
 
     private void initOptionalFields() throws Exception {
+        initOptionalFields(true);
+    }
+
+    private void initOptionalFields(boolean devMode) throws Exception {
         for (String fieldName : new String[] { "gradleCmd", "appLogEnabled" }) {
             Field f = QuarkusProcessManager.class.getDeclaredField(fieldName);
             f.setAccessible(true);
             f.set(manager, Optional.empty());
         }
+        Field devModeField = QuarkusProcessManager.class.getDeclaredField("devMode");
+        devModeField.setAccessible(true);
+        devModeField.setBoolean(manager, devMode);
     }
 
     @Test
@@ -280,5 +287,84 @@ class QuarkusProcessManagerTest {
         String path2 = (String) m.invoke(manager, tempDir.toString() + "/./");
 
         assertEquals(path1, path2);
+    }
+
+    @Test
+    void devModeDefaultIsTrue() {
+        // CDI injects defaultValue = "true"; verify getter reflects that when set
+        QuarkusProcessManager pm = new QuarkusProcessManager();
+        try {
+            Field f = QuarkusProcessManager.class.getDeclaredField("devMode");
+            f.setAccessible(true);
+            f.setBoolean(pm, true);
+            assertTrue(pm.isDevMode());
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void processBuilderUsesMavenDevModeByDefault() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields(true);
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, (String) null, (String) null);
+        assertTrue(pb.command().contains("quarkus:dev"));
+        assertTrue(pb.command().contains("-Dquarkus.dev-mcp.enabled=true"));
+        assertTrue(pb.command().contains("-Dquarkus.console.basic=true"));
+    }
+
+    @Test
+    void processBuilderUsesMavenProdMode() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields(false);
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, (String) null, (String) null);
+        assertTrue(pb.command().contains("quarkus:run"));
+        assertFalse(pb.command().contains("quarkus:dev"));
+        assertFalse(pb.command().contains("-Dquarkus.dev-mcp.enabled=true"));
+        assertFalse(pb.command().contains("-Dquarkus.console.basic=true"));
+    }
+
+    @Test
+    void processBuilderUsesGradleProdMode() throws Exception {
+        Files.writeString(tempDir.resolve("build.gradle"), "// gradle");
+        initOptionalFields(false);
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "gradle", (Integer) null, (String) null, (String) null);
+        assertTrue(pb.command().contains("quarkusRun"));
+        assertFalse(pb.command().contains("quarkusDev"));
+        assertFalse(pb.command().contains("-Dquarkus.dev-mcp.enabled=true"));
+        assertFalse(pb.command().contains("-Dquarkus.console.basic=true"));
+    }
+
+    @Test
+    void processBuilderProdModeIncludesPortArgs() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields(false);
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", 9090, (String) null, (String) null);
+        assertTrue(pb.command().contains("quarkus:run"));
+        assertTrue(pb.command().contains("-Dquarkus.http.port=9090"));
+    }
+
+    @Test
+    void processBuilderProdModeIncludesMavenProfile() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields(false);
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, "myprofile", (String) null);
+        assertTrue(pb.command().contains("quarkus:run"));
+        assertTrue(pb.command().contains("-Pmyprofile"));
     }
 }

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -406,4 +406,24 @@ class QuarkusProcessManagerTest {
         assertTrue(pb.command().contains("quarkus:run"));
         assertTrue(pb.command().contains("-Pmyprofile"));
     }
+
+    @Test
+    void validateModeAcceptsValidModes() throws Exception {
+        for (String validMode : new String[] { "dev", "test", "prod" }) {
+            QuarkusProcessManager pm = new QuarkusProcessManager();
+            Field f = QuarkusProcessManager.class.getDeclaredField("mode");
+            f.setAccessible(true);
+            f.set(pm, validMode);
+            pm.validateMode();
+        }
+    }
+
+    @Test
+    void validateModeRejectsInvalidMode() throws Exception {
+        QuarkusProcessManager pm = new QuarkusProcessManager();
+        Field f = QuarkusProcessManager.class.getDeclaredField("mode");
+        f.setAccessible(true);
+        f.set(pm, "invalid");
+        assertThrows(IllegalStateException.class, pm::validateMode);
+    }
 }


### PR DESCRIPTION
Some users — especially in corporate environments with heavy dev services — don't use dev mode and find it unreliable for their workflows. They want the agent for skills and docs, using standard `mvn compile` / `mvn test` workflows instead of hot-reload.

This adds an `agent-mcp.mode` config property (default: `dev`) with three values:

- **dev** — `quarkus:dev` / `quarkusDev` with hot reload, Dev MCP, Dev UI, and all tools available
- **test** — `quarkus:run` / `quarkusRun` with `-Dquarkus.profile=test`, dev-only tools removed
- **prod** — `quarkus:run` / `quarkusRun`, dev-only tools removed

When mode is `test` or `prod`:
- Dev-mode-only tools (`quarkus_searchTools`, `quarkus_callTool`, `quarkus_browser`) are removed from the MCP tool list at startup via `ToolManager.removeTool()`
- Restart performs a full stop + rebuild + start instead of sending the 's' keystroke for live reload
- Skills, docs, and all lifecycle tools (start/stop/restart/status/logs) continue to work normally

Fixes #211