### PR TITLE
Skip integration tests in the release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
             </activation>
             <properties>
                 <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
+                <skipITs>true</skipITs>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
The release profile uses uber-jar packaging (`quarkus.package.jar.type=uber-jar`), which produces a single `*-runner.jar`. However, `McpAssured.newConnectedStdioClient()` hardcodes `target/quarkus-app/quarkus-run.jar` (fast-jar layout), so all integration tests time out trying to connect to a JAR that doesn't exist.

The ITs already run successfully in the regular CI build where fast-jar packaging is used, so skipping them during release loses no coverage.