### PR TITLE
Fix for Bob path issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,20 @@ Add to `.bob/mcp.json`:
 {
   "mcpServers": {
     "quarkus-agent": {
-      "command": "jbang",
-      "args": ["quarkus-agent-mcp@quarkusio"]
+      "command": "/home/you/.jbang/bin/jbang",
+      "args": [
+        "quarkus-agent-mcp@quarkusio"
+      ],
+      "env": {
+        "JAVA_HOME": "/path/to/your/java/home"
+      },
+      "disabled": false
     }
   }
 }
 ```
+
+> **Why absolute paths?** Bob inherits system PATH, not your shell PATH. See [Troubleshooting](#jbang-or-java-not-found-enoent) below.
 
 #### Cursor
 


### PR DESCRIPTION
Bob didn't seem to recognize the jbang path, similar to the Intellij issues in the readme. This is a workaround that seems consistent with the other solutions in the readme.