### PR TITLE
add a quarkus_attach tool to connect to Quarkus apps already running in dev mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ replay_pid*
 .claude
 .cachebro/
 .jackknife/
+.bob/

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,3 @@ replay_pid*
 .claude
 .cachebro/
 .jackknife/
-.bob/

--- a/README.md
+++ b/README.md
@@ -257,18 +257,24 @@ NEW PROJECT                           EXISTING PROJECT
                                       2. quarkus_skills
 2. quarkus_skills                        → learn extension patterns
    → learn extension patterns            → query 'quarkus-update' to check version
-                                      3. quarkus_searchDocs
-3. quarkus_searchDocs                    → look up APIs, config
-   → look up APIs, config
-                                      4. Write code + tests
-4. Write code + tests
-                                      5. Run tests
-5. Run tests                             → quarkus_callTool
-   → quarkus_callTool                    → devui-testing_runTests
-   → devui-testing_runTests
+
+3. quarkus_searchDocs                 3. quarkus_searchDocs
+   → look up APIs, config                → look up APIs, config
+
+4. Write code + tests                 4. Write code + tests
+
+5. Run tests                          5. Run tests
+   → quarkus_callTool                    → quarkus_callTool
+   → devui-testing_runTests              → devui-testing_runTests
 
 6. Iterate
 ```
+
+If the app is **already running in your own terminal**, use `quarkus_attach` instead of `quarkus_start` and the rest of the workflow is unchanged.
+
+Attaching requires that the app expose a Dev MCP server. `quarkus_start` passes `-Dquarkus.dev-mcp.enabled=true` itself, so apps it launches always do; an app you started by hand does so only if Dev MCP is enabled for it — commonly `enabled=true` in `~/.quarkus/dev-mcp.properties`, which applies to every project, or `quarkus.dev-mcp.enabled=true` in the project's `application.properties`. `quarkus_attach` calls the server before registering anything and reports what to fix if it gets no answer, rather than attaching to something the proxy tools cannot reach.
+
+Since the process belongs to your terminal, `quarkus_stop` only detaches, and `quarkus_restart` and `quarkus_logs` give way to `devui-logstream_forceRestart` and `devui-logstream_logHistory` through `quarkus_callTool`.
 
 **Key points:**
 
@@ -349,7 +355,8 @@ quarkus_searchDocs query="broadcasting messages" extension="quarkus-json-rpc"
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | `quarkus_start` | Start a Quarkus app in dev mode | `projectDir` (required), `buildTool` |
-| `quarkus_stop` | Graceful shutdown | `projectDir` (required) |
+| `quarkus_attach` | Attach to a Quarkus app already running in dev mode (e.g. started in a terminal). Verifies its Dev MCP server responds before attaching | `projectDir` (required), `httpPort` (read from `application.properties` if omitted) |
+| `quarkus_stop` | Graceful shutdown — only detaches for an attached app | `projectDir` (required) |
 | `quarkus_restart` | Force restart (usually not needed — hot reload is automatic) | `projectDir` (required) |
 | `quarkus_status` | Get app state | `projectDir` (required) |
 | `quarkus_logs` | Get recent log output | `projectDir` (required), `lines` |

--- a/src/main/java/io/quarkus/agent/mcp/AppLogTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/AppLogTools.java
@@ -46,6 +46,9 @@ public class AppLogTools {
         if (instance == null) {
             return ToolResponse.error("No managed Quarkus instance found at: " + projectDir);
         }
+        if (instance.isExternal()) {
+            return ToolResponse.error(externalNotCaptured(projectDir));
+        }
         if (instance.getLogFile() != null) {
             return ToolResponse.success("App file logging is already enabled. Log file: " + instance.getLogFile());
         }
@@ -59,6 +62,9 @@ public class AppLogTools {
         if (instance == null) {
             return ToolResponse.error("No managed Quarkus instance found at: " + projectDir);
         }
+        if (instance.isExternal()) {
+            return ToolResponse.error(externalNotCaptured(projectDir));
+        }
         Path logFile = instance.getLogFile();
         instance.disableFileLogging();
         if (logFile != null) {
@@ -67,7 +73,22 @@ public class AppLogTools {
         return ToolResponse.success("App file logging is not enabled.");
     }
 
+    /**
+     * File logging is fed by the child process's captured output, so it has nothing to write for an
+     * application this server did not start. Reading the file would return output from an earlier
+     * managed run, which is worse than saying so.
+     */
+    private static String externalNotCaptured(String projectDir) {
+        return "This server did not start the application at: " + projectDir
+                + ", so its output is not captured — the logs go to the terminal that started it. "
+                + "Call devui-logstream_logHistory via quarkus_callTool for recent log lines.";
+    }
+
     private ToolResponse readAppLog(String projectDir, Integer lines) {
+        QuarkusInstance instance = processManager.getInstance(projectDir);
+        if (instance != null && instance.isExternal()) {
+            return ToolResponse.error(externalNotCaptured(projectDir));
+        }
         Path logFile = QuarkusProcessManager.computeLogFile(projectDir);
         if (!Files.exists(logFile)) {
             return ToolResponse.error("No app log file found at " + logFile

--- a/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/DevMcpProxyTools.java
@@ -35,6 +35,7 @@ public class DevMcpProxyTools {
     private static final Logger LOG = Logger.getLogger(DevMcpProxyTools.class);
 
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration PROBE_TIMEOUT = Duration.ofSeconds(5);
     private static final int MAX_RETRIES = 3;
     private static final long INITIAL_RETRY_DELAY_MS = 2000;
 
@@ -604,6 +605,42 @@ public class DevMcpProxyTools {
             return sb.toString();
         }
         return "";
+    }
+
+    /**
+     * Checks whether a Dev MCP server answers on the given port. Used by quarkus_attach to fail
+     * immediately instead of registering an app the proxy tools cannot reach. Unlike
+     * {@link #callDevMcp} this does not retry, so a wrong port reports back in seconds.
+     *
+     * @return empty when the server responded, otherwise the reason it did not
+     */
+    Optional<String> probeDevMcp(int port, String devMcpPath) {
+        String endpoint = "http://localhost:" + port + devMcpPath;
+        String jsonRpcRequest;
+        try {
+            jsonRpcRequest = mapper.writeValueAsString(Map.of(
+                    "jsonrpc", "2.0",
+                    "id", requestId.incrementAndGet(),
+                    "method", "tools/list",
+                    "params", Map.of()));
+        } catch (JsonProcessingException e) {
+            return Optional.of("Failed to serialize the probe request: " + e.getMessage());
+        }
+        try {
+            var response = webClient.postAbs(endpoint)
+                    .putHeader("Content-Type", "application/json")
+                    .putHeader("Accept", "application/json, text/event-stream")
+                    .timeout(PROBE_TIMEOUT.toMillis())
+                    .sendBuffer(Buffer.buffer(jsonRpcRequest))
+                    .await().atMost(PROBE_TIMEOUT.plusSeconds(2));
+            if (response.statusCode() == 200) {
+                return Optional.empty();
+            }
+            return Optional.of(endpoint + " returned HTTP " + response.statusCode());
+        } catch (Exception e) {
+            String reason = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            return Optional.of("No Dev MCP server answered at " + endpoint + " (" + reason + ")");
+        }
     }
 
     private Uni<JsonNode> fetchDevMcpTools(int port, String devMcpPath) {

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -26,6 +26,9 @@ public class LifecycleTools {
     @Inject
     ObjectMapper mapper;
 
+    @Inject
+    DevMcpProxyTools devMcpProxyTools;
+
     static final long STARTUP_TIMEOUT_MS = 120_000;
     static final long STARTUP_POLL_INTERVAL_MS = 2_000;
 
@@ -90,12 +93,69 @@ public class LifecycleTools {
         }
     }
 
+    @Tool(name = "quarkus_attach", description = "Attach to a Quarkus application already running in dev mode "
+            + "(e.g. started manually in a terminal), so quarkus_searchTools and quarkus_callTool can proxy "
+            + "to its Dev MCP server. That server is contacted first and attaching fails if it does not "
+            + "answer, which is the only way to know: an app started by hand exposes Dev MCP only if it was "
+            + "enabled for it, and that can come from a user-level file this server cannot see. "
+            + "If httpPort is omitted, the port is read from src/main/resources/application.properties "
+            + "(%dev.quarkus.http.port, then quarkus.http.port), falling back to 8080; pass it explicitly "
+            + "when the application listens elsewhere. "
+            + "Note that this server does not own the process, so quarkus_stop only detaches and "
+            + "quarkus_restart and quarkus_logs do not work. Use quarkus_callTool instead: "
+            + "devui-logstream_forceRestart to restart, devui-logstream_logHistory for logs, "
+            + "devui-exceptions_getLastException for errors.")
+    ToolResponse attach(
+            @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir,
+            @ToolArg(description = "HTTP port the application is listening on. "
+                    + "If omitted, read from application.properties (defaults to 8080).",
+                    required = false) Integer httpPort) {
+        try {
+            processManager.validateAttachable(projectDir);
+            int port = httpPort != null ? httpPort : QuarkusProcessManager.detectHttpPort(projectDir);
+
+            Optional<String> unreachable = devMcpProxyTools.probeDevMcp(port, QuarkusInstance.DEFAULT_DEV_MCP_PATH);
+            if (unreachable.isPresent()) {
+                return ToolResponse.error(unreachable.get() + ".\nCheck that:\n"
+                        + "- the application is running in dev mode on port " + port
+                        + (httpPort == null
+                                ? " (guessed from application.properties — pass httpPort if it differs)"
+                                : "")
+                        + "\n- Dev MCP is enabled for that app: set enabled=true in ~/.quarkus/dev-mcp.properties "
+                        + "to turn it on for every project, or add quarkus.dev-mcp.enabled=true to the project's "
+                        + "application.properties, or restart it with -Dquarkus.dev-mcp.enabled=true. "
+                        + "Apps launched by quarkus_start always get the flag; one started by hand does not "
+                        + "unless it is enabled somewhere.");
+            }
+
+            processManager.register(projectDir, port);
+            return ToolResponse.success("Attached to external Quarkus application at: " + projectDir
+                    + " (port: " + port + ")\n"
+                    + "Its Dev MCP server responded, so quarkus_searchTools and quarkus_callTool are ready.\n"
+                    + "The process belongs to the terminal that started it, so quarkus_stop only detaches "
+                    + "and quarkus_restart and quarkus_logs do not work. Go through quarkus_callTool instead: "
+                    + "devui-logstream_forceRestart, devui-logstream_logHistory, "
+                    + "devui-exceptions_getLastException.");
+        } catch (Exception e) {
+            LOG.error("Failed to attach to Quarkus application at " + projectDir, e);
+            return ToolResponse.error(e.getMessage());
+        }
+    }
+
     @Tool(name = "quarkus_stop", description = "Stop a running Quarkus application. "
-            + "Sends a graceful shutdown signal, then force-kills if needed.")
+            + "Sends a graceful shutdown signal, then force-kills if needed. "
+            + "For an application attached with quarkus_attach this only drops the attachment — "
+            + "the process keeps running, since this server did not start it.")
     ToolResponse stop(
             @ToolArg(description = "Absolute path to the Quarkus project directory") String projectDir) {
         try {
+            QuarkusInstance instance = processManager.getInstance(projectDir);
+            boolean external = instance != null && instance.isExternal();
             processManager.stop(projectDir);
+            if (external) {
+                return ToolResponse.success("Detached from Quarkus application at: " + projectDir
+                        + "\nThe application is still running — stop it in the terminal that started it.");
+            }
             return ToolResponse.success("Quarkus application stopped at: " + projectDir);
         } catch (Exception e) {
             LOG.error("Failed to stop Quarkus application at " + projectDir, e);
@@ -215,6 +275,12 @@ public class LifecycleTools {
             QuarkusInstance instance = processManager.getInstance(projectDir);
             if (instance == null) {
                 return ToolResponse.error("No instance found for: " + projectDir);
+            }
+            if (instance.isExternal()) {
+                return ToolResponse.error("This server did not start the application at: " + projectDir
+                        + ", so it does not capture its output — the logs go to the terminal that started it. "
+                        + "Call devui-logstream_logHistory via quarkus_callTool for recent log lines, "
+                        + "or devui-exceptions_getLastException for the last error.");
             }
             int count = (lines != null && lines > 0) ? Math.min(lines, 10000) : 50;
             String logs = instance.getRecentLogs(count);

--- a/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
+++ b/src/main/java/io/quarkus/agent/mcp/LifecycleTools.java
@@ -111,8 +111,11 @@ public class LifecycleTools {
                     + "If omitted, read from application.properties (defaults to 8080).",
                     required = false) Integer httpPort) {
         try {
-            processManager.validateAttachable(projectDir);
-            int port = httpPort != null ? httpPort : QuarkusProcessManager.detectHttpPort(projectDir);
+            if (httpPort != null) {
+                QuarkusProcessManager.validatePort(httpPort);
+            }
+            String normalizedDir = processManager.validateAttachable(projectDir);
+            int port = httpPort != null ? httpPort : QuarkusProcessManager.detectHttpPort(normalizedDir);
 
             Optional<String> unreachable = devMcpProxyTools.probeDevMcp(port, QuarkusInstance.DEFAULT_DEV_MCP_PATH);
             if (unreachable.isPresent()) {
@@ -128,7 +131,7 @@ public class LifecycleTools {
                         + "unless it is enabled somewhere.");
             }
 
-            processManager.register(projectDir, port);
+            processManager.registerNormalized(normalizedDir, port);
             return ToolResponse.success("Attached to external Quarkus application at: " + projectDir
                     + " (port: " + port + ")\n"
                     + "Its Dev MCP server responded, so quarkus_searchTools and quarkus_callTool are ready.\n"

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.net.Socket;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -221,10 +222,24 @@ public class QuarkusInstance {
 
     private void reconcileStatus() {
         if (isExternal()) {
+            if (status.get() == Status.RUNNING && !isPortListening(httpPort)) {
+                status.compareAndSet(Status.RUNNING, Status.STOPPED);
+            }
             return;
         }
         if (status.get() == Status.RUNNING && !process.isAlive()) {
             status.compareAndSet(Status.RUNNING, Status.CRASHED);
+        }
+    }
+
+    private static boolean isPortListening(int port) {
+        if (port <= 0) {
+            return false;
+        }
+        try (Socket s = new Socket("localhost", port)) {
+            return true;
+        } catch (IOException e) {
+            return false;
         }
     }
 

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusInstance.java
@@ -39,6 +39,8 @@ public class QuarkusInstance {
 
     static final int MAX_LOG_LINES = 500;
 
+    static final String DEFAULT_DEV_MCP_PATH = "/q/dev-mcp";
+
     // Quarkus dev output may be wrapped in ANSI escape codes (Gradle forces color
     // on the forked dev JVM), which must be stripped before URI parsing.
     private static final Pattern ANSI = Pattern.compile("\\u001B\\[[0-9;]*m");
@@ -68,6 +70,26 @@ public class QuarkusInstance {
         executor.submit(() -> captureStream(process.getInputStream()));
         executor.submit(() -> captureStream(process.getErrorStream()));
         executor.submit(() -> monitorExit());
+    }
+
+    /**
+     * Creates an instance for an application started outside this server (see quarkus_attach).
+     * There is no child process to manage, so the lifecycle operations that drive one
+     * (restart, stop, stdin) are unavailable and log capture is empty.
+     */
+    public QuarkusInstance(String projectDir, int httpPort) {
+        this.projectDir = projectDir;
+        this.buildTool = null;
+        this.requestedHttpPort = httpPort;
+        this.mavenProfiles = null;
+        this.extraArgs = null;
+        this.process = null;
+        this.httpPort = httpPort;
+        this.status.set(Status.RUNNING);
+    }
+
+    public boolean isExternal() {
+        return process == null;
     }
 
     private void captureStream(InputStream inputStream) {
@@ -198,6 +220,9 @@ public class QuarkusInstance {
     }
 
     private void reconcileStatus() {
+        if (isExternal()) {
+            return;
+        }
         if (status.get() == Status.RUNNING && !process.isAlive()) {
             status.compareAndSet(Status.RUNNING, Status.CRASHED);
         }
@@ -211,6 +236,9 @@ public class QuarkusInstance {
     }
 
     public void sendInput(char c) {
+        if (isExternal()) {
+            throw new IllegalStateException("Cannot send input to an externally-managed process.");
+        }
         OutputStream os = process.getOutputStream();
         try {
             os.write(c);
@@ -222,6 +250,11 @@ public class QuarkusInstance {
     }
 
     public void restart() {
+        if (isExternal()) {
+            throw new IllegalStateException(
+                    "Cannot restart an externally-managed process: this server has no stdin to send 's' to. "
+                            + "Call devui-logstream_forceRestart via quarkus_callTool instead.");
+        }
         if (!process.isAlive()) {
             throw new IllegalStateException(
                     "Process is not running. Use quarkus_start to start a new instance.");
@@ -234,6 +267,10 @@ public class QuarkusInstance {
     }
 
     public void stop() {
+        if (isExternal()) {
+            status.set(Status.STOPPED);
+            return;
+        }
         disableFileLogging();
         status.set(Status.STOPPED);
         if (process.isAlive()) {
@@ -254,6 +291,9 @@ public class QuarkusInstance {
     }
 
     public boolean isAlive() {
+        if (isExternal()) {
+            return status.get() == Status.RUNNING;
+        }
         return process.isAlive();
     }
 
@@ -263,7 +303,7 @@ public class QuarkusInstance {
 
     public String getDevMcpPath() {
         String path = devMcpPath;
-        return path != null ? path : "/q/dev-mcp";
+        return path != null ? path : DEFAULT_DEV_MCP_PATH;
     }
 
     public String getBuildTool() {

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -7,12 +7,15 @@ import jakarta.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -75,9 +78,8 @@ public class QuarkusProcessManager {
             throw new IllegalArgumentException(
                     "Invalid build tool: '" + buildTool + "'. Must be 'maven' or 'gradle'.");
         }
-        if (httpPort != null && (httpPort < 1 || httpPort > 65535)) {
-            throw new IllegalArgumentException(
-                    "Invalid HTTP port: " + httpPort + ". Must be between 1 and 65535.");
+        if (httpPort != null) {
+            validatePort(httpPort);
         }
         String normalizedDir = normalize(projectDir);
 
@@ -132,6 +134,12 @@ public class QuarkusProcessManager {
             throw new IllegalStateException(
                     "No Quarkus instance found at: " + normalizedDir + ". Use quarkus_start first.");
         }
+        if (instance.isExternal()) {
+            throw new IllegalStateException(
+                    "Cannot restart an attached application at: " + normalizedDir
+                            + ". This server does not own the process. "
+                            + "Call devui-logstream_forceRestart via quarkus_callTool instead.");
+        }
 
         if (isDevMode() && instance.isAlive()) {
             instance.restart();
@@ -148,6 +156,37 @@ public class QuarkusProcessManager {
             start(normalizedDir, savedBuildTool, savedHttpPort, savedMavenProfiles, savedExtraArgs);
             LOG.infof("Full restart at: %s", normalizedDir);
         }
+    }
+
+    /**
+     * Checks that projectDir can be attached to, without registering anything.
+     * Lets a caller reject a bad path before it goes looking for a Dev MCP server on the network.
+     *
+     * @return the normalized project directory
+     */
+    public synchronized String validateAttachable(String projectDir) {
+        String normalizedDir = normalize(projectDir);
+        if (!new File(normalizedDir).isDirectory()) {
+            throw new IllegalArgumentException("Not a directory: " + projectDir);
+        }
+        // Throws if there is no pom.xml or build.gradle, i.e. this is not a Quarkus project.
+        detectBuildTool(normalizedDir);
+        QuarkusInstance existing = instances.get(normalizedDir);
+        if (existing != null && existing.isAlive()) {
+            throw new IllegalStateException("A Quarkus instance is already registered at: " + normalizedDir);
+        }
+        return normalizedDir;
+    }
+
+    /**
+     * Registers an application that is already running outside this server, so the Dev MCP
+     * proxy tools can reach it. No process is started and none is owned.
+     */
+    public synchronized void register(String projectDir, int httpPort) {
+        validatePort(httpPort);
+        String normalizedDir = validateAttachable(projectDir);
+        instances.put(normalizedDir, new QuarkusInstance(normalizedDir, httpPort));
+        LOG.infof("Attached to external Quarkus instance at: %s (port: %d)", normalizedDir, httpPort);
     }
 
     public QuarkusInstance getInstance(String projectDir) {
@@ -173,6 +212,13 @@ public class QuarkusProcessManager {
             }
         }
         instances.clear();
+    }
+
+    private static void validatePort(int httpPort) {
+        if (httpPort < 1 || httpPort > 65535) {
+            throw new IllegalArgumentException(
+                    "Invalid HTTP port: " + httpPort + ". Must be between 1 and 65535.");
+        }
     }
 
     private String normalize(String projectDir) {
@@ -286,6 +332,41 @@ public class QuarkusProcessManager {
     static Path computeLogFile(String projectDir) {
         String dirName = Path.of(projectDir).getFileName().toString();
         return Path.of(System.getProperty("user.home"), ".quarkus", "apps", dirName, "quarkus-dev.log");
+    }
+
+    /**
+     * Best-effort guess at the port an already-running application listens on, read from
+     * application.properties. The dev profile wins, since attaching only applies to dev mode.
+     *
+     * <p>A port set on the command line, in a YAML config file, or in an environment variable is
+     * invisible here, so callers must verify the guess rather than trust it, and users can always
+     * pass the port explicitly.
+     */
+    static int detectHttpPort(String projectDir) {
+        Path file = Path.of(projectDir, "src", "main", "resources", "application.properties");
+        if (!Files.exists(file)) {
+            return DEFAULT_HTTP_PORT;
+        }
+        Properties props = new Properties();
+        try (var reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            props.load(reader);
+        } catch (IOException e) {
+            LOG.debugf("Could not read %s: %s", file, e.getMessage());
+            return DEFAULT_HTTP_PORT;
+        }
+        for (String key : new String[] { "%dev.quarkus.http.port", "quarkus.http.port" }) {
+            String val = props.getProperty(key);
+            if (val == null || val.isBlank()) {
+                continue;
+            }
+            try {
+                return Integer.parseInt(val.trim());
+            } catch (NumberFormatException e) {
+                // A config expression such as ${PORT:8080}, or a typo. Fall through to the default.
+                LOG.debugf("Ignoring non-numeric %s: '%s'", key, val);
+            }
+        }
+        return DEFAULT_HTTP_PORT;
     }
 
 }

--- a/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
+++ b/src/main/java/io/quarkus/agent/mcp/QuarkusProcessManager.java
@@ -185,6 +185,15 @@ public class QuarkusProcessManager {
     public synchronized void register(String projectDir, int httpPort) {
         validatePort(httpPort);
         String normalizedDir = validateAttachable(projectDir);
+        registerNormalized(normalizedDir, httpPort);
+    }
+
+    /**
+     * Like {@link #register} but accepts a directory path that has already been normalized and
+     * validated by {@link #validateAttachable}. Used by the attach tool to avoid a second
+     * redundant validation round-trip.
+     */
+    synchronized void registerNormalized(String normalizedDir, int httpPort) {
         instances.put(normalizedDir, new QuarkusInstance(normalizedDir, httpPort));
         LOG.infof("Attached to external Quarkus instance at: %s (port: %d)", normalizedDir, httpPort);
     }
@@ -214,7 +223,7 @@ public class QuarkusProcessManager {
         instances.clear();
     }
 
-    private static void validatePort(int httpPort) {
+    static void validatePort(int httpPort) {
         if (httpPort < 1 || httpPort > 65535) {
             throw new IllegalArgumentException(
                     "Invalid HTTP port: " + httpPort + ". Must be between 1 and 65535.");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,11 @@ quarkus.mcp.server.server-info.instructions=You are working with the Quarkus Age
   4. Write code and tests\n\
   5. Run tests -- see AGENTS.md in your project for mode-specific instructions\n\n\
   WORKFLOW for existing projects:\n\
-  1. quarkus_start -- start the app (blocks until ready)\n\
+  1. quarkus_start -- start the app (blocks until ready). If the user already has it running in \
+  their own terminal, use quarkus_attach instead: it verifies the app's Dev MCP server responds, \
+  then lets quarkus_searchTools and quarkus_callTool reach it. An attached process is not ours, so \
+  quarkus_stop only detaches, and instead of quarkus_restart/quarkus_logs call \
+  devui-logstream_forceRestart and devui-logstream_logHistory via quarkus_callTool\n\
   2. quarkus_skills -- learn extension-specific patterns before writing code\n\
   3. Write code following patterns from skills and docs\n\
   4. Run tests -- see AGENTS.md in your project for mode-specific instructions\n\n\

--- a/src/test/java/io/quarkus/agent/mcp/McpIT.java
+++ b/src/test/java/io/quarkus/agent/mcp/McpIT.java
@@ -18,6 +18,7 @@ public class McpIT {
     private static final List<String> EXPECTED_TOOLS = List.of(
             "quarkus_create",
             "quarkus_start",
+            "quarkus_attach",
             "quarkus_stop",
             "quarkus_restart",
             "quarkus_browser",

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -2,6 +2,7 @@ package io.quarkus.agent.mcp;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.net.ServerSocket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -264,13 +265,17 @@ class QuarkusInstanceTest {
     }
 
     @Test
-    void externalInstanceIsRunningWithCorrectPort() {
-        QuarkusInstance instance = new QuarkusInstance("/test/project", 9090);
+    void externalInstanceIsRunningWithCorrectPort() throws Exception {
+        // Use a real open port so the liveness probe in reconcileStatus returns true.
+        try (ServerSocket server = new ServerSocket(0)) {
+            int port = server.getLocalPort();
+            QuarkusInstance instance = new QuarkusInstance("/test/project", port);
 
-        assertEquals(QuarkusInstance.Status.RUNNING, instance.getStatus());
-        assertEquals(9090, instance.getHttpPort());
-        assertTrue(instance.isExternal());
-        assertTrue(instance.isAlive());
+            assertEquals(QuarkusInstance.Status.RUNNING, instance.getStatus());
+            assertEquals(port, instance.getHttpPort());
+            assertTrue(instance.isExternal());
+            assertTrue(instance.isAlive());
+        }
     }
 
     @Test
@@ -288,6 +293,14 @@ class QuarkusInstanceTest {
 
         assertEquals(QuarkusInstance.Status.STOPPED, instance.getStatus());
         assertFalse(instance.isAlive());
+    }
+
+    @Test
+    void externalInstanceTransitionsToStoppedWhenPortUnreachable() {
+        // Port 1 is reserved and will not be listening in any test environment.
+        QuarkusInstance instance = new QuarkusInstance("/test/project", 1);
+
+        assertEquals(QuarkusInstance.Status.STOPPED, instance.getStatus());
     }
 
     @Test

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusInstanceTest.java
@@ -262,4 +262,45 @@ class QuarkusInstanceTest {
 
         assertThrows(IllegalStateException.class, instance::restart);
     }
+
+    @Test
+    void externalInstanceIsRunningWithCorrectPort() {
+        QuarkusInstance instance = new QuarkusInstance("/test/project", 9090);
+
+        assertEquals(QuarkusInstance.Status.RUNNING, instance.getStatus());
+        assertEquals(9090, instance.getHttpPort());
+        assertTrue(instance.isExternal());
+        assertTrue(instance.isAlive());
+    }
+
+    @Test
+    void externalInstanceHasDefaultDevMcpPath() {
+        QuarkusInstance instance = new QuarkusInstance("/test/project", 8080);
+
+        assertEquals(QuarkusInstance.DEFAULT_DEV_MCP_PATH, instance.getDevMcpPath());
+    }
+
+    @Test
+    void externalInstanceStopSetsStatusWithoutKillingProcess() {
+        QuarkusInstance instance = new QuarkusInstance("/test/project", 8080);
+
+        instance.stop();
+
+        assertEquals(QuarkusInstance.Status.STOPPED, instance.getStatus());
+        assertFalse(instance.isAlive());
+    }
+
+    @Test
+    void externalInstanceRestartThrows() {
+        QuarkusInstance instance = new QuarkusInstance("/test/project", 8080);
+
+        assertThrows(IllegalStateException.class, instance::restart);
+    }
+
+    @Test
+    void externalInstanceSendInputThrows() {
+        QuarkusInstance instance = new QuarkusInstance("/test/project", 8080);
+
+        assertThrows(IllegalStateException.class, () -> instance.sendInput('s'));
+    }
 }

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -459,4 +459,120 @@ class QuarkusProcessManagerTest {
         assertTrue(toolIdx >= 0, "tool extra arg should be present");
         assertTrue(configIdx < toolIdx, "config extra args should come before tool extra args");
     }
+
+    /** Makes tempDir look like a Quarkus project, which attaching requires. */
+    private void writePom() throws IOException {
+        Files.writeString(tempDir.resolve("pom.xml"), "<project/>");
+    }
+
+    private void writeAppProperties(String content) throws IOException {
+        Path resources = Files.createDirectories(tempDir.resolve("src/main/resources"));
+        Files.writeString(resources.resolve("application.properties"), content);
+    }
+
+    @Test
+    void registerCreatesExternalInstance() throws Exception {
+        initOptionalFields();
+        writePom();
+        manager.register(tempDir.toString(), 9090);
+
+        QuarkusInstance instance = manager.getInstance(tempDir.toString());
+        assertNotNull(instance);
+        assertTrue(instance.isExternal());
+        assertEquals(9090, instance.getHttpPort());
+        assertEquals(QuarkusInstance.Status.RUNNING, instance.getStatus());
+    }
+
+    @Test
+    void registerThrowsForInvalidPort() throws Exception {
+        writePom();
+        assertThrows(IllegalArgumentException.class, () -> manager.register(tempDir.toString(), 0));
+        assertThrows(IllegalArgumentException.class, () -> manager.register(tempDir.toString(), 70000));
+    }
+
+    @Test
+    void registerThrowsForNonExistentDirectory() {
+        assertThrows(IllegalArgumentException.class,
+                () -> manager.register(tempDir.resolve("nope").toString(), 8080));
+    }
+
+    @Test
+    void registerThrowsWhenNotAQuarkusProject() {
+        assertThrows(IllegalArgumentException.class, () -> manager.register(tempDir.toString(), 8080));
+    }
+
+    @Test
+    void registerThrowsWhenInstanceAlreadyAlive() throws Exception {
+        initOptionalFields();
+        writePom();
+        manager.register(tempDir.toString(), 8080);
+
+        assertThrows(IllegalStateException.class, () -> manager.register(tempDir.toString(), 8080));
+    }
+
+    @Test
+    void registerReplacesDeadInstance() throws Exception {
+        initOptionalFields();
+        writePom();
+        manager.register(tempDir.toString(), 8080);
+        manager.stop(tempDir.toString());
+
+        manager.register(tempDir.toString(), 9090);
+
+        QuarkusInstance instance = manager.getInstance(tempDir.toString());
+        assertNotNull(instance);
+        assertEquals(9090, instance.getHttpPort());
+    }
+
+    @Test
+    void restartThrowsForExternalInstance() throws Exception {
+        initOptionalFields();
+        writePom();
+        manager.register(tempDir.toString(), 8080);
+
+        assertThrows(IllegalStateException.class, () -> manager.restart(tempDir.toString()));
+    }
+
+    @Test
+    void detectHttpPortReadsFromProperties() throws Exception {
+        writeAppProperties("quarkus.http.port=9191\n");
+
+        assertEquals(9191, QuarkusProcessManager.detectHttpPort(tempDir.toString()));
+    }
+
+    @Test
+    void detectHttpPortPrefersDevProfileOverride() throws Exception {
+        writeAppProperties("quarkus.http.port=9191\n%dev.quarkus.http.port=8081\n");
+
+        assertEquals(8081, QuarkusProcessManager.detectHttpPort(tempDir.toString()));
+    }
+
+    @Test
+    void detectHttpPortReadsDevProfileOverrideAlone() throws Exception {
+        writeAppProperties("%dev.quarkus.http.port=8081\n");
+
+        assertEquals(8081, QuarkusProcessManager.detectHttpPort(tempDir.toString()));
+    }
+
+    @Test
+    void detectHttpPortFallsBackToDefaultWhenNoFile() {
+        assertEquals(QuarkusProcessManager.DEFAULT_HTTP_PORT,
+                QuarkusProcessManager.detectHttpPort(tempDir.toString()));
+    }
+
+    @Test
+    void detectHttpPortFallsBackToDefaultWhenPropertyAbsent() throws Exception {
+        writeAppProperties("quarkus.datasource.db-kind=h2\n");
+
+        assertEquals(QuarkusProcessManager.DEFAULT_HTTP_PORT,
+                QuarkusProcessManager.detectHttpPort(tempDir.toString()));
+    }
+
+    @Test
+    void detectHttpPortFallsBackToDefaultForConfigExpression() throws Exception {
+        writeAppProperties("quarkus.http.port=${PORT:8080}\n");
+
+        assertEquals(QuarkusProcessManager.DEFAULT_HTTP_PORT,
+                QuarkusProcessManager.detectHttpPort(tempDir.toString()));
+    }
 }

--- a/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
+++ b/src/test/java/io/quarkus/agent/mcp/QuarkusProcessManagerTest.java
@@ -474,13 +474,17 @@ class QuarkusProcessManagerTest {
     void registerCreatesExternalInstance() throws Exception {
         initOptionalFields();
         writePom();
-        manager.register(tempDir.toString(), 9090);
+        // Use a real open port so the liveness probe in getStatus() returns RUNNING.
+        try (ServerSocket server = new ServerSocket(0)) {
+            int port = server.getLocalPort();
+            manager.register(tempDir.toString(), port);
 
-        QuarkusInstance instance = manager.getInstance(tempDir.toString());
-        assertNotNull(instance);
-        assertTrue(instance.isExternal());
-        assertEquals(9090, instance.getHttpPort());
-        assertEquals(QuarkusInstance.Status.RUNNING, instance.getStatus());
+            QuarkusInstance instance = manager.getInstance(tempDir.toString());
+            assertNotNull(instance);
+            assertTrue(instance.isExternal());
+            assertEquals(port, instance.getHttpPort());
+            assertEquals(QuarkusInstance.Status.RUNNING, instance.getStatus());
+        }
     }
 
     @Test
@@ -488,6 +492,30 @@ class QuarkusProcessManagerTest {
         writePom();
         assertThrows(IllegalArgumentException.class, () -> manager.register(tempDir.toString(), 0));
         assertThrows(IllegalArgumentException.class, () -> manager.register(tempDir.toString(), 70000));
+    }
+
+    @Test
+    void validatePortRejectsOutOfRangePorts() {
+        assertThrows(IllegalArgumentException.class, () -> QuarkusProcessManager.validatePort(0));
+        assertThrows(IllegalArgumentException.class, () -> QuarkusProcessManager.validatePort(70000));
+        assertThrows(IllegalArgumentException.class, () -> QuarkusProcessManager.validatePort(65536));
+        assertThrows(IllegalArgumentException.class, () -> QuarkusProcessManager.validatePort(-1));
+        // boundary values must pass
+        QuarkusProcessManager.validatePort(1);
+        QuarkusProcessManager.validatePort(65535);
+    }
+
+    @Test
+    void registerNormalizedCreatesExternalInstance() throws Exception {
+        initOptionalFields();
+        writePom();
+        String normalizedDir = manager.validateAttachable(tempDir.toString());
+        manager.registerNormalized(normalizedDir, 9191);
+
+        QuarkusInstance instance = manager.getInstance(normalizedDir);
+        assertNotNull(instance);
+        assertTrue(instance.isExternal());
+        assertEquals(9191, instance.getHttpPort());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Developers often start their Quarkus app in a terminal (`mvn quarkus:dev` or `quarkus dev`) before using the agent. Previously, `quarkus_searchTools` and `quarkus_callTool` only worked for apps the agent had launched itself — Dev MCP was unreachable for everything else.

This PR adds a `quarkus_attach` tool that registers an already-running app so the proxy tools work as normal, without the agent owning the process.

## How it works

- Reads the HTTP port from `application.properties` if not provided explicitly (`%dev.quarkus.http.port` takes priority over `quarkus.http.port`, falls back to 8080)
- Probes the Dev MCP server before registering — fails fast with a clear error and fix instructions if Dev MCP is not enabled on that app
- Once attached, `quarkus_searchTools` and `quarkus_callTool` work as they do for managed apps

Since the agent did not start the process, some operations are restricted:
- `quarkus_stop` only detaches (the process keeps running in the terminal)
- `quarkus_restart` and `quarkus_logs` return errors pointing to `devui-logstream_forceRestart` and `devui-logstream_logHistory` via `quarkus_callTool`
- App log file capture (enable/disable/read) is unavailable for attached apps

## Changes

- `QuarkusInstance`: external constructor (no `Process`), `isExternal()` predicate, guards on `restart`/`sendInput`/`stop`/`reconcileStatus`/`isAlive`
- `QuarkusProcessManager`: `validateAttachable()`, `register()`, `detectHttpPort()`, `validatePort()` helper
- `DevMcpProxyTools`: `probeDevMcp()` — single no-retry `tools/list` call before attach
- `LifecycleTools`: `quarkus_attach` tool, detach-aware `quarkus_stop`, external guard on `quarkus_logs`
- `AppLogTools`: external guards pointing to `devui-logstream_logHistory`
- README and `application.properties` instructions updated
- Tests added for all new paths in `QuarkusInstanceTest` and `QuarkusProcessManagerTest`, `quarkus_attach` added to the expected tool list in `McpIT`