### PR TITLE
Add quarkus_update tool for running Quarkus version updates

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/UpdateTools.java
@@ -1,0 +1,185 @@
+package io.quarkus.agent.mcp;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolResponse;
+import jakarta.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.jboss.logging.Logger;
+
+public class UpdateTools {
+
+    private static final Logger LOG = Logger.getLogger(UpdateTools.class);
+
+    @Inject
+    LatestQuarkusVersionResolver latestVersionResolver;
+
+    static final Pattern VALID_STREAM = Pattern.compile("^[0-9]+\\.[0-9]+[a-zA-Z0-9._-]*$");
+    static final Pattern VALID_RECIPES = Pattern.compile("^[a-zA-Z0-9._:,/-]+$");
+
+    @Tool(name = "quarkus_update", description = "Run the Quarkus update tool against an existing project. "
+            + "Updates the project to a newer Quarkus version by applying OpenRewrite recipes. "
+            + "Use with dryRun=true to preview changes before applying. "
+            + "After a non-dry-run update, do a full quarkus_stop + quarkus_start cycle to pick up the new dependencies.")
+    ToolResponse update(
+            @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
+            @ToolArg(description = "Target Quarkus stream (e.g. '3.36'). "
+                    + "If omitted, updates to the latest available version.", required = false) String stream,
+            @ToolArg(description = "If true, only show what would change without applying modifications.",
+                    required = false) Boolean dryRun,
+            @ToolArg(description = "Maven coordinates of additional update recipes to apply "
+                    + "(e.g. 'com.example:my-recipes:1.0.0'). "
+                    + "Multiple recipes can be comma-separated.", required = false) String additionalUpdateRecipes) {
+        try {
+            File dir = new File(projectDir);
+            if (!dir.isDirectory()) {
+                return ToolResponse.error("Not a directory: " + projectDir);
+            }
+
+            if (stream != null && !stream.isBlank() && !VALID_STREAM.matcher(stream).matches()) {
+                return ToolResponse.error(
+                        "Invalid stream: must be a version stream like '3.36'. Only digits, dots, letters, hyphens, underscores allowed.");
+            }
+            if (additionalUpdateRecipes != null && !additionalUpdateRecipes.isBlank()
+                    && !VALID_RECIPES.matcher(additionalUpdateRecipes).matches()) {
+                return ToolResponse.error(
+                        "Invalid additionalUpdateRecipes: must contain only letters, digits, dots, hyphens, underscores, colons, commas, slashes.");
+            }
+
+            String buildTool = detectBuildTool(dir);
+            List<String> command = buildCommand(dir, buildTool, stream, dryRun, additionalUpdateRecipes);
+            LOG.infof("Running Quarkus update: %s", String.join(" ", command));
+
+            ProcessBuilder pb = new ProcessBuilder(command)
+                    .directory(dir)
+                    .redirectErrorStream(true);
+
+            Process process = pb.start();
+            StringBuilder outputCapture = new StringBuilder();
+            Thread captureThread = new Thread(() -> {
+                try {
+                    outputCapture.append(ProcessUtils.captureOutput(process));
+                } catch (IOException e) {
+                    LOG.debugf("Error capturing process output: %s", e.getMessage());
+                }
+            }, "update-output-capture");
+            captureThread.setDaemon(true);
+            captureThread.start();
+
+            int exitCode;
+            String output;
+            try {
+                if (!process.waitFor(10, TimeUnit.MINUTES)) {
+                    process.destroyForcibly();
+                    captureThread.join(5000);
+                    return ToolResponse.error("Quarkus update timed out after 10 minutes.");
+                }
+                captureThread.join(5000);
+                exitCode = process.exitValue();
+                output = outputCapture.toString();
+            } finally {
+                process.destroyForcibly();
+            }
+
+            if (exitCode != 0) {
+                return ToolResponse.error("Quarkus update failed (exit " + exitCode + "):\n" + output);
+            }
+
+            if (!Boolean.TRUE.equals(dryRun)) {
+                QuarkusVersionDetector.invalidate(projectDir);
+            }
+
+            return ToolResponse.success(output);
+        } catch (Exception e) {
+            LOG.error("Failed to run Quarkus update at " + projectDir, e);
+            return ToolResponse.error("Failed to run Quarkus update: " + e.getMessage());
+        }
+    }
+
+    List<String> buildCommand(File projectDir, String buildTool, String stream, Boolean dryRun,
+            String additionalUpdateRecipes) {
+        if (ProcessUtils.isCommandAvailable("quarkus")) {
+            return buildCliCommand(stream, dryRun, additionalUpdateRecipes);
+        }
+        if ("maven".equals(buildTool)) {
+            return buildMavenCommand(projectDir, stream, dryRun, additionalUpdateRecipes);
+        }
+        throw new IllegalStateException(
+                "Cannot run Quarkus update: Quarkus CLI not found and project uses Gradle. "
+                        + "Install the Quarkus CLI (https://quarkus.io/guides/cli-tooling) to update Gradle projects.");
+    }
+
+    static List<String> buildCliCommand(String stream, Boolean dryRun, String additionalUpdateRecipes) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add("quarkus");
+        cmd.add("update");
+        if (stream != null && !stream.isBlank()) {
+            cmd.add("--stream=" + stream);
+        }
+        if (Boolean.TRUE.equals(dryRun)) {
+            cmd.add("--dry-run");
+        }
+        if (additionalUpdateRecipes != null && !additionalUpdateRecipes.isBlank()) {
+            cmd.add("--additional-update-recipes=" + additionalUpdateRecipes);
+        }
+        return cmd;
+    }
+
+    List<String> buildMavenCommand(File projectDir, String stream, Boolean dryRun,
+            String additionalUpdateRecipes) {
+        String mvnCmd = ProcessUtils.resolveMavenCommand(projectDir);
+        String pluginVersion = resolvePluginVersion(projectDir.getAbsolutePath());
+        return buildMavenCommand(mvnCmd, pluginVersion, stream, dryRun, additionalUpdateRecipes);
+    }
+
+    static List<String> buildMavenCommand(String mvnCmd, String pluginVersion, String stream,
+            Boolean dryRun, String additionalUpdateRecipes) {
+        List<String> cmd = new ArrayList<>();
+        cmd.add(mvnCmd);
+        cmd.add("-DquarkusRegistryClient=true");
+        cmd.add("io.quarkus:quarkus-maven-plugin:" + pluginVersion + ":update");
+        cmd.add("-e");
+        cmd.add("-N");
+        cmd.add("-ntp");
+        if (stream != null && !stream.isBlank()) {
+            cmd.add("-Dstream=" + stream);
+        }
+        if (Boolean.TRUE.equals(dryRun)) {
+            cmd.add("-DrewriteDryRun");
+        }
+        if (additionalUpdateRecipes != null && !additionalUpdateRecipes.isBlank()) {
+            cmd.add("-DadditionalUpdateRecipes=" + additionalUpdateRecipes);
+        }
+        return cmd;
+    }
+
+    private String resolvePluginVersion(String projectDir) {
+        String latest = latestVersionResolver.resolve(projectDir);
+        if (latest != null) {
+            return latest;
+        }
+        String detected = QuarkusVersionDetector.detect(projectDir);
+        if (detected != null) {
+            return detected;
+        }
+        throw new IllegalStateException(
+                "Cannot determine Quarkus version for the Maven update plugin. "
+                        + "Specify a stream or ensure the project has a detectable Quarkus version.");
+    }
+
+    static String detectBuildTool(File projectDir) {
+        if (new File(projectDir, "pom.xml").exists()) {
+            return "maven";
+        } else if (new File(projectDir, "build.gradle").exists()
+                || new File(projectDir, "build.gradle.kts").exists()) {
+            return "gradle";
+        }
+        throw new IllegalArgumentException(
+                "Cannot detect build tool at: " + projectDir + ". No pom.xml or build.gradle found.");
+    }
+}

--- a/src/test/java/io/quarkus/agent/mcp/McpIT.java
+++ b/src/test/java/io/quarkus/agent/mcp/McpIT.java
@@ -31,7 +31,8 @@ public class McpIT {
             "quarkus_skills",
             "quarkus_updateSkill",
             "quarkus_saveSkill",
-            "quarkus_callTool");
+            "quarkus_callTool",
+            "quarkus_update");
 
     @Test
     public void toolsList() {

--- a/src/test/java/io/quarkus/agent/mcp/UpdateToolsTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/UpdateToolsTest.java
@@ -1,0 +1,176 @@
+package io.quarkus.agent.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UpdateToolsTest {
+
+    // --- Stream validation ---
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "3.36",
+            "3.21",
+            "4.0",
+            "3.36.1",
+    })
+    void validStreams(String stream) {
+        assertTrue(UpdateTools.VALID_STREAM.matcher(stream).matches(), stream + " should be valid");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "latest",
+            "3",
+            "abc",
+            "3.36; echo pwned",
+            "3.36 && rm -rf /",
+            "${version}",
+            "",
+    })
+    void invalidStreams(String stream) {
+        assertFalse(UpdateTools.VALID_STREAM.matcher(stream).matches(), stream + " should be invalid");
+    }
+
+    // --- Additional recipes validation ---
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "com.example:my-recipes:1.0.0",
+            "com.x.y.quarkus:z-quarkus-update-recipes:1.0.0-SNAPSHOT",
+            "org.acme:recipes:2.0,org.other:more:1.0",
+    })
+    void validRecipes(String recipes) {
+        assertTrue(UpdateTools.VALID_RECIPES.matcher(recipes).matches(), recipes + " should be valid");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "com.example:recipes:1.0; echo pwned",
+            "recipes && rm -rf /",
+            "$(whoami):recipes:1.0",
+            "recipes `id`",
+    })
+    void invalidRecipes(String recipes) {
+        assertFalse(UpdateTools.VALID_RECIPES.matcher(recipes).matches(), recipes + " should be invalid");
+    }
+
+    // --- CLI command building ---
+
+    @Test
+    void cliCommand_noOptions() {
+        List<String> cmd = UpdateTools.buildCliCommand(null, null, null);
+        assertEquals(List.of("quarkus", "update"), cmd);
+    }
+
+    @Test
+    void cliCommand_allOptions() {
+        List<String> cmd = UpdateTools.buildCliCommand("3.36", true, "com.example:recipes:1.0");
+        assertEquals(List.of(
+                "quarkus", "update",
+                "--stream=3.36",
+                "--dry-run",
+                "--additional-update-recipes=com.example:recipes:1.0"), cmd);
+    }
+
+    @Test
+    void cliCommand_streamOnly() {
+        List<String> cmd = UpdateTools.buildCliCommand("3.36", null, null);
+        assertEquals(List.of("quarkus", "update", "--stream=3.36"), cmd);
+    }
+
+    @Test
+    void cliCommand_dryRunOnly() {
+        List<String> cmd = UpdateTools.buildCliCommand(null, true, null);
+        assertEquals(List.of("quarkus", "update", "--dry-run"), cmd);
+    }
+
+    @Test
+    void cliCommand_dryRunFalse() {
+        List<String> cmd = UpdateTools.buildCliCommand(null, false, null);
+        assertEquals(List.of("quarkus", "update"), cmd);
+    }
+
+    @Test
+    void cliCommand_blankStreamIgnored() {
+        List<String> cmd = UpdateTools.buildCliCommand("  ", null, null);
+        assertEquals(List.of("quarkus", "update"), cmd);
+    }
+
+    // --- Maven command building ---
+
+    @Test
+    void mavenCommand_noOptions() {
+        List<String> cmd = UpdateTools.buildMavenCommand("mvn", "3.37.0", null, null, null);
+        assertEquals("mvn", cmd.get(0));
+        assertEquals("-DquarkusRegistryClient=true", cmd.get(1));
+        assertEquals("io.quarkus:quarkus-maven-plugin:3.37.0:update", cmd.get(2));
+        assertTrue(cmd.contains("-e"));
+        assertTrue(cmd.contains("-N"));
+        assertTrue(cmd.contains("-ntp"));
+        assertFalse(cmd.stream().anyMatch(s -> s.startsWith("-Dstream=")));
+        assertFalse(cmd.contains("-DrewriteDryRun"));
+    }
+
+    @Test
+    void mavenCommand_allOptions() {
+        List<String> cmd = UpdateTools.buildMavenCommand("./mvnw", "3.37.0", "3.36", true,
+                "com.example:recipes:1.0");
+        assertEquals("./mvnw", cmd.get(0));
+        assertTrue(cmd.contains("-Dstream=3.36"));
+        assertTrue(cmd.contains("-DrewriteDryRun"));
+        assertTrue(cmd.contains("-DadditionalUpdateRecipes=com.example:recipes:1.0"));
+        assertTrue(cmd.contains("-DquarkusRegistryClient=true"));
+        assertTrue(cmd.contains("-e"));
+        assertTrue(cmd.contains("-N"));
+        assertTrue(cmd.contains("-ntp"));
+    }
+
+    @Test
+    void mavenCommand_dryRunFalseNotAdded() {
+        List<String> cmd = UpdateTools.buildMavenCommand("mvn", "3.37.0", null, false, null);
+        assertFalse(cmd.contains("-DrewriteDryRun"));
+    }
+
+    // --- Build tool detection ---
+
+    @Test
+    void detectBuildTool_maven(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        assertEquals("maven", UpdateTools.detectBuildTool(tempDir.toFile()));
+    }
+
+    @Test
+    void detectBuildTool_gradle(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("build.gradle"), "plugins {}");
+        assertEquals("gradle", UpdateTools.detectBuildTool(tempDir.toFile()));
+    }
+
+    @Test
+    void detectBuildTool_gradleKts(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("build.gradle.kts"), "plugins {}");
+        assertEquals("gradle", UpdateTools.detectBuildTool(tempDir.toFile()));
+    }
+
+    @Test
+    void detectBuildTool_mavenPreferredOverGradle(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+        Files.writeString(tempDir.resolve("build.gradle"), "plugins {}");
+        assertEquals("maven", UpdateTools.detectBuildTool(tempDir.toFile()));
+    }
+
+    @Test
+    void detectBuildTool_noBuildFile(@TempDir Path tempDir) {
+        assertThrows(IllegalArgumentException.class,
+                () -> UpdateTools.detectBuildTool(tempDir.toFile()));
+    }
+}


### PR DESCRIPTION
Adds a `quarkus_update` MCP tool that wraps `quarkus update` (CLI) or the equivalent Maven plugin goal (`io.quarkus:quarkus-maven-plugin:VERSION:update`). This complements the existing `quarkus-update` skill which does analysis and dry-run planning — the tool is the execution primitive that actually applies the update.

Supports all flags from the issue:
- **CLI**: `--stream`, `--dry-run`, `--additional-update-recipes`
- **Maven**: `-Dstream`, `-DrewriteDryRun`, `-DadditionalUpdateRecipes`, `-DquarkusRegistryClient=true`, `-ntp -e -N`

The tool detects the Quarkus CLI first and falls back to the Maven wrapper/system Maven for Maven projects. For the Maven plugin version, it uses `LatestQuarkusVersionResolver` (so the latest update plugin handles the migration), falling back to the project's detected version.

After a successful non-dry-run update, the tool invalidates the `QuarkusVersionDetector` cache so subsequent calls see the new version.

Closes #260