### PR TITLE
Add agent-mcp.extra-args config property

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -39,6 +39,9 @@ public class QuarkusProcessManager {
     @ConfigProperty(name = "agent-mcp.process.gradle-cmd")
     Optional<String> gradleCmd;
 
+    @ConfigProperty(name = "agent-mcp.extra-args")
+    Optional<String> configExtraArgs;
+
     @ConfigProperty(name = "agent-mcp.app-log.enabled")
     Optional<Boolean> appLogEnabled;
 
@@ -211,6 +214,12 @@ public class QuarkusProcessManager {
             pb.command().add("-Dquarkus.http.port=" + httpPort);
             pb.command().add("-Dquarkus.http.test-port=0");
         }
+
+        configExtraArgs.filter(s -> !s.isBlank()).ifPresent(args -> {
+            for (String token : args.trim().split("\\s+")) {
+                pb.command().add(token);
+            }
+        });
 
         if (extraArgs != null && !extraArgs.isBlank()) {
             for (String token : extraArgs.trim().split("\\s+")) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,6 +41,10 @@ quarkus.mcp.server.tools.name-pattern=^[A-Za-z0-9_.-]{1,128}$
 # prod — quarkus:run / quarkusRun (dev-only tools removed)
 agent-mcp.mode=dev
 
+# Extra arguments appended to every Maven/Gradle command line
+# Useful for WSL setups where the debugger must bind to all interfaces:
+# agent-mcp.extra-args=-DdebugHost=*
+
 # Include transitive dependencies when scanning for extension skills
 # Default is false (only direct dependencies) for backward compatibility
 # Set to true to discover skills from indirect dependencies as well

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -179,11 +179,18 @@ class QuarkusProcessManagerTest {
     }
 
     private void initOptionalFields(String mode) throws Exception {
+        initOptionalFields(mode, Optional.empty());
+    }
+
+    private void initOptionalFields(String mode, Optional<String> extraArgs) throws Exception {
         for (String fieldName : new String[] { "gradleCmd", "appLogEnabled" }) {
             Field f = QuarkusProcessManager.class.getDeclaredField(fieldName);
             f.setAccessible(true);
             f.set(manager, Optional.empty());
         }
+        Field configExtraArgsField = QuarkusProcessManager.class.getDeclaredField("configExtraArgs");
+        configExtraArgsField.setAccessible(true);
+        configExtraArgsField.set(manager, extraArgs);
         Field modeField = QuarkusProcessManager.class.getDeclaredField("mode");
         modeField.setAccessible(true);
         modeField.set(manager, mode);
@@ -425,5 +432,31 @@ class QuarkusProcessManagerTest {
         f.setAccessible(true);
         f.set(pm, "invalid");
         assertThrows(IllegalStateException.class, pm::validateMode);
+    }
+
+    @Test
+    void processBuilderIncludesConfigExtraArgs() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields("dev", Optional.of("-DdebugHost=*"));
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, (String) null, (String) null);
+        assertTrue(pb.command().contains("-DdebugHost=*"));
+    }
+
+    @Test
+    void processBuilderAppendsToolExtraArgsAfterConfigExtraArgs() throws Exception {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        initOptionalFields("dev", Optional.of("-DdebugHost=*"));
+        Method m = QuarkusProcessManager.class.getDeclaredMethod(
+                "createProcessBuilder", String.class, String.class, Integer.class, String.class, String.class);
+        m.setAccessible(true);
+        ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, (String) null, "-Ddebug=5005");
+        int configIdx = pb.command().indexOf("-DdebugHost=*");
+        int toolIdx = pb.command().indexOf("-Ddebug=5005");
+        assertTrue(configIdx >= 0, "config extra arg should be present");
+        assertTrue(toolIdx >= 0, "tool extra arg should be present");
+        assertTrue(configIdx < toolIdx, "config extra args should come before tool extra args");
     }
 }


### PR DESCRIPTION
Adds a new `agent-mcp.extra-args` configuration property that appends extra arguments to every Maven/Gradle command line when starting Quarkus applications.

This lets users set default flags once (e.g. `-DdebugHost=*` for WSL setups where the debugger must bind to all interfaces) without having to ask the agent each time. The tool-level `extraArgs` parameter still works and is appended after the config args, so per-invocation args can override the defaults.

### Usage

Set the `AGENT_MCP_EXTRA_ARGS` environment variable in your MCP server configuration:

**Claude Code:**
```bash
claude mcp add -s user quarkus-agent -e AGENT_MCP_EXTRA_ARGS="-DdebugHost=*" -- jbang quarkus-agent-mcp@quarkusio
```

**VS Code / Cursor / Windsurf (JSON config):**
```json
"env": {
  "AGENT_MCP_EXTRA_ARGS": "-DdebugHost=*"
}
```

Closes #240