### PR TITLE
Add --help flag and startup banner on stderr

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/Main.java
+++ b/src/main/java/io/quarkus/agent/mcp/Main.java
@@ -1,0 +1,34 @@
+package io.quarkus.agent.mcp;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+@QuarkusMain
+public class Main {
+
+    public static void main(String[] args) {
+        if (args.length > 0 && ("--help".equals(args[0]) || "-h".equals(args[0]))) {
+            printHelp();
+            return;
+        }
+        Quarkus.run(args);
+    }
+
+    private static void printHelp() {
+        System.err.println("""
+                Quarkus Agent MCP — MCP server for AI coding agents
+
+                This server speaks the Model Context Protocol (MCP) over stdio.
+                It is designed to be launched by an AI coding agent (Claude Code, etc.),
+                not run interactively.
+
+                INSTALL (native binary — recommended):
+                  curl -sL https://github.com/quarkusio/quarkus-agent-mcp/releases/latest/download/install.sh | bash
+
+                INSTALL (JBang):
+                  claude mcp add -s user quarkus-agent -- jbang quarkus-agent-mcp@quarkusio
+
+                MORE INFO:
+                  https://github.com/quarkusio/quarkus-agent-mcp""");
+    }
+}

--- a/src/main/java/io/quarkus/agent/mcp/StartupObserver.java
+++ b/src/main/java/io/quarkus/agent/mcp/StartupObserver.java
@@ -28,6 +28,7 @@ public class StartupObserver {
     void onStart(@Observes StartupEvent event) {
         LOG.infof("Quarkus Agent MCP running on Java %s (%s) — %s mode",
                 Runtime.version(), System.getProperty("java.vm.name"), processManager.getMode());
+        System.err.println("Quarkus Agent MCP server ready (stdio) — " + processManager.getMode() + " mode");
         containerManager.warmUpDefaultAsync();
 
         if (!processManager.isDevMode()) {


### PR DESCRIPTION
Running `quarkus-agent-mcp` bare or via JBang previously gave no output and no guidance. This adds two things:

- **`--help` / `-h`**: prints installation and usage info to stderr and exits immediately (no container startup, instant response)
- **Startup banner**: prints a one-line "ready" message to stderr on normal startup so users debugging MCP connections can confirm the server is alive

Both use stderr so they never interfere with the MCP JSON-RPC transport on stdout.

Closes #261