### PR TITLE
Fix mvnw.cmd and gradlew.bat not found on Windows

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProcessUtils.java
@@ -31,7 +31,7 @@ final class ProcessUtils {
             boolean win = OS.WINDOWS.isCurrent();
             File wrapper = win ? new File(projectDir, "mvnw.cmd") : new File(projectDir, "mvnw");
             if (wrapper.exists()) {
-                return win ? "mvnw.cmd" : "./mvnw";
+                return wrapper.getAbsolutePath();
             }
             return win ? "mvn.cmd" : "mvn";
         });
@@ -41,7 +41,7 @@ final class ProcessUtils {
         boolean win = OS.WINDOWS.isCurrent();
         File wrapper = win ? new File(projectDir, "gradlew.bat") : new File(projectDir, "gradlew");
         if (wrapper.exists()) {
-            return win ? "gradlew.bat" : "./gradlew";
+            return wrapper.getAbsolutePath();
         }
         return win ? "gradle.bat" : "gradle";
     }


### PR DESCRIPTION
On Windows, `resolveMavenCommand` and `resolveGradleCommand` returned bare filenames like `mvnw.cmd` and `gradlew.bat` when the wrapper script existed in the project directory. Java's `ProcessBuilder` doesn't search the working directory for executables — it only searches `PATH` — so `CreateProcess` failed with "The system cannot find the file specified" even though the file was present.

Both methods now return the wrapper's absolute path, which works reliably on all platforms.

Fixes #235