### PR TITLE
Remove stale doc-search containers on startup to prevent disk leak

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/ContainerManager.java
@@ -3,6 +3,8 @@ package io.quarkus.agent.mcp;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -111,6 +113,8 @@ public class ContainerManager {
             return;
         }
 
+        removeStaleContainers(versionKey);
+
         if (supportsRagSql(quarkusVersion)) {
             try {
                 startGenericContainer(versionKey);
@@ -180,6 +184,30 @@ public class ContainerManager {
     public int getEmbeddingPort() {
         GenericContainer<?> container = getContainer(null);
         return container.getMappedPort(9222);
+    }
+
+    private void removeStaleContainers(String versionKey) {
+        try {
+            var client = DockerClientFactory.instance().client();
+            var stale = client.listContainersCmd()
+                    .withLabelFilter(Map.of(
+                            "quarkus-agent-mcp", "doc-search",
+                            "quarkus-agent-mcp.version", versionKey))
+                    .withStatusFilter(List.of("exited", "dead", "created"))
+                    .exec();
+
+            for (var container : stale) {
+                var shortId = container.getId().substring(0, 12);
+                LOG.infof("Removing stale doc-search container %s (status: %s)",
+                        shortId, container.getState());
+                client.removeContainerCmd(container.getId())
+                        .withRemoveVolumes(true)
+                        .exec();
+            }
+        } catch (Exception e) {
+            LOG.debugf("Failed to clean up stale containers for version %s: %s",
+                    versionKey, e.getMessage());
+        }
     }
 
     private void checkDockerAvailable() {


### PR DESCRIPTION
Testcontainers reuse only matches *running* containers by hash. When a doc-search
container stops (server exit, Docker restart), it becomes invisible to reuse and a
fresh container plus anonymous volume gets created on the next startup. Over several
sessions this silently leaks ~819 MB per orphaned container.

Before creating a new container, `ensureRunning()` now queries Docker for stopped
containers (`exited`, `dead`, `created`) matching our labels and removes them with
their volumes. Failures are caught at debug level so they never block startup.

Fixes #267