### PR TITLE
Fix native doc search: defer DJL/ONNX init and register JNI

### DIFF
--- a/src/main/resources/META-INF/native-image/ai/djl/tokenizers/jni-config.json
+++ b/src/main/resources/META-INF/native-image/ai/djl/tokenizers/jni-config.json
@@ -1,0 +1,138 @@
+[
+  {
+    "name": "ai.djl.huggingface.tokenizers.jni.TokenizersLibrary",
+    "methods": [
+      {"name": "createTokenizer", "parameterTypes": ["java.lang.String", "java.lang.String"]},
+      {"name": "createTokenizerFromString", "parameterTypes": ["java.lang.String"]},
+      {"name": "createBpeTokenizer", "parameterTypes": ["java.lang.String", "java.lang.String"]},
+      {"name": "deleteTokenizer", "parameterTypes": ["long"]},
+      {"name": "encode", "parameterTypes": ["long", "java.lang.String", "boolean"]},
+      {"name": "encodeDual", "parameterTypes": ["long", "java.lang.String", "java.lang.String", "boolean"]},
+      {"name": "encodeList", "parameterTypes": ["long", "java.lang.String[]", "boolean"]},
+      {"name": "batchEncode", "parameterTypes": ["long", "java.lang.String[]", "boolean"]},
+      {"name": "batchEncodePair", "parameterTypes": ["long", "java.lang.String[]", "java.lang.String[]", "boolean"]},
+      {"name": "batchDecode", "parameterTypes": ["long", "long[][]", "boolean"]},
+      {"name": "deleteEncoding", "parameterTypes": ["long"]},
+      {"name": "getTokenIds", "parameterTypes": ["long"]},
+      {"name": "getTypeIds", "parameterTypes": ["long"]},
+      {"name": "getWordIds", "parameterTypes": ["long"]},
+      {"name": "getTokens", "parameterTypes": ["long"]},
+      {"name": "getAttentionMask", "parameterTypes": ["long"]},
+      {"name": "getSpecialTokenMask", "parameterTypes": ["long"]},
+      {"name": "getTokenCharSpans", "parameterTypes": ["long"]},
+      {"name": "getOverflowing", "parameterTypes": ["long"]},
+      {"name": "decode", "parameterTypes": ["long", "long[]", "boolean"]},
+      {"name": "getTruncationStrategy", "parameterTypes": ["long"]},
+      {"name": "getPaddingStrategy", "parameterTypes": ["long"]},
+      {"name": "getMaxLength", "parameterTypes": ["long"]},
+      {"name": "getStride", "parameterTypes": ["long"]},
+      {"name": "getPadToMultipleOf", "parameterTypes": ["long"]},
+      {"name": "disablePadding", "parameterTypes": ["long"]},
+      {"name": "setPadding", "parameterTypes": ["long", "int", "java.lang.String", "int"]},
+      {"name": "disableTruncation", "parameterTypes": ["long"]},
+      {"name": "setTruncation", "parameterTypes": ["long", "int", "java.lang.String", "int"]}
+    ]
+  },
+  {
+    "name": "ai.djl.huggingface.tokenizers.jni.CharSpan",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OnnxMap",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OnnxRuntime",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OnnxSequence",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OnnxSparseTensor",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OnnxTensor",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OrtAllocator",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OrtEnvironment",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OrtEnvironment$ThreadingOptions",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OrtSession",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OrtSession$RunOptions",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OrtSession$SessionOptions",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OrtLoraAdapter",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OrtTrainingSession",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.OrtTrainingSession$OrtCheckpointState",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.providers.OrtCUDAProviderOptions",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "ai.onnxruntime.providers.OrtTensorRTProviderOptions",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  }
+]

--- a/src/main/resources/META-INF/native-image/ai/djl/tokenizers/native-image.properties
+++ b/src/main/resources/META-INF/native-image/ai/djl/tokenizers/native-image.properties
@@ -1,0 +1,2 @@
+Args = -H:JNIConfigurationResources=${.}/jni-config.json \
+       -H:ResourceConfigurationResources=${.}/resource-config.json

--- a/src/main/resources/META-INF/native-image/ai/djl/tokenizers/resource-config.json
+++ b/src/main/resources/META-INF/native-image/ai/djl/tokenizers/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {"pattern": "native/lib/.*"},
+      {"pattern": "ai/onnxruntime/native/.*"},
+      {"pattern": "bge-small-en-v1\\.5-q.*"}
+    ]
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,6 +68,9 @@ quarkus.native.additional-build-args=\
   --initialize-at-run-time=com.github.dockerjava,\
   --initialize-at-run-time=org.postgresql.sspi.SSPIClient,\
   --initialize-at-run-time=org.postgresql.util.LazyCleanerImpl,\
+  --initialize-at-run-time=ai.djl,\
+  --initialize-at-run-time=ai.onnxruntime,\
+  --initialize-at-run-time=dev.langchain4j.model.embedding.onnx,\
   --enable-url-protocols=https
 quarkus.native.auto-service-loader-registration=true
 


### PR DESCRIPTION
Doc search in the native binary fails with `UnsatisfiedLinkError` on the DJL tokenizer's `encode()` JNI call. The root cause is that the embedding model's static initializer runs at build time, loading the tokenizer and ONNX runtime native libraries inside the build environment. At runtime those JNI handles are stale.

Three fixes:
1. **Defer initialization** of `ai.djl`, `ai.onnxruntime`, and `dev.langchain4j.model.embedding.onnx` to runtime so native libraries are loaded fresh
2. **Register JNI methods** for the DJL tokenizer (`TokenizersLibrary`) and all ONNX runtime native classes (`OrtEnvironment`, `OrtSession`, `OnnxTensor`, etc.)
3. **Include native resources** — the tokenizer `.so`, ONNX runtime `.so`, and BGE model weight files need to be embedded so they can be extracted at runtime

Note: the native binary size will increase (~150-200 MB) because the ONNX runtime and model weights are embedded. This is the tradeoff for having doc search work without external dependencies.

We could not fully test locally because our local native build uses `--container-build` (UBI9 container) which causes a glibc mismatch segfault. The CI build on `ubuntu-latest` builds directly on the runner, which should not have this issue. The CI native build check will validate.