### PR TITLE
Fix non-core extension metadata in RAG SQL loading

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -165,13 +165,13 @@ public class RagSqlLoader {
         }
 
         // 2. Non-core extensions: always scan (Quarkiverse, third-party)
-        fragments.addAll(scanNonCoreExtensionJars(m2Repo, projectDir));
+        fragments.addAll(scanNonCoreExtensionJars(m2Repo, projectDir, quarkusVersion));
 
         LOG.infof("Discovered %d RAG SQL fragment(s) for Quarkus %s", fragments.size(), quarkusVersion);
         return fragments;
     }
 
-    private List<RagFragment> scanNonCoreExtensionJars(Path m2Repo, String projectDir) {
+    private List<RagFragment> scanNonCoreExtensionJars(Path m2Repo, String projectDir, String quarkusVersion) {
         if (projectDir == null) {
             return List.of();
         }
@@ -196,13 +196,15 @@ public class RagSqlLoader {
                 continue;
             }
 
+            String guideUrl = readGuideUrl(m2Repo, dep);
+
             // Check for a pointer to a separate RAG artifact
             RagArtifactPointer pointer = readRagArtifactPointer(deploymentJar);
             if (pointer != null) {
                 RagFragment fragment = resolveExternalRagArtifact(
                         pointer, dep.version(), m2Repo, projectDir);
                 if (fragment != null) {
-                    fragments.add(injectExtensionMetadata(fragment, dep.artifactId()));
+                    fragments.add(injectExtensionMetadata(fragment, dep.artifactId(), quarkusVersion, guideUrl));
                     LOG.debugf("Found RAG SQL via external artifact %s:%s:%s",
                             pointer.groupId(), pointer.artifactId(), dep.version());
                     continue;
@@ -212,7 +214,7 @@ public class RagSqlLoader {
             // Fallback: read RAG SQL directly from the deployment JAR
             RagFragment fragment = readFragmentFromJar(deploymentJar, dep.artifactId());
             if (fragment != null) {
-                fragments.add(injectExtensionMetadata(fragment, dep.artifactId()));
+                fragments.add(injectExtensionMetadata(fragment, dep.artifactId(), quarkusVersion, guideUrl));
                 LOG.debugf("Found RAG SQL in non-core extension %s", dep.artifactId());
             }
         }
@@ -269,16 +271,76 @@ public class RagSqlLoader {
         return null;
     }
 
-    private RagFragment injectExtensionMetadata(RagFragment fragment, String extensionName) {
-        String enriched = fragment.sql().replace("'{\"source\":",
+    /**
+     * Fixes metadata in non-core extension SQL fragments. The upstream plugin generates
+     * metadata assuming core Quarkus conventions; this method corrects it at load time:
+     * <ul>
+     *   <li>{@code source} — replaced with the correct runtime artifact ID</li>
+     *   <li>{@code quarkus_version} — renamed to {@code extension_version}; actual Quarkus version injected</li>
+     *   <li>{@code url} — replaced with the guide URL from {@code quarkus-extension.yaml}, or removed if wrong</li>
+     *   <li>{@code extension} — added (existing behavior)</li>
+     * </ul>
+     */
+    static RagFragment injectExtensionMetadata(RagFragment fragment, String extensionName,
+            String quarkusVersion, String guideUrl) {
+        String sql = fragment.sql();
+
+        // Fix source in DELETE statement
+        sql = SOURCE_PATTERN.matcher(sql).replaceAll(
+                Matcher.quoteReplacement("metadata->>'source' = '" + extensionName + "'"));
+
+        // Fix source value in JSON metadata (source is always the first field)
+        sql = sql.replaceAll("'\\{\"source\":\"[^\"]+\"",
+                "'{\"source\":\"" + extensionName + "\"");
+
+        // Add extension field before source
+        sql = sql.replace("'{\"source\":",
                 "'{\"extension\":\"" + extensionName + "\",\"source\":");
-        return new RagFragment(fragment.source(), enriched);
+
+        // Rename version key to extension_version and inject correct quarkus_version.
+        // Handles both old plugin format ("quarkus_version":) and new format (,"version":).
+        if (quarkusVersion != null) {
+            sql = sql.replace("\"quarkus_version\":", "\"extension_version\":");
+            sql = sql.replace(",\"version\":", ",\"extension_version\":");
+            sql = sql.replace("\"extension_version\":",
+                    "\"quarkus_version\":\"" + quarkusVersion + "\",\"extension_version\":");
+        }
+
+        // Fix URL: use guide URL from extension metadata, or remove wrong quarkus.io URLs
+        if (guideUrl != null) {
+            sql = sql.replaceAll("\"url\":\"[^\"]*\"",
+                    Matcher.quoteReplacement("\"url\":\"" + guideUrl + "\""));
+        } else {
+            sql = sql.replaceAll(",\"url\":\"https://quarkus\\.io/guides/[^\"]*\"", "");
+        }
+
+        return new RagFragment(extensionName, sql);
+    }
+
+    private String readGuideUrl(Path m2Repo, DependencyResolver.Dependency dep) {
+        String groupPath = dep.groupId().replace('.', '/');
+        Path runtimeJar = m2Repo.resolve(groupPath)
+                .resolve(dep.artifactId())
+                .resolve(dep.version())
+                .resolve(dep.artifactId() + "-" + dep.version() + ".jar");
+        if (!Files.isRegularFile(runtimeJar)) {
+            return null;
+        }
+        try (JarFile jar = new JarFile(runtimeJar.toFile())) {
+            SkillReader.ExtensionMetadata meta = SkillReader.readExtensionMetadata(jar);
+            return meta != null ? meta.guide : null;
+        } catch (IOException e) {
+            LOG.debugf("Failed to read guide URL from %s: %s", runtimeJar, e.getMessage());
+            return null;
+        }
     }
 
     private RagFragment injectExtensionFromSource(RagFragment fragment) {
         String enriched = fragment.sql().replaceAll(
                 "'\\{\"source\":\"([^\"]+)\"",
                 "'{\"extension\":\"$1\",\"source\":\"$1\"");
+        // Handle new plugin format: rename generic "version" to "quarkus_version" for core extensions
+        enriched = enriched.replace(",\"version\":", ",\"quarkus_version\":");
         return new RagFragment(fragment.source(), enriched);
     }
 

--- a/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
+++ b/src/main/java/io/quarkus/agent/mcp/RagSqlLoader.java
@@ -196,14 +196,13 @@ public class RagSqlLoader {
                 continue;
             }
 
-            String guideUrl = readGuideUrl(m2Repo, dep);
-
             // Check for a pointer to a separate RAG artifact
             RagArtifactPointer pointer = readRagArtifactPointer(deploymentJar);
             if (pointer != null) {
                 RagFragment fragment = resolveExternalRagArtifact(
                         pointer, dep.version(), m2Repo, projectDir);
                 if (fragment != null) {
+                    String guideUrl = readGuideUrl(m2Repo, dep);
                     fragments.add(injectExtensionMetadata(fragment, dep.artifactId(), quarkusVersion, guideUrl));
                     LOG.debugf("Found RAG SQL via external artifact %s:%s:%s",
                             pointer.groupId(), pointer.artifactId(), dep.version());
@@ -214,6 +213,7 @@ public class RagSqlLoader {
             // Fallback: read RAG SQL directly from the deployment JAR
             RagFragment fragment = readFragmentFromJar(deploymentJar, dep.artifactId());
             if (fragment != null) {
+                String guideUrl = readGuideUrl(m2Repo, dep);
                 fragments.add(injectExtensionMetadata(fragment, dep.artifactId(), quarkusVersion, guideUrl));
                 LOG.debugf("Found RAG SQL in non-core extension %s", dep.artifactId());
             }
@@ -291,7 +291,7 @@ public class RagSqlLoader {
 
         // Fix source value in JSON metadata (source is always the first field)
         sql = sql.replaceAll("'\\{\"source\":\"[^\"]+\"",
-                "'{\"source\":\"" + extensionName + "\"");
+                Matcher.quoteReplacement("'{\"source\":\"" + extensionName + "\""));
 
         // Add extension field before source
         sql = sql.replace("'{\"source\":",

--- a/src/test/java/io/quarkus/agent/mcp/RagSqlLoaderTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/RagSqlLoaderTest.java
@@ -113,4 +113,124 @@ class RagSqlLoaderTest {
         String sql = "DELETE FROM rag_documents WHERE metadata ->>'source'  =  'quarkus-hibernate-orm';\n";
         assertEquals("quarkus-hibernate-orm", RagSqlLoader.extractSource(sql, "fallback"));
     }
+
+    // ── injectExtensionMetadata tests ───────────────────────────────────────────
+
+    private static final String NON_CORE_SQL = """
+            -- quarkus-rag fragment: my-ext-deployment 1.2.0-SNAPSHOT
+            DELETE FROM rag_documents WHERE metadata->>'source' = 'quarkus-index';
+
+            INSERT INTO rag_documents (embedding_id, embedding, text, metadata) VALUES (\
+            'a1b2c3', '[0.1,0.2]'::vector, 'Some documentation text', \
+            '{"source":"quarkus-index","quarkus_version":"1.2.0-SNAPSHOT","title":"My Extension",\
+            "url":"https://quarkus.io/guides/index","section_title":"Config","section_level":"1",\
+            "section_path":"Config"}'::jsonb);
+
+            INSERT INTO rag_documents (embedding_id, embedding, text, metadata) VALUES (\
+            'd4e5f6', '[0.3,0.4]'::vector, 'More docs', \
+            '{"source":"quarkus-index","quarkus_version":"1.2.0-SNAPSHOT","title":"My Extension",\
+            "url":"https://quarkus.io/guides/index","section_title":"Usage","section_level":"1",\
+            "section_path":"Usage"}'::jsonb);
+            """;
+
+    @Test
+    void injectExtensionMetadataFixesSourceInDeleteAndInsert() {
+        var fragment = new RagSqlLoader.RagFragment("quarkus-index", NON_CORE_SQL);
+        var result = RagSqlLoader.injectExtensionMetadata(fragment, "quarkus-vault", "3.21.0", null);
+
+        assertEquals("quarkus-vault", result.source());
+        assertTrue(result.sql().contains("metadata->>'source' = 'quarkus-vault'"),
+                "DELETE should use corrected source");
+        assertFalse(result.sql().contains("metadata->>'source' = 'quarkus-index'"),
+                "Old source should be gone from DELETE");
+        assertTrue(result.sql().contains("\"source\":\"quarkus-vault\""),
+                "INSERT metadata should use corrected source");
+        assertFalse(result.sql().contains("\"source\":\"quarkus-index\""),
+                "Old source should be gone from INSERT metadata");
+    }
+
+    @Test
+    void injectExtensionMetadataAddsExtensionField() {
+        var fragment = new RagSqlLoader.RagFragment("quarkus-index", NON_CORE_SQL);
+        var result = RagSqlLoader.injectExtensionMetadata(fragment, "quarkus-vault", "3.21.0", null);
+
+        assertTrue(result.sql().contains("\"extension\":\"quarkus-vault\""),
+                "Extension field should be injected");
+        assertTrue(result.sql().contains("\"extension\":\"quarkus-vault\",\"source\":\"quarkus-vault\""),
+                "Extension should appear before source");
+    }
+
+    @Test
+    void injectExtensionMetadataFixesVersionFields() {
+        var fragment = new RagSqlLoader.RagFragment("quarkus-index", NON_CORE_SQL);
+        var result = RagSqlLoader.injectExtensionMetadata(fragment, "quarkus-vault", "3.21.0", null);
+
+        assertTrue(result.sql().contains("\"quarkus_version\":\"3.21.0\""),
+                "quarkus_version should have the actual Quarkus version");
+        assertTrue(result.sql().contains("\"extension_version\":\"1.2.0-SNAPSHOT\""),
+                "extension_version should have the original extension version");
+        assertTrue(result.sql().contains("\"quarkus_version\":\"3.21.0\",\"extension_version\":\"1.2.0-SNAPSHOT\""),
+                "quarkus_version should come before extension_version");
+    }
+
+    @Test
+    void injectExtensionMetadataReplacesUrlWhenGuideAvailable() {
+        var fragment = new RagSqlLoader.RagFragment("quarkus-index", NON_CORE_SQL);
+        String guideUrl = "https://docs.quarkiverse.io/quarkus-vault/dev/index.html";
+        var result = RagSqlLoader.injectExtensionMetadata(fragment, "quarkus-vault", "3.21.0", guideUrl);
+
+        assertTrue(result.sql().contains("\"url\":\"" + guideUrl + "\""),
+                "URL should be replaced with guide URL from extension metadata");
+        assertFalse(result.sql().contains("quarkus.io/guides"),
+                "Wrong quarkus.io URL should be gone");
+    }
+
+    @Test
+    void injectExtensionMetadataRemovesWrongUrlWhenNoGuide() {
+        var fragment = new RagSqlLoader.RagFragment("quarkus-index", NON_CORE_SQL);
+        var result = RagSqlLoader.injectExtensionMetadata(fragment, "quarkus-vault", "3.21.0", null);
+
+        assertFalse(result.sql().contains("quarkus.io/guides"),
+                "Wrong quarkus.io URL should be removed");
+        assertFalse(result.sql().contains("\"url\""),
+                "No url field should remain");
+    }
+
+    @Test
+    void injectExtensionMetadataPreservesNonQuarkusUrl() {
+        String sqlWithCustomUrl = NON_CORE_SQL.replace(
+                "https://quarkus.io/guides/index",
+                "https://docs.example.com/my-ext/guide");
+        var fragment = new RagSqlLoader.RagFragment("quarkus-index", sqlWithCustomUrl);
+        var result = RagSqlLoader.injectExtensionMetadata(fragment, "my-ext", "3.21.0", null);
+
+        assertTrue(result.sql().contains("\"url\":\"https://docs.example.com/my-ext/guide\""),
+                "Non-quarkus.io URLs should be preserved when no guide URL is available");
+    }
+
+    @Test
+    void injectExtensionMetadataHandlesNewPluginVersionKey() {
+        // New plugin format uses "version" instead of "quarkus_version"
+        String newFormatSql = NON_CORE_SQL.replace("\"quarkus_version\":", "\"version\":");
+        var fragment = new RagSqlLoader.RagFragment("quarkus-index", newFormatSql);
+        var result = RagSqlLoader.injectExtensionMetadata(fragment, "quarkus-vault", "3.21.0", null);
+
+        assertTrue(result.sql().contains("\"quarkus_version\":\"3.21.0\""),
+                "quarkus_version should have the actual Quarkus version");
+        assertTrue(result.sql().contains("\"extension_version\":\"1.2.0-SNAPSHOT\""),
+                "extension_version should have the original extension version");
+        assertFalse(result.sql().contains(",\"version\":"),
+                "Generic version key should be gone");
+    }
+
+    @Test
+    void injectExtensionMetadataSkipsVersionFixWhenQuarkusVersionNull() {
+        var fragment = new RagSqlLoader.RagFragment("quarkus-index", NON_CORE_SQL);
+        var result = RagSqlLoader.injectExtensionMetadata(fragment, "quarkus-vault", null, null);
+
+        assertTrue(result.sql().contains("\"quarkus_version\":\"1.2.0-SNAPSHOT\""),
+                "quarkus_version should remain unchanged when quarkusVersion is null");
+        assertFalse(result.sql().contains("\"extension_version\""),
+                "extension_version should not be added when quarkusVersion is null");
+    }
 }


### PR DESCRIPTION
When non-core extensions (Quarkiverse, third-party) contribute RAG SQL via the `quarkus-documentation-rag` plugin, three metadata fields are wrong because the plugin defaults assume core Quarkus conventions:

- **`source`** — falls back to `"quarkus-index"` or includes `-deployment` suffix
- **`quarkus_version`** — contains the extension version instead of the Quarkus platform version
- **`url`** — points to `quarkus.io/guides/` instead of the extension's own docs

This enhances `injectExtensionMetadata()` to fix all three at load time:

1. Replaces `source` with the correct runtime artifact ID in both DELETE and INSERT statements
2. Renames `quarkus_version` to `extension_version` (keeping the extension's own version) and injects the actual Quarkus platform version as `quarkus_version`
3. Reads the correct guide URL from the runtime JAR's `quarkus-extension.yaml` and replaces wrong URLs; removes `quarkus.io/guides/` URLs when no guide URL is available
4. Handles both old (`quarkus_version`) and new (`version`) plugin key formats for forward compatibility

After the fix, non-core extension metadata looks like:
```json
{
  "extension": "quarkus-vault",
  "source": "quarkus-vault",
  "quarkus_version": "3.21.0",
  "extension_version": "1.2.0-SNAPSHOT",
  "title": "Vault",
  "url": "https://docs.quarkiverse.io/quarkus-vault/dev/index.html",
  "section_title": "Configuration"
}
```

Companion plugin fix: https://github.com/quarkusio/quarkus-documentation-rag/pull/10

Related: quarkusio/quarkus-documentation-rag#9