### PR TITLE
Disable dev-mode interactive console and strip ANSI from captured output

### DIFF
--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -75,15 +75,18 @@ public class QuarkusInstance {
             String line;
             while ((line = reader.readLine()) != null) {
                 appendLog(line);
-                System.err.println(line);
+                String clean = ANSI.matcher(line).replaceAll("");
+                if (!clean.isBlank()) {
+                    System.err.println(clean);
+                }
 
-                if (line.contains("Listening on:")) {
-                    parsePort(line);
+                if (clean.contains("Listening on:")) {
+                    parsePort(clean);
                 }
-                if (line.contains("Dev MCP available at:")) {
-                    parseDevMcpPath(line);
+                if (clean.contains("Dev MCP available at:")) {
+                    parseDevMcpPath(clean);
                 }
-                if (status.get() == Status.STARTING && isStartedLine(line)) {
+                if (status.get() == Status.STARTING && isStartedLine(clean)) {
                     status.compareAndSet(Status.STARTING, Status.RUNNING);
                 }
             }
@@ -118,11 +121,10 @@ public class QuarkusInstance {
     }
 
     private void parseDevMcpPath(String line) {
-        String clean = ANSI.matcher(line).replaceAll("");
         String marker = "Dev MCP available at:";
-        int idx = clean.indexOf(marker);
+        int idx = line.indexOf(marker);
         if (idx >= 0) {
-            String path = clean.substring(idx + marker.length()).trim();
+            String path = line.substring(idx + marker.length()).trim();
             if (!path.isEmpty()) {
                 devMcpPath = path;
             }
@@ -130,14 +132,13 @@ public class QuarkusInstance {
     }
 
     private int parsePortFromLine(String line) {
-        String clean = ANSI.matcher(line).replaceAll("");
-        int idx = clean.indexOf("http://");
+        int idx = line.indexOf("http://");
         if (idx < 0) {
-            idx = clean.indexOf("https://");
+            idx = line.indexOf("https://");
         }
         if (idx >= 0) {
             try {
-                String url = clean.substring(idx).trim();
+                String url = line.substring(idx).trim();
                 int spaceIdx = url.indexOf(' ');
                 if (spaceIdx > 0) {
                     url = url.substring(0, spaceIdx);

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -238,7 +238,7 @@ public class QuarkusProcessManager {
         command.add(mvnCmd);
         if (isDevMode()) {
             command.addAll(List.of("quarkus:dev",
-                    "-Dquarkus.console.basic=true", "-Dquarkus.dev-mcp.enabled=true"));
+                    "-Dquarkus.console.enabled=false", "-Dquarkus.dev-mcp.enabled=true"));
         } else {
             command.add("quarkus:run");
             if ("test".equals(mode)) {
@@ -255,7 +255,7 @@ public class QuarkusProcessManager {
         String cmd = gradleCmd.orElseGet(() -> ProcessUtils.resolveGradleCommand(projectDir));
         if (isDevMode()) {
             return new ProcessBuilder(cmd, "quarkusDev",
-                    "-Dquarkus.console.basic=true", "-Dquarkus.dev-mcp.enabled=true");
+                    "-Dquarkus.console.enabled=false", "-Dquarkus.dev-mcp.enabled=true");
         }
         var command = new ArrayList<>(List.of(cmd, "quarkusRun"));
         if ("test".equals(mode)) {

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -333,7 +333,7 @@ class QuarkusProcessManagerTest {
         ProcessBuilder pb = (ProcessBuilder) m.invoke(manager, tempDir.toString(), "maven", (Integer) null, (String) null, (String) null);
         assertTrue(pb.command().contains("quarkus:dev"));
         assertTrue(pb.command().contains("-Dquarkus.dev-mcp.enabled=true"));
-        assertTrue(pb.command().contains("-Dquarkus.console.basic=true"));
+        assertTrue(pb.command().contains("-Dquarkus.console.enabled=false"));
     }
 
     @Test
@@ -347,7 +347,7 @@ class QuarkusProcessManagerTest {
         assertTrue(pb.command().contains("quarkus:run"));
         assertFalse(pb.command().contains("quarkus:dev"));
         assertFalse(pb.command().contains("-Dquarkus.dev-mcp.enabled=true"));
-        assertFalse(pb.command().contains("-Dquarkus.console.basic=true"));
+        assertFalse(pb.command().contains("-Dquarkus.console.enabled=false"));
         assertFalse(pb.command().contains("-Dquarkus.profile=test"));
     }
 


### PR DESCRIPTION
Fixes #268

The dev-mode interactive console (`[r]/[o]/[c]/[w]/[d]/[s]/[e]` menu, spinners, ANSI cursor repaints) was painting into the agent's terminal under the stdio transport, and could prevent `quarkus_start` from detecting readiness.

Three changes:

- Replace `-Dquarkus.console.basic=true` with `-Dquarkus.console.enabled=false` in both Maven and Gradle process builders. `console.basic` is an undocumented internal property that merely simplifies the console; `console.enabled=false` is the documented way to fully disable it.
- Strip ANSI escape codes once in `captureStream` so all downstream consumers (`isStartedLine`, `parsePort`, `parseDevMcpPath`, stderr echo) work with clean text. Lines that are blank after stripping (pure escape sequences like spinner repaints) are suppressed from stderr entirely.
- Remove the now-redundant per-method ANSI stripping from `parseDevMcpPath` and `parsePortFromLine`.