### PR TITLE
fix: defer ProcessUtil$PathEnv init to runtime so native binary uses runtime PATH

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -66,12 +66,14 @@ agent-mcp.doc-search.min-score=0.82
 testcontainers.reuse.enable=true
 
 # Native image: defer class initialization to runtime for classes that create
-# threads, reference Windows-only JNA classes, or hold java.lang.ref.Cleaner instances
+# threads, reference Windows-only JNA classes, hold java.lang.ref.Cleaner instances,
+# or cache process environment that must reflect the runtime user's setup.
 quarkus.native.additional-build-args=\
   --initialize-at-run-time=org.testcontainers,\
   --initialize-at-run-time=com.github.dockerjava,\
   --initialize-at-run-time=org.postgresql.sspi.SSPIClient,\
   --initialize-at-run-time=org.postgresql.util.LazyCleanerImpl,\
+  --initialize-at-run-time=io.smallrye.common.process.ProcessUtil$PathEnv,\
   --enable-url-protocols=https
 quarkus.native.auto-service-loader-registration=true
 


### PR DESCRIPTION
Closes #255 

- Added io.smallrye.common.process.ProcessUtil$PathEnv to the existing --initialize-at-run-time list so the PATH cache reflects the actual runtime environment.
- Verified the fix with a local native image build.