### PR TITLE
Cap JVM heap and use SerialGC to reduce memory footprint

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -7,7 +7,9 @@
        "runtime-options": [
         "--add-opens",
         "java.base/java.lang=ALL-UNNAMED",
-        "--enable-native-access=ALL-UNNAMED"
+        "--enable-native-access=ALL-UNNAMED",
+        "-Xmx512m",
+        "-XX:+UseSerialGC"
       ]
     }
   }


### PR DESCRIPTION
When launched via JBang without explicit memory limits, the JVM defaults to reserving ~1/4 of physical RAM as max heap. On small VPS instances this causes the MCP server to consume 1.3-1.6 GB — more than the agent using it.

This adds `-Xmx512m` and `-XX:+UseSerialGC` to the JBang runtime options. SerialGC has lower baseline overhead than the default G1GC, which is a better fit for a single-purpose tool process. Together these should bring the footprint well under 1 GB without affecting functionality.