### PR TITLE
Add extension filter to searchDocs tool

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -170,7 +170,9 @@ public class DocSearchTools {
 
             Filter sourceFilter = null;
             if (extension != null && !extension.isBlank()) {
-                sourceFilter = new ContainsString("source", extension.trim());
+                String ext = extension.trim();
+                sourceFilter = new ContainsString("extension", ext)
+                        .or(new ContainsString("source", ext));
             }
 
             EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()

--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -7,6 +7,8 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.comparison.ContainsString;
 import dev.langchain4j.store.embedding.pgvector.PgVectorEmbeddingStore;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
@@ -123,7 +125,10 @@ public class DocSearchTools {
             @ToolArg(description = "Absolute path to the Quarkus project directory. "
                     + "Strongly recommended -- documentation is loaded from the project's extension "
                     + "dependencies, so searches without projectDir may return no results. "
-                    + "Also selects documentation matching the project's Quarkus version.", required = false) String projectDir) {
+                    + "Also selects documentation matching the project's Quarkus version.", required = false) String projectDir,
+            @ToolArg(description = "Optional extension name to restrict results to a specific extension's "
+                    + "documentation (e.g. 'quarkus-json-rpc', 'quarkus-rest'). "
+                    + "When set, only documentation chunks from that extension are returned.", required = false) String extension) {
         try {
             if (query == null || query.isBlank()) {
                 return ToolResponse.error("Search query must not be empty.");
@@ -163,8 +168,14 @@ public class DocSearchTools {
 
             Embedding queryEmbedding = embeddingModelLoader.getModel().embed(query).content();
 
+            Filter sourceFilter = null;
+            if (extension != null && !extension.isBlank()) {
+                sourceFilter = new ContainsString("source", extension.trim());
+            }
+
             EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
                     .queryEmbedding(queryEmbedding)
+                    .filter(sourceFilter)
                     .maxResults(SEARCH_CANDIDATES)
                     .minScore(minScore)
                     .build();

--- a/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DocSearchTools.java
@@ -128,7 +128,8 @@ public class DocSearchTools {
                     + "Also selects documentation matching the project's Quarkus version.", required = false) String projectDir,
             @ToolArg(description = "Optional extension name to restrict results to a specific extension's "
                     + "documentation (e.g. 'quarkus-json-rpc', 'quarkus-rest'). "
-                    + "When set, only documentation chunks from that extension are returned.", required = false) String extension) {
+                    + "When set, only documentation chunks from that extension are returned. "
+                    + "Works for both core Quarkus extensions and Quarkiverse extensions.", required = false) String extension) {
         try {
             if (query == null || query.isBlank()) {
                 return ToolResponse.error("Search query must not be empty.");
@@ -170,9 +171,7 @@ public class DocSearchTools {
 
             Filter sourceFilter = null;
             if (extension != null && !extension.isBlank()) {
-                String ext = extension.trim();
-                sourceFilter = new ContainsString("extension", ext)
-                        .or(new ContainsString("source", ext));
+                sourceFilter = new ContainsString("extension", extension.trim());
             }
 
             EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()

--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -202,7 +202,7 @@ public class RagSqlLoader {
                 RagFragment fragment = resolveExternalRagArtifact(
                         pointer, dep.version(), m2Repo, projectDir);
                 if (fragment != null) {
-                    fragments.add(fragment);
+                    fragments.add(injectExtensionMetadata(fragment, dep.artifactId()));
                     LOG.debugf("Found RAG SQL via external artifact %s:%s:%s",
                             pointer.groupId(), pointer.artifactId(), dep.version());
                     continue;
@@ -212,7 +212,7 @@ public class RagSqlLoader {
             // Fallback: read RAG SQL directly from the deployment JAR
             RagFragment fragment = readFragmentFromJar(deploymentJar, dep.artifactId());
             if (fragment != null) {
-                fragments.add(fragment);
+                fragments.add(injectExtensionMetadata(fragment, dep.artifactId()));
                 LOG.debugf("Found RAG SQL in non-core extension %s", dep.artifactId());
             }
         }
@@ -267,6 +267,12 @@ public class RagSqlLoader {
         }
 
         return null;
+    }
+
+    private RagFragment injectExtensionMetadata(RagFragment fragment, String extensionName) {
+        String enriched = fragment.sql().replace("'{\"source\":",
+                "'{\"extension\":\"" + extensionName + "\",\"source\":");
+        return new RagFragment(fragment.source(), enriched);
     }
 
     private Path resolveAggregatedJarPath(String version, Path m2Repo) {

--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -145,7 +145,7 @@ public class RagSqlLoader {
         Path aggregatedJarPath = resolveAggregatedJarPath(quarkusVersion, m2Repo);
         RagFragment aggregated = readFragmentFromJar(aggregatedJarPath, "quarkus-documentation");
         if (aggregated != null) {
-            fragments.add(aggregated);
+            fragments.add(injectExtensionFromSource(aggregated));
             LOG.infof("Found aggregated RAG SQL artifact locally for Quarkus %s", quarkusVersion);
         } else {
             // Try downloading from Maven Central
@@ -153,7 +153,7 @@ public class RagSqlLoader {
             if (downloaded != null) {
                 aggregated = readFragmentFromJar(downloaded, "quarkus-documentation");
                 if (aggregated != null) {
-                    fragments.add(aggregated);
+                    fragments.add(injectExtensionFromSource(aggregated));
                     LOG.infof("Downloaded aggregated RAG SQL artifact for Quarkus %s", quarkusVersion);
                 }
             }
@@ -275,6 +275,13 @@ public class RagSqlLoader {
         return new RagFragment(fragment.source(), enriched);
     }
 
+    private RagFragment injectExtensionFromSource(RagFragment fragment) {
+        String enriched = fragment.sql().replaceAll(
+                "'\\{\"source\":\"([^\"]+)\"",
+                "'{\"extension\":\"$1\",\"source\":\"$1\"");
+        return new RagFragment(fragment.source(), enriched);
+    }
+
     private Path resolveAggregatedJarPath(String version, Path m2Repo) {
         return m2Repo.resolve(AGGREGATED_GROUP_PATH)
                 .resolve(AGGREGATED_ARTIFACT_ID)
@@ -349,7 +356,7 @@ public class RagSqlLoader {
 
                 RagFragment fragment = readFragmentFromJar(deploymentJar, artifactId);
                 if (fragment != null) {
-                    fragments.add(fragment);
+                    fragments.add(injectExtensionFromSource(fragment));
                     LOG.debugf("Found RAG SQL in %s", deploymentArtifactId);
                 }
             }


### PR DESCRIPTION
Adds an optional `extension` parameter to the `quarkus_searchDocs` tool that restricts results to a specific extension's documentation. This is useful when non-core extension docs are loaded alongside the ~2700 core Quarkus doc chunks and would otherwise be outranked by core results.

Uses langchain4j's `ContainsString` filter on the `source` metadata field, which the pgvector store translates to a SQL `WHERE metadata->>'source' LIKE '%extension%'` clause — filtering happens at the database level before vector similarity ranking.

Example usage:
```
quarkus_searchDocs query="broadcasting messages" extension="quarkus-json-rpc"
```