### PR TITLE
Register Jandex types for reflection in native mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Build
-        run: ./mvnw package -DskipTests
+      - name: Build and test
+        run: ./mvnw verify
 
       - name: Upload runner jar
         uses: actions/upload-artifact@v4

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <quarkus.platform.version>3.36.0</quarkus.platform.version>
         <quarkus-mcp-server.version>1.13.1</quarkus-mcp-server.version>
         <langchain4j.version>1.12.2-beta22</langchain4j.version>
-        <skipITs>true</skipITs>
+        <skipITs>false</skipITs>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.36.0</quarkus.platform.version>
-        <quarkus-mcp-server.version>1.11.0</quarkus-mcp-server.version>
+        <quarkus-mcp-server.version>1.13.1</quarkus-mcp-server.version>
         <langchain4j.version>1.12.2-beta22</langchain4j.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.4</surefire-plugin.version>
@@ -142,6 +142,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-test</artifactId>
+            <version>${quarkus-mcp-server.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/resources/META-INF/native-image/jandex/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/jandex/reflect-config.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "org.jboss.jandex.ClassInfo[]"
+  },
+  {
+    "name": "org.jboss.jandex.ClassInfo",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.jboss.jandex.AnnotationInstance[]"
+  },
+  {
+    "name": "org.jboss.jandex.AnnotationInstance",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.jboss.jandex.MethodInfo",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.jboss.jandex.MethodParameterInfo",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.jboss.jandex.AnnotationValue",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.jboss.jandex.AnnotationTarget",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.jboss.jandex.Type",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.jboss.jandex.Index",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.jboss.jandex.Indexer",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "org.jboss.jandex.DotName",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  }
+]

--- a/src/test/java/io/quarkus/agent/mcp/McpIT.java
+++ b/src/test/java/io/quarkus/agent/mcp/McpIT.java
@@ -1,0 +1,102 @@
+package io.quarkus.agent.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStdioTestClient;
+
+public class McpIT {
+
+    private static final List<String> EXPECTED_TOOLS = List.of(
+            "quarkus_create",
+            "quarkus_start",
+            "quarkus_stop",
+            "quarkus_restart",
+            "quarkus_browser",
+            "quarkus_status",
+            "quarkus_logs",
+            "quarkus_list",
+            "quarkus_app_log",
+            "quarkus_agent_log",
+            "quarkus_searchDocs",
+            "quarkus_searchTools",
+            "quarkus_skills",
+            "quarkus_updateSkill",
+            "quarkus_saveSkill",
+            "quarkus_callTool");
+
+    @Test
+    public void toolsList() {
+        try (McpStdioTestClient client = McpAssured.newConnectedStdioClient()) {
+            client.when()
+                    .toolsList(page -> {
+                        assertEquals(EXPECTED_TOOLS.size(), page.size());
+                        for (String toolName : EXPECTED_TOOLS) {
+                            var tool = page.findByName(toolName);
+                            assertNotNull(tool, "Tool not found: " + toolName);
+                            assertNotNull(tool.description(), "Missing description for: " + toolName);
+                            assertNotNull(tool.inputSchema(), "Missing inputSchema for: " + toolName);
+                        }
+                    })
+                    .thenAssertResults();
+        }
+    }
+
+    @Test
+    public void listInstances() {
+        try (McpStdioTestClient client = McpAssured.newConnectedStdioClient()) {
+            client.when()
+                    .toolsCall("quarkus_list", response -> {
+                        assertFalse(response.isError());
+                        assertEquals("No managed Quarkus instances",
+                                response.firstContent().asText().text());
+                    })
+                    .thenAssertResults();
+        }
+    }
+
+    @Test
+    public void statusNotStarted() {
+        try (McpStdioTestClient client = McpAssured.newConnectedStdioClient()) {
+            client.when()
+                    .toolsCall("quarkus_status", Map.of("projectDir", "/tmp/nonexistent"), response -> {
+                        assertFalse(response.isError());
+                        assertEquals("not_started", response.firstContent().asText().text());
+                    })
+                    .thenAssertResults();
+        }
+    }
+
+    @Test
+    public void agentLogReadNoFile() {
+        try (McpStdioTestClient client = McpAssured.newConnectedStdioClient()) {
+            client.when()
+                    .toolsCall("quarkus_agent_log", Map.of("action", "read"), response -> {
+                        assertTrue(response.isError());
+                        assertTrue(response.firstContent().asText().text().contains("No log file found"));
+                    })
+                    .thenAssertResults();
+        }
+    }
+
+    @Test
+    public void agentLogUnknownAction() {
+        try (McpStdioTestClient client = McpAssured.newConnectedStdioClient()) {
+            client.when()
+                    .toolsCall("quarkus_agent_log", Map.of("action", "foo"), response -> {
+                        assertTrue(response.isError());
+                        assertTrue(response.firstContent().asText().text()
+                                .contains("Unknown action: 'foo'"));
+                    })
+                    .thenAssertResults();
+        }
+    }
+}


### PR DESCRIPTION
The `quarkus_skills` tool fails in native mode because Jandex internally needs reflective access to `ClassInfo[]` when building its index — SkillReader uses Jandex to scan extension JARs for MCP tool annotations (`@JsonRpcDescription`, `@DevMCPEnableByDefault`, `@DevMcpBuildTimeTool`).

This adds a `reflect-config.json` for Jandex (following the same pattern as the existing `pgvector` and `docker-java` configs) registering `ClassInfo[]` and the other Jandex types used by SkillReader to prevent similar reflection errors on other code paths.