### PR TITLE
Stop generating .mcp.json in new and existing projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Ask your agent to build a Quarkus application using natural language. The agent 
 
 > **You:** Create a Quarkus REST API with a greeting endpoint and a PostgreSQL database
 >
-> **Agent:** _(uses `quarkus_create` to scaffold the project with `rest-jackson,jdbc-postgresql,hibernate-orm-panache` extensions — the app starts automatically in dev mode, a `CLAUDE.md` is generated with project-specific workflow instructions, and a `.mcp.json` is created for automatic MCP server discovery)_
+> **Agent:** _(uses `quarkus_create` to scaffold the project with `rest-jackson,jdbc-postgresql,hibernate-orm-panache` extensions — the app starts automatically in dev mode and a `CLAUDE.md` is generated with project-specific workflow instructions)_
 >
 > **Agent:** _(calls `quarkus_skills` to learn the correct patterns for Panache, REST, and other extensions before writing any code)_
 >
@@ -243,7 +243,7 @@ NEW PROJECT                           EXISTING PROJECT
 
 1. quarkus_create                     1. quarkus_start
    → scaffolds + auto-starts             → starts dev mode
-   → generates CLAUDE.md + .mcp.json
+   → generates CLAUDE.md
                                       2. quarkus_skills
 2. quarkus_skills                        → learn extension patterns
    → learn extension patterns            → query 'quarkus-update' to check version
@@ -267,7 +267,6 @@ NEW PROJECT                           EXISTING PROJECT
 - **Tests via subagents** — if your agent supports subagents, test execution can be dispatched to one so the main conversation stays responsive.
 - **The MCP server survives crashes** — if the app crashes due to a code error, the agent can use `devui-exceptions_getLastException` to get structured exception details (class, message, stack trace, user code location) and fix it. Use `quarkus_logs` for broader context.
 - **CLAUDE.md** — every new project gets a `CLAUDE.md` with Quarkus-specific workflow instructions that guide the agent.
-- **`.mcp.json`** — every new project gets a `.mcp.json` for automatic MCP server discovery by agents that support the convention (Claude Code, Pi/pi.dev).
 
 ### What the agent can do with a running app
 
@@ -325,7 +324,7 @@ quarkus_searchDocs query="broadcasting messages" extension="quarkus-json-rpc"
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `quarkus_create` | Create a new Quarkus app, auto-start in dev mode, generate CLAUDE.md and `.mcp.json` | `outputDir` (required), `groupId`, `artifactId`, `extensions`, `buildTool`, `quarkusVersion`, `noCode`, `noWrapper`, `createInCurrentDir` |
+| `quarkus_create` | Create a new Quarkus app, auto-start in dev mode, generate CLAUDE.md | `outputDir` (required), `groupId`, `artifactId`, `extensions`, `buildTool`, `quarkusVersion`, `noCode`, `noWrapper`, `createInCurrentDir` |
 
 ### Extension Skills
 

--- a/src/main/java/io/quarkus/agent/mcp/CreateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/CreateTools.java
@@ -184,9 +184,8 @@ public class CreateTools {
             // full restart.
             createSourceDirectories(projectDir);
 
-            // Generate AGENTS.md, CLAUDE.md, and .mcp.json
+            // Generate AGENTS.md and CLAUDE.md
             ProjectFiles.generateProjectInstructions(projectDir, processManager.isDevMode());
-            ProjectFiles.generateMcpConfig(projectDir);
 
             // Auto-start the app in dev mode and wait for it to be ready
             try {

--- a/src/main/java/io/quarkus/agent/mcp/ProjectFiles.java
+++ b/src/main/java/io/quarkus/agent/mcp/ProjectFiles.java
@@ -9,7 +9,7 @@ import java.util.List;
 import org.jboss.logging.Logger;
 
 /**
- * Generates agent instruction files (AGENTS.md, CLAUDE.md, .mcp.json)
+ * Generates agent instruction files (AGENTS.md, CLAUDE.md)
  * that coding agents rely on when working with a Quarkus project.
  * Used by {@link CreateTools} (always writes) and {@link LifecycleTools} (writes only if missing).
  */
@@ -22,7 +22,6 @@ public final class ProjectFiles {
 
     static final String AGENTS_MD = "AGENTS.md";
     static final String CLAUDE_MD = "CLAUDE.md";
-    static final String MCP_JSON = ".mcp.json";
 
     /**
      * Checks for missing agent files and generates any that don't exist.
@@ -41,10 +40,6 @@ public final class ProjectFiles {
         if (!Files.exists(dir.resolve(CLAUDE_MD))) {
             generateClaudeMd(projectDir);
             created.add(CLAUDE_MD);
-        }
-        if (!Files.exists(dir.resolve(MCP_JSON))) {
-            generateMcpConfig(projectDir);
-            created.add(MCP_JSON);
         }
 
         return created;
@@ -221,24 +216,4 @@ public final class ProjectFiles {
         }
     }
 
-    static void generateMcpConfig(String projectDir) {
-        try {
-            String mcpJson = """
-                    {
-                      "mcpServers": {
-                        "quarkus-agent": {
-                          "command": "jbang",
-                          "args": [
-                            "quarkus-agent-mcp@quarkusio"
-                          ]
-                        }
-                      }
-                    }
-                    """;
-            Files.writeString(Path.of(projectDir, MCP_JSON), mcpJson, StandardCharsets.UTF_8);
-            LOG.debugf("Generated %s in %s", MCP_JSON, projectDir);
-        } catch (IOException e) {
-            LOG.warnf("Failed to generate %s in %s: %s", MCP_JSON, projectDir, e.getMessage());
-        }
-    }
 }

--- a/src/test/java/io/quarkus/agent/mcp/ProjectFilesTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/ProjectFilesTest.java
@@ -15,24 +15,21 @@ class ProjectFilesTest {
     void ensureAgentFiles_createsAllInEmptyDir(@TempDir Path tempDir) {
         List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
 
-        assertEquals(List.of("AGENTS.md", "CLAUDE.md", ".mcp.json"), created);
+        assertEquals(List.of("AGENTS.md", "CLAUDE.md"), created);
         assertTrue(Files.exists(tempDir.resolve("AGENTS.md")));
         assertTrue(Files.exists(tempDir.resolve("CLAUDE.md")));
-        assertTrue(Files.exists(tempDir.resolve(".mcp.json")));
     }
 
     @Test
     void ensureAgentFiles_skipsExistingFiles(@TempDir Path tempDir) throws IOException {
         Files.writeString(tempDir.resolve("AGENTS.md"), "custom content");
         Files.writeString(tempDir.resolve("CLAUDE.md"), "custom claude");
-        Files.writeString(tempDir.resolve(".mcp.json"), "{}");
 
         List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
 
         assertTrue(created.isEmpty());
         assertEquals("custom content", Files.readString(tempDir.resolve("AGENTS.md")));
         assertEquals("custom claude", Files.readString(tempDir.resolve("CLAUDE.md")));
-        assertEquals("{}", Files.readString(tempDir.resolve(".mcp.json")));
     }
 
     @Test
@@ -41,10 +38,9 @@ class ProjectFilesTest {
 
         List<String> created = ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
 
-        assertEquals(List.of("CLAUDE.md", ".mcp.json"), created);
+        assertEquals(List.of("CLAUDE.md"), created);
         assertEquals("custom content", Files.readString(tempDir.resolve("AGENTS.md")));
         assertTrue(Files.exists(tempDir.resolve("CLAUDE.md")));
-        assertTrue(Files.exists(tempDir.resolve(".mcp.json")));
     }
 
     @Test
@@ -63,16 +59,6 @@ class ProjectFilesTest {
 
         String content = Files.readString(tempDir.resolve("CLAUDE.md"));
         assertTrue(content.contains("AGENTS.md"));
-    }
-
-    @Test
-    void generatedMcpJson_containsServerConfig(@TempDir Path tempDir) throws IOException {
-        ProjectFiles.ensureAgentFiles(tempDir.toString(), true);
-
-        String content = Files.readString(tempDir.resolve(".mcp.json"));
-        assertTrue(content.contains("quarkus-agent"));
-        assertTrue(content.contains("jbang"));
-        assertTrue(content.contains("quarkus-agent-mcp@quarkusio"));
     }
 
     @Test


### PR DESCRIPTION
The MCP server was writing a `.mcp.json` file into every Quarkus project it created or started. This removes that behavior entirely — the `generateMcpConfig` method, its call sites in `CreateTools` and `ensureAgentFiles`, the associated tests, and all README references.