### PR TITLE
Fix native binary download instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@ Pre-built native binaries are available on each [GitHub Release](https://github.
 | macOS Apple Silicon | `quarkus-agent-mcp-<version>-macos-aarch64` |
 
 ```bash
-# Download (replace the artifact name for your platform)
+# Download the latest version (replace PLATFORM with your platform from the table above)
+PLATFORM=linux-x86_64
+VERSION=$(curl -sI https://github.com/quarkusio/quarkus-agent-mcp/releases/latest | grep -i ^location: | sed 's|.*/||' | tr -d '\r')
 curl -L -o quarkus-agent-mcp \
-  https://github.com/quarkusio/quarkus-agent-mcp/releases/latest/download/quarkus-agent-mcp-linux-x86_64
+  "https://github.com/quarkusio/quarkus-agent-mcp/releases/download/${VERSION}/quarkus-agent-mcp-${VERSION}-${PLATFORM}"
 chmod +x quarkus-agent-mcp
 
 # Register with Claude Code


### PR DESCRIPTION
The GitHub Release assets include the version in the filename (e.g. `quarkus-agent-mcp-1.1.8-linux-x86_64`), so the download command in the README would 404. This fixes it by resolving the latest version tag from the GitHub redirect before constructing the download URL.

Tested locally — the full download + run flow works.